### PR TITLE
Add scalable read via blob storage.

### DIFF
--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -55,10 +55,10 @@ that is using it. Please verify the following before using Kusto connector:
  'admin' privileges on the table.
  
  * **KUSTO_AAD_CLIENT_ID**: 
- AAD application identifier of the client.
- 
- * **KUSTO_AAD_AUTHORITY_ID**: 
- AAD authentication authority.
+  AAD application (client) identifier.
+  
+  * **KUSTO_AAD_AUTHORITY_ID**: 
+  AAD authentication authority. This is the AAD Directory (tenant) ID.
  
  * **KUSTO_AAD_CLIENT_PASSWORD**: 
  AAD application key for the client.

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -66,10 +66,10 @@ Where **parameters map** is identical for both syntax flavors.
   privileges on this database, unless it has 'admin' privileges on the table.
   
   * **KUSTO_AAD_CLIENT_ID**: 
-  AAD application identifier of the client.
+  AAD application (client) identifier.
   
   * **KUSTO_AAD_AUTHORITY_ID**: 
-  AAD authentication authority.
+  AAD authentication authority. This is the AAD Directory (tenant) ID.
   
   * **KUSTO_AAD_CLIENT_PASSWORD**: 
   AAD application key for the client.

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -24,6 +24,7 @@ that is using it. Please verify the following before using Kusto connector:
  Kusto table schema is translated into a spark as explained in [DataTypes](Spark-Kusto DataTypes mapping.md).
  
  ### Command Syntax
+ 
  There are two command flavors for reading from Kusto:
  
  **Simplified Command Syntax**: 
@@ -50,6 +51,8 @@ sqlContext.read
 .load()
 ```
 Where **parameters map** is identical for both syntax flavors.
+
+In addition, there are two main reading modes: see **KUSTO_READ_MODE** option below
       
  ### Supported Options
   
@@ -74,14 +77,40 @@ Where **parameters map** is identical for both syntax flavors.
   * **KUSTO_AAD_CLIENT_PASSWORD**: 
   AAD application key for the client.
   
-
-  
   * **KUSTO_QUERY**: 
  A flexible Kusto query (can simply be a table name). The schema of the resulting dataframe will match the schema of the query result. 
  
+ 
  **Optional Parameters:** 
  
-    * **KUSTO_NUM_PARTITIONS**: in current release must be set to one (default).
+ * **KUSTO_READ_MODE**: 
+ Selects one of two supported modes for reading data from Kusto:
+   * When set to "lean", queries Kusto admin node directly, and returns the query result. 
+   This option doesn't involve partitioning the data in any way, and is therefore limited to queries resulting in small amount of data 
+   (typically in the order of KiloBytes up to few MegaBytes).
+   * When set to "scale" (**default**), uses a scalable method to export data from Kusto nodes, and convert this data to an RDD.
+   The data is exported to a transient blob storage account provided by the caller, as specified [below](#transient-storage-parameters)    
+    
+#### Transient Storage Parameters
+When reading data from Kusto in 'scale' mode, the data is exported from Kusto into a blob storage every time the corresponding RDD is materialized.
+In order to allow working in 'scale' mode, storage parameters must be provided by the caller. 
+
+>Note: maintenance of the blob storage is the caller responsibility. This includes provisioning the storage, rotating access keys, 
+deleting transient artifacts etc.
+
+* **KUSTO_BLOB_STORAGE_ACCOUNT_NAME**
+Transient storage account name
+
+* **KUSTO_BLOB_STORAGE_ACCOUNT_KEY**
+Storage account key. Either this, or a SAS key, must be provided in order to access the storage account
+
+* **KUSTO_BLOB_STORAGE_SAS_KEY**
+SAS access key: a complete query string of the SAS as a container. Either this, or a storage account key, must be provided
+  in order to access the storage account
+  
+* **KUSTO_BLOB_CONTAINER**
+Blob container name. This container will be used to store all transient artifacts created every time the corresponding RDD is materialized. 
+Once the RDD is no longer required by the caller application, the container and/or all its contents can be deleted by the caller.  
     
  ### Examples
  
@@ -91,7 +120,8 @@ Where **parameters map** is identical for both syntax flavors.
  ```
  val conf: Map[String, String] = Map(
        KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
-       KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey
+       KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
+       KustoOptions.KUSTO_READ_MODE -> "lean"
      )
      
  val df = spark.read.kusto(cluster, database, "MyKustoTable | where (ColB % 1000 == 0) | distinct ColA ", conf)

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <!-- see http://davidb.github.com/scala-maven-plugin -->
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.4.4</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <!-- see http://davidb.github.com/scala-maven-plugin -->
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.4.4</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/scala/com/microsoft/kusto/spark/Sample/KustoConnectorDemo.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/Sample/KustoConnectorDemo.scala
@@ -131,11 +131,12 @@ object KustoConnectorDemo {
     /** ************************************************/
     /*               SOURCE EXAMPLES                  */
     /** ************************************************/
-    /* USING KUSTO QUERY */
-    /** *******************/
+    /* USING KUSTO QUERY, LEAN MODE */
+    /** *****************************/
     val conf: Map[String, String] = Map(
       KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
       KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
+      KustoOptions.KUSTO_READ_MODE -> "lean",
       KustoOptions.KUSTO_QUERY -> s"$table | where (ColB % 1000 == 0) | distinct ColA "
     )
 
@@ -149,6 +150,7 @@ object KustoConnectorDemo {
     val conf2: Map[String, String] = Map(
       KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
       KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
+      KustoOptions.KUSTO_READ_MODE -> "lean",
       KustoOptions.KUSTO_QUERY -> s"$table | where (ColB % 1000 == 0) | distinct ColA "
     )
 

--- a/src/main/scala/com/microsoft/kusto/spark/Sample/KustoConnectorDemo.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/Sample/KustoConnectorDemo.scala
@@ -98,7 +98,7 @@ object KustoConnectorDemo {
     /** ************************************************/
     /*          STREAMING SINK EXAMPLE                */
     /** ************************************************/
-    var customSchema = new StructType().add("colA", StringType, nullable = true).add("colB", IntegerType, nullable = true)
+    val customSchema = new StructType().add("colA", StringType, nullable = true).add("colB", IntegerType, nullable = true)
 
     // Read data from a file to a stream
     val csvDf = spark

--- a/src/main/scala/com/microsoft/kusto/spark/Sample/SimpleKustoDataSource.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/Sample/SimpleKustoDataSource.scala
@@ -16,7 +16,11 @@ object SimpleKustoDataSource {
     val conf: Map[String, String] = Map(
       KustoOptions.KUSTO_AAD_CLIENT_ID -> "Your Client ID",
       KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> "Your secret",
-      KustoOptions.KUSTO_QUERY -> "Your Kusto query"
+      KustoOptions.KUSTO_QUERY -> "Your Kusto query",
+      KustoOptions.KUSTO_READ_MODE -> "Your reading mode. When set as 'lean', storage parameters are not required",
+      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_NAME -> "Your blob storage account",
+      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_KEY -> "Your storage account key, Alternatively, SAS key can be used",
+      KustoOptions.KUSTO_BLOB_CONTAINER -> "Your blob storage container name"
     )
     val df = sparkSession.read.kusto("Your Kusto Cluster", "Your Kusto Database", "Your Kusto Query in KustoOptions.Kusto_Query", conf)
     df.show

--- a/src/main/scala/com/microsoft/kusto/spark/Sample/pyKusto.py
+++ b/src/main/scala/com/microsoft/kusto/spark/Sample/pyKusto.py
@@ -30,15 +30,16 @@ df.write. \
 
 # COMMAND ----------
 
-# Read the data from the kusto table
+# Read the data from the kusto table in 'lean' mode
 kustoDf  = pyKusto.read. \
             format("com.microsoft.kusto.spark.datasource"). \
-            option("kustoCluster",kustoOptions["kustoCluster"]). \
-            option("kustoDatabase",kustoOptions["kustoDatabase"]). \
+            option("kustoCluster", kustoOptions["kustoCluster"]). \
+            option("kustoDatabase", kustoOptions["kustoDatabase"]). \
             option("kustoTable", kustoOptions["kustoTable"]). \
-            option("kustoAADClientID",kustoOptions["kustoAADClientID"]). \
-            option("kustoClientAADClientPassword",kustoOptions["kustoClientAADClientPassword"]). \
-            option("kustoAADAuthorityID",kustoOptions["kustoAADAuthorityID"]). \
+            option("kustoAADClientID", kustoOptions["kustoAADClientID"]). \
+            option("kustoClientAADClientPassword", kustoOptions["kustoClientAADClientPassword"]). \
+            option("kustoAADAuthorityID", kustoOptions["kustoAADAuthorityID"]). \
+            option("readMode", "lean"). \
             load()
 
 kustoDf.show()

--- a/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkProvider.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkProvider.scala
@@ -8,17 +8,16 @@ import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
 import org.apache.spark.sql.streaming.OutputMode
 
-class KustoSinkProvider extends StreamSinkProvider with DataSourceRegister{
+class KustoSinkProvider extends StreamSinkProvider with DataSourceRegister {
 
   override def shortName(): String = "KustoSink"
 
-  override def createSink(
-                           sqlContext: SQLContext,
-                           parameters: Map[String, String],
-                           partitionColumns: Seq[String],
-                           outputMode: OutputMode): Sink = {
-    val (isAsync,tableCreation, kustoAuthentication) = KustoDataSourceUtils.validateSinkParameters(parameters)
-    val tableCoordinates = KustoTableCoordinates(parameters.getOrElse(KustoOptions.KUSTO_CLUSTER, ""), parameters.getOrElse(KustoOptions.KUSTO_DATABASE, ""),parameters.getOrElse(KustoOptions.KUSTO_TABLE, ""))
+  override def createSink(sqlContext: SQLContext,
+                          parameters: Map[String, String],
+                          partitionColumns: Seq[String],
+                          outputMode: OutputMode): Sink = {
+    val (isAsync, tableCreation, kustoAuthentication) = KustoDataSourceUtils.validateSinkParameters(parameters)
+    val tableCoordinates = KustoTableCoordinates(parameters.getOrElse(KustoOptions.KUSTO_CLUSTER, ""), parameters.getOrElse(KustoOptions.KUSTO_DATABASE, ""), parameters.getOrElse(KustoOptions.KUSTO_TABLE, ""))
     val writeOptions = KustoSparkWriteOptions(tableCreation, isAsync, parameters.getOrElse(KustoOptions.KUSTO_WRITE_RESULT_LIMIT, "1"), parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, "UTC"))
 
     new KustoSink(

--- a/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -210,7 +210,7 @@ object KustoWriter{
       val ingestionResult = Await.result(ackIngestion, timeOut)
 
       // Proceed only on success. Will throw on failure for the driver to handle
-      runSequentially[IngestionStatus](
+      KDSU.runSequentially[IngestionStatus](
         func = () => ingestionResult.GetIngestionStatusCollection().get(0),
         0, delayPeriodBetweenCalls, (timeOut.toMillis / delayPeriodBetweenCalls + 5).toInt,
         res => res.status == OperationStatus.Pending,
@@ -224,48 +224,6 @@ object KustoWriter{
               s" Cluster: '$cluster', database: '$database', table: '$table'$batchIdIfExists, partition: '$partitionId'. Ingestion info: '${readIngestionResult(res)}'")
         }).await(timeOut.toMillis, TimeUnit.MILLISECONDS)
     }
-
-  /**
-    * A function to run sequentially async work on TimerTask using a Timer.
-    * The function passed is scheduled sequentially by the timer, until last calculated returned value by func does not
-    * satisfy the condition of doWhile or a given number of times has passed.
-    * After one of these conditions was held true the finalWork function is called over the last returned value by func.
-    * Returns a CountDownLatch object use to countdown times and await on it synchronously if needed
-    * @param func - the function to run
-    * @param delay - delay before first job
-    * @param runEvery - delay between jobs
-    * @param numberOfTimesToRun - stop jobs after numberOfTimesToRun.
-    *                            set negative value to run infinitely
-    * @param doWhile - stop jobs if condition holds for the func.apply output
-    * @param finalWork - do final work with the last func.apply output
-    */
-  def runSequentially[A](func: () => A, delay: Int, runEvery: Int, numberOfTimesToRun: Int, doWhile: A => Boolean, finalWork: A => Unit): CountDownLatch = {
-    val latch = new CountDownLatch(if (numberOfTimesToRun > 0) numberOfTimesToRun else 1)
-    val t = new Timer()
-    val task = new TimerTask() {
-      def run(): Unit = {
-        val res = func.apply()
-        if(numberOfTimesToRun > 0){
-          latch.countDown()
-        }
-
-        if (latch.getCount == 0)
-        {
-          throw new TimeoutException(s"runSequentially: Reached maximal allowed repetitions ($numberOfTimesToRun), aborting")
-        }
-
-        if (!doWhile.apply(res)){
-          t.cancel()
-          finalWork.apply(res)
-          while (latch.getCount > 0){
-            latch.countDown()
-          }
-        }
-      }
-    }
-    t.schedule(task, delay, runEvery)
-    latch
-  }
 
   def All(list: util.ArrayList[Boolean]) : Boolean = {
     val it = list.iterator

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -13,8 +13,6 @@ import scala.concurrent.duration._
 class DefaultSource extends CreatableRelationProvider
   with RelationProvider with DataSourceRegister {
 
-  val timeout: FiniteDuration = 60 minutes
-
   override def createRelation(sqlContext: SQLContext, mode: SaveMode, parameters: Map[String, String], data: DataFrame): BaseRelation = {
     val (isAsync, tableCreation, kustoAuthentication) = KustoDataSourceUtils.validateSinkParameters(parameters)
     val tableCoordinates = KustoTableCoordinates(parameters.getOrElse(KustoOptions.KUSTO_CLUSTER, ""), parameters.getOrElse(KustoOptions.KUSTO_DATABASE, ""), parameters.getOrElse(KustoOptions.KUSTO_TABLE, ""))

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
@@ -51,6 +51,7 @@ object KustoOptions {
   // When writing to Kusto, limits the number of rows read back as BaseRelation. Default: '1'.
   // To read back all rows, set as 'none' (NONE_RESULT_LIMIT)
   val KUSTO_WRITE_RESULT_LIMIT: String = newOption("writeResultLimit")
+  // Select either 'scale' or 'lean' read mode. Default: 'scale'
   val KUSTO_READ_MODE: String = newOption("readMode")
 
   // Partitioning parameters

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
@@ -1,9 +1,7 @@
 package com.microsoft.kusto.spark.datasource
 
 import java.util.Locale
-
 import org.apache.spark.sql.SaveMode
-
 
 object KustoOptions {
   private val kustoOptionNames = collection.mutable.Set[String]()
@@ -35,9 +33,6 @@ object KustoOptions {
   // Target/source Kusto database for writing/reading the data. See KustoSink.md/KustoSource.md for
   // required permissions
   val KUSTO_DATABASE: String = newOption("kustoDatabase")
-  val KUSTO_LOWER_BOUND: String = newOption("lowerBound")
-  val KUSTO_NUM_PARTITIONS: String = newOption("numPartitions")
-  val KUSTO_PARTITION_COLUMN: String = newOption("partitionColumn")
   val KUSTO_QUERY: String = newOption("kustoQuery")
   val KUSTO_QUERY_RETRY_TIMES: String = newOption("kustoQueryRetryTimes")
   // Target/source Kusto table for writing/reading the data. See KustoSink.md/KustoSource.md for
@@ -50,7 +45,6 @@ object KustoOptions {
   // Default: 'FailIfNotExist'
   val KUSTO_TABLE_CREATE_OPTIONS: String = newOption("tableCreateOptions")
   val KUSTO_TRUNCATE: String = newOption("truncate")
-  val KUSTO_UPPER_BOUND: String = newOption("upperBound")
   // When writing to Kusto, allows the driver to complete operation asynchronously.  See KustoSink.md for
   // details and limitations. Default: 'false'
   val KUSTO_WRITE_ENABLE_ASYNC: String = newOption("writeEnableAsync")
@@ -59,13 +53,32 @@ object KustoOptions {
   val KUSTO_WRITE_RESULT_LIMIT: String = newOption("writeResultLimit")
   val KUSTO_READ_MODE: String = newOption("readMode")
 
+  // Partitioning parameters
+  val KUSTO_READ_PARTITION_MODE: String = newOption("partitionMode")
+  val KUSTO_NUM_PARTITIONS: String = newOption("numPartitions")
+  val KUSTO_PARTITION_COLUMN: String = newOption("partitionColumn")
+
   object SinkTableCreationMode extends Enumeration {
     type SinkTableCreationMode = Value
     val CreateIfNotExist, FailIfNotExist = Value
   }
 
+  // Blob Storage access parameters for source connector when working in 'scale' mode (read)
+
+  // Transient storage account when reading from Kusto
+  val KUSTO_BLOB_STORAGE_ACCOUNT_NAME: String = newOption("blobStorageAccountName")
+  // Storage account key. Use either this or SAS key to access the storage account
+  val KUSTO_BLOB_STORAGE_ACCOUNT_KEY: String = newOption("blobStorageAccountKey")
+  // SAS access key: a complete query string of the SAS as a container
+  // Use either this or storage account key to access the storage account
+  val KUSTO_BLOB_STORAGE_SAS_KEY: String = newOption("blobStorageSasKey")
+  // Blob container name
+  val KUSTO_BLOB_CONTAINER: String = newOption("blobContainer")
+
   val NONE_RESULT_LIMIT = "none"
   val supportedReadModes: Set[String] = Set("lean", "scale")
+  // The foll
+  val supportedPartitioningModes: Set[String] = Set("hash", "auto")
 }
 
 abstract class KustoAuthentication

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
@@ -77,8 +77,10 @@ object KustoOptions {
 
   val NONE_RESULT_LIMIT = "none"
   val supportedReadModes: Set[String] = Set("lean", "scale")
-  // The foll
-  val supportedPartitioningModes: Set[String] = Set("hash", "auto")
+  // Partitioning modes allow to export data from Kusto to separate folders within the blob container per-partition
+  // In current implementation this is not exploited by Kusto read connector, and is not recommended.
+  // Left for future experimentation
+  val supportedPartitioningModes: Set[String] = Set("hash")
 }
 
 abstract class KustoAuthentication

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoOptions.scala
@@ -55,6 +55,9 @@ object KustoOptions {
 
   // Partitioning parameters
   val KUSTO_READ_PARTITION_MODE: String = newOption("partitionMode")
+  // Note: for 'read', this allows to partition export from Kusto to blob (default is '1')
+  // It does not affect the number of partitions created when reading from blob.
+  // Therefore it is not recommended to use this option when reading from Kusto, left here for experimentation
   val KUSTO_NUM_PARTITIONS: String = newOption("numPartitions")
   val KUSTO_PARTITION_COLUMN: String = newOption("partitionColumn")
 
@@ -88,7 +91,7 @@ abstract class KeyVaultAuthentication(uri: String) extends KustoAuthentication
 
 case class KustoTableCoordinates(cluster: String, database: String, table:String)
 case class AadApplicationAuthentication(ID: String, password: String, authority: String) extends KustoAuthentication
-case class KeyVaultAppAuthentiaction(uri: String, keyVaultAppID:String, keyVaultAppKey: String) extends KeyVaultAuthentication(uri)
+case class KeyVaultAppAuthentication(uri: String, keyVaultAppID:String, keyVaultAppKey: String) extends KeyVaultAuthentication(uri)
 case class KeyVaultCertificateAuthentication(uri: String, pemFilePath: String, pemFilePassword: String) extends KeyVaultAuthentication(uri)
 case class KustoSparkWriteOptions(tableCreateOptions: KustoOptions.SinkTableCreationMode.SinkTableCreationMode = KustoOptions.SinkTableCreationMode.FailIfNotExist,
                                   isAsync: Boolean = false, writeResultLimit: String, timeZone: String = "UTC", mode: SaveMode = SaveMode.Append)

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -114,13 +114,4 @@ private[kusto] class KustoReader(request: KustoReadRequest, storage: KustoStorag
     val commandResult = client.execute(request.database, exportCommand)
     KDSU.verifyAsyncCommandCompletion(client, request.database, commandResult)
   }
-
-  private[kusto] def importPartitionFromBlob(
-                                              request: KustoReadRequest,
-                                              storage: KustoStorageParameters,
-                                              directory: String
-                                            ): DataFrame = {
-
-    request.sparkSession.read.parquet(s"wasbs://${storage.container}@${storage.account}.blob.core.windows.net/$directory")
-  }
 }

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -1,0 +1,128 @@
+package com.microsoft.kusto.spark.datasource
+
+import java.security.InvalidParameterException
+import java.util.UUID
+
+import com.microsoft.azure.kusto.data.Client
+import com.microsoft.kusto.spark.utils.{CslCommandsGenerator, KustoClient, KustoQueryUtils}
+import org.apache.spark.Partition
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
+import scala.collection.JavaConverters._
+
+private[kusto] case class KustoPartition(predicate: Option[String], idx: Int) extends Partition {
+  override def index: Int = idx
+}
+
+private[kusto] case class KustoPartitionInfo(num: Int, column: String, mode: String)
+
+private[kusto] case class KustoStorageParameters(account: String,
+                                                 secrete: String,
+                                                 container: String,
+                                                 isKeyNotSas: Boolean)
+
+private[kusto] case class KustoReadRequest(
+                                            sparkSession: SparkSession,
+                                            schema: StructType,
+                                            cluster: String,
+                                            database: String,
+                                            query: String,
+                                            appId: String,
+                                            appKey: String,
+                                            authorityId: String)
+
+private[kusto] object KustoReader {
+  private val myName = this.getClass.getSimpleName
+
+  private[kusto] def leanBuildScan(request: KustoReadRequest): RDD[Row] = {
+    val kustoClient = KustoClient.getAdmin(request.cluster, request.appId, request.appKey, request.authorityId)
+
+    val kustoResult = kustoClient.execute(request.database, request.query)
+    val serializer = KustoResponseDeserializer(kustoResult)
+    request.sparkSession.createDataFrame(serializer.toRows, serializer.getSchema).rdd
+  }
+
+  private[kusto] def scaleBuildScan(request: KustoReadRequest, storage: KustoStorageParameters, partitionInfo: KustoPartitionInfo): RDD[Row] = {
+
+    setupBlobAccess(request, storage)
+    val partitions = calculatePartitions(partitionInfo)
+    val reader = new KustoReader(partitions, request, storage)
+    val directory = KustoQueryUtils.simplifyName(s"${request.appId}/dir${UUID.randomUUID()}/")
+
+    for (partition <- partitions) {
+      reader.exportPartitionToBlob(partition.asInstanceOf[KustoPartition], request, storage, directory)
+    }
+
+    val path = s"wasbs://${storage.container}@${storage.account}.blob.core.windows.net/$directory"
+    request.sparkSession.read.parquet(s"$path").rdd
+  }
+
+  private[kusto] def setupBlobAccess(request: KustoReadRequest, storage: KustoStorageParameters): Unit = {
+    val config = request.sparkSession.conf
+    if (storage.isKeyNotSas) {
+      config.set(s"fs.azure.account.key.${storage.account}.blob.core.windows.net", s"${storage.secrete}")
+    }
+    else {
+      config.set(s"fs.azure.sas.${storage.container}.${storage.account}.blob.core.windows.net", s"${storage.secrete}")
+    }
+    config.set("fs.azure", "org.apache.hadoop.fs.azure.NativeAzureFileSystem")
+  }
+
+  private def calculatePartitions(partitionInfo: KustoPartitionInfo): Array[Partition] = {
+    partitionInfo.mode match {
+      case "hash" => calculateHashPartitions(partitionInfo)
+      case "integral" | "timestamp" | "predicate" => throw new InvalidParameterException(s"Partitioning mode '${partitionInfo.mode}' is not yet supported ")
+      case _ => throw new InvalidParameterException(s"Partitioning mode '${partitionInfo.mode}' is not valid")
+    }
+  }
+
+  private def calculateHashPartitions(partitionInfo: KustoPartitionInfo): Array[Partition] = {
+    // Single partition
+    if (partitionInfo.num <= 1) return Array[Partition](KustoPartition(None, 0))
+
+    val partitions = new Array[Partition](partitionInfo.num)
+    for (partitionId <- 0 until partitionInfo.num) {
+      val partitionPredicate = s" hash(${partitionInfo.column}, ${partitionInfo.num}) == $partitionId"
+      partitions(partitionId) = KustoPartition(Some(partitionPredicate), partitionId)
+    }
+    partitions
+  }
+}
+
+private[kusto] class KustoReader(partitions: Array[Partition], request: KustoReadRequest, storage: KustoStorageParameters) {
+  private val myName = this.getClass.getSimpleName
+  val client: Client = KustoClient.getAdmin(request.cluster, request.appId, request.appKey, request.authorityId)
+
+  // Export a single partition from Kusto to transient Blob storage.
+  // Returns the directory path for these blobs
+  private[kusto] def exportPartitionToBlob(partition: KustoPartition,
+                                           request: KustoReadRequest,
+                                           storage: KustoStorageParameters,
+                                           directory: String): Unit = {
+
+    val exportCommand = CslCommandsGenerator.generateExportDataCommand(
+      request.appId,
+      request.query,
+      storage.account,
+      storage.container,
+      directory,
+      storage.secrete,
+      storage.isKeyNotSas,
+      partition.idx,
+      partition.predicate
+    )
+
+    client.execute(request.database, exportCommand).getValues.asScala.map(row => row.get(0)).toList
+  }
+
+  private[kusto] def importPartitionFromBlob(
+                                              request: KustoReadRequest,
+                                              storage: KustoStorageParameters,
+                                              directory: String
+                                            ): DataFrame = {
+
+    request.sparkSession.read.parquet(s"wasbs://${storage.container}@${storage.account}.blob.core.windows.net/$directory")
+  }
+}

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -1,14 +1,14 @@
 package com.microsoft.kusto.spark.datasource
 
 import java.security.InvalidParameterException
+import java.util.Locale
 
 import com.microsoft.azure.kusto.data.{ClientFactory, ConnectionStringBuilder}
 import com.microsoft.kusto.spark.utils.KustoQueryUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{Row, SQLContext}
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
+import org.apache.spark.sql.{Row, SQLContext, SparkSession}
 
 case class KustoRelation(cluster: String,
                          database: String,
@@ -17,34 +17,59 @@ case class KustoRelation(cluster: String,
                          authorityId: String,
                          query: String,
                          isLeanMode: Boolean,
-                         customSchema: Option[String] = None)
-                   (@transient val sparkContext: SQLContext) extends BaseRelation with TableScan with Serializable {
+                         numPartitions: Int,
+                         partitioningColumn: Option[String],
+                         partitioningMode: Option[String],
+                         customSchema: Option[String] = None,
+                         storageAccount: Option[String] = None,
+                         storageContainer: Option[String] = None,
+                         storageAccountSecrete: Option[String] = None,
+                         isStrogageSecreteKeyNotSas: Boolean = true)
+                        (@transient val sparkSession: SparkSession) extends BaseRelation with TableScan with Serializable {
 
   private val normalizedQuery = KustoQueryUtils.normalizeQuery(query)
 
-  override def sqlContext: SQLContext = sparkContext
+  override def sqlContext: SQLContext = sparkSession.sqlContext
 
   override def schema: StructType = {
-    if (customSchema.isDefined)
-    {
+    if (customSchema.isDefined) {
       StructType.fromDDL(customSchema.get)
     }
     else getSchema
   }
 
   override def buildScan(): RDD[Row] = {
-    if (isLeanMode) leanBuildScan() else scaleBuildScan()
+    if (isLeanMode) {
+      KustoReader.leanBuildScan(
+        KustoReadRequest(sparkSession, schema, cluster, database, query, appId, appKey, authorityId)
+      )
+    } else {
+      KustoReader.scaleBuildScan(
+        KustoReadRequest(sparkSession, schema, cluster, database, query, appId, appKey, authorityId),
+        getTransientStorageParameters(storageAccount, storageContainer, storageAccountSecrete, isStrogageSecreteKeyNotSas),
+        KustoPartitionInfo(numPartitions, getPartitioningColumn(partitioningColumn, isLeanMode), getPartitioningMode(partitioningMode))
+      )
+    }
   }
 
-  def leanBuildScan() : RDD[Row] = {
-    val kustoConnectionString = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://$cluster.kusto.windows.net", appId, appKey, authorityId)
-    val kustoResult = ClientFactory.createClient(kustoConnectionString).execute(database, normalizedQuery)
-    var serializer = KustoResponseDeserializer(kustoResult)
-    sparkContext.createDataFrame(serializer.toRows, serializer.getSchema).rdd
-  }
+  private def getTransientStorageParameters(
+                                             storageAccount: Option[String],
+                                             storageContainer: Option[String],
+                                             storageAccountSecrete: Option[String],
+                                             isKeyNotSas: Boolean): KustoStorageParameters = {
+    if (storageAccount.isEmpty) {
+      throw new InvalidParameterException("Storage account name is empty. Reading in 'Scale' mode requires a transient blob storage")
+    }
 
-  def scaleBuildScan() : RDD[Row] = {
-    throw new NotImplementedException
+    if (storageContainer.isEmpty) {
+      throw new InvalidParameterException("Storage container name is empty.")
+    }
+
+    if (storageAccountSecrete.isEmpty) {
+      throw new InvalidParameterException("Storage account secrete is empty. Please provide a storage account key or a SAS key")
+    }
+
+    KustoStorageParameters(storageAccount.get, storageAccountSecrete.get, storageContainer.get, isKeyNotSas)
   }
 
   private def getSchema: StructType = {
@@ -59,5 +84,29 @@ case class KustoRelation(cluster: String,
 
     val kustoConnectionString = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://$cluster.kusto.windows.net", appId, appKey, authorityId)
     KustoResponseDeserializer(ClientFactory.createClient(kustoConnectionString).execute(database, getSchemaQuery)).getSchema
+  }
+
+  private def getPartitioningColumn(partitioningColumn: Option[String], isLean: Boolean): String = {
+    if (isLean) return ""
+
+    if (partitioningColumn.isDefined) {
+      val requestedColumn = partitioningColumn.get.toLowerCase(Locale.ROOT)
+      if (!schema.contains(requestedColumn)) {
+        throw new InvalidParameterException(
+          s"Cannot partition by column '$requestedColumn' since it is not art of the query schema: ${sys.props("line.separator")}${schema.mkString(", ")}")
+      }
+      requestedColumn
+    } else schema.head.name
+  }
+
+  private def getPartitioningMode(partitioningMode: Option[String]): String = {
+    if (partitioningMode.isDefined) {
+      val mode = partitioningMode.get.toLowerCase(Locale.ROOT)
+      if (!KustoOptions.supportedPartitioningModes.contains(mode)) {
+        throw new InvalidParameterException(
+          s"Specified partitioning mode '$mode' : ${sys.props("line.separator")}${KustoOptions.supportedPartitioningModes.mkString(", ")}")
+      }
+      mode
+    } else "hash"
   }
 }

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -52,11 +52,10 @@ case class KustoRelation(cluster: String,
     }
   }
 
-  private def getTransientStorageParameters(
-                                             storageAccount: Option[String],
-                                             storageContainer: Option[String],
-                                             storageAccountSecrete: Option[String],
-                                             isKeyNotSas: Boolean): KustoStorageParameters = {
+  private def getTransientStorageParameters(storageAccount: Option[String],
+                                            storageContainer: Option[String],
+                                            storageAccountSecrete: Option[String],
+                                            isKeyNotSas: Boolean): KustoStorageParameters = {
     if (storageAccount.isEmpty) {
       throw new InvalidParameterException("Storage account name is empty. Reading in 'Scale' mode requires a transient blob storage")
     }
@@ -93,7 +92,7 @@ case class KustoRelation(cluster: String,
       val requestedColumn = partitioningColumn.get.toLowerCase(Locale.ROOT)
       if (!schema.contains(requestedColumn)) {
         throw new InvalidParameterException(
-          s"Cannot partition by column '$requestedColumn' since it is not art of the query schema: ${sys.props("line.separator")}${schema.mkString(", ")}")
+          s"Cannot partition by column '$requestedColumn' since it is not part of the query schema: ${sys.props("line.separator")}${schema.mkString(", ")}")
       }
       requestedColumn
     } else schema.head.name

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -24,7 +24,7 @@ case class KustoRelation(cluster: String,
                          storageAccount: Option[String] = None,
                          storageContainer: Option[String] = None,
                          storageAccountSecrete: Option[String] = None,
-                         isStrogageSecreteKeyNotSas: Boolean = true)
+                         isStorageSecreteKeyNotSas: Boolean = true)
                         (@transient val sparkSession: SparkSession) extends BaseRelation with TableScan with Serializable {
 
   private val normalizedQuery = KustoQueryUtils.normalizeQuery(query)
@@ -46,7 +46,7 @@ case class KustoRelation(cluster: String,
     } else {
       KustoReader.scaleBuildScan(
         KustoReadRequest(sparkSession, schema, cluster, database, query, appId, appKey, authorityId),
-        getTransientStorageParameters(storageAccount, storageContainer, storageAccountSecrete, isStrogageSecreteKeyNotSas),
+        getTransientStorageParameters(storageAccount, storageContainer, storageAccountSecrete, isStorageSecreteKeyNotSas),
         KustoPartitionInfo(numPartitions, getPartitioningColumn(partitioningColumn, isLeanMode), getPartitioningMode(partitioningMode))
       )
     }

--- a/src/main/scala/com/microsoft/kusto/spark/datasource/KustoResponseDeserializer.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/datasource/KustoResponseDeserializer.scala
@@ -57,7 +57,7 @@ class KustoResponseDeserializer(val kustoResult: Results) {
     val columnInOrder = this.getOrderedColumnName
     val value: util.ArrayList[Row] = new util.ArrayList[Row](kustoResult.getValues.size)
 
-    // Calculate the transfomer function for each column to use later by order
+    // Calculate the transformer function for each column to use later by order
     val valueTransformers: mutable.Seq[String => Any] = columnInOrder.map(col => getValueTransformer(kustoResult.getTypeByColumnName(col)))
     kustoResult.getValues.toArray().foreach(row => {
       val genericRow = row.asInstanceOf[util.ArrayList[String]].toArray().zipWithIndex.map(

--- a/src/main/scala/com/microsoft/kusto/spark/sql/extension/SparkExtension.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/sql/extension/SparkExtension.scala
@@ -23,7 +23,6 @@ object SparkExtension {
         .option(KustoOptions.KUSTO_CLUSTER, kustoCluster)
         .option(KustoOptions.KUSTO_DATABASE, database)
         .option(KustoOptions.KUSTO_QUERY, query)
-        .option(KustoOptions.KUSTO_NUM_PARTITIONS, "1")
         .options(properties)
         .load()
     }
@@ -37,8 +36,6 @@ object SparkExtension {
               numPartitions: Int,
               connectionProperties: Properties): DataFrame = {
       dataframeReader.option(KustoOptions.KUSTO_PARTITION_COLUMN, columnName)
-        .option(KustoOptions.KUSTO_LOWER_BOUND, lowerBound)
-        .option(KustoOptions.KUSTO_UPPER_BOUND, upperBound)
         .option(KustoOptions.KUSTO_NUM_PARTITIONS, numPartitions.toString)
 
       val hashMap = new scala.collection.mutable.HashMap[String, String]

--- a/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -46,6 +46,10 @@ object CslCommandsGenerator{
     s""".alter table $table policy merge @'{"AllowMerge":"$allowMerge", "AllowRebuild":"$allowRebuild"}'"""
   }
 
+  def generateOperationsShowCommand(operationId: String): String = {
+    s".show operations $operationId"
+  }
+
   // Export data to blob
   def generateExportDataCommand(
                                  appId: String,
@@ -56,12 +60,14 @@ object CslCommandsGenerator{
                                  secret: String,
                                  useKeyNotSas: Boolean = true,
                                  partitionId: Int,
-                                 partitionPredicate: Option[String] = None): String = {
+                                 partitionPredicate: Option[String] = None,
+                                 isAsync: Boolean): String = {
 
     val secretString = if (useKeyNotSas) s""";" h@"$secret"""" else s"""?" h@"$secret""""
     val blobUri = s"https://$storageAccountName.blob.core.windows.net"
+    val async = if (isAsync) "async " else ""
 
-    var command = s""".export to parquet ("$blobUri/$container$secretString)""" +
+    var command = s""".export ${async}to parquet ("$blobUri/$container$secretString)""" +
       s""" with (namePrefix="${directory}part$partitionId", fileExtension=parquet) <| $query"""
 
     if (partitionPredicate.nonEmpty)

--- a/src/main/scala/com/microsoft/kusto/spark/utils/KeyVaultADALAuthenticator.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/KeyVaultADALAuthenticator.scala
@@ -28,7 +28,7 @@ class KeyVaultADALAuthenticator(clientId: String, clientKey: String) {
     new KeyVaultCredentials() { //Callback that supplies the token type and access token on request.
       override def doAuthenticate(authorization: String, resource: String, scope: String): String = {
         try {
-          var authResult = getAccessToken(authorization, resource)
+          val authResult = getAccessToken(authorization, resource)
           authResult.getAccessToken
         } catch {
           case e: Exception =>

--- a/src/main/scala/com/microsoft/kusto/spark/utils/KeyVaultUtils.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/KeyVaultUtils.scala
@@ -19,7 +19,7 @@ object KeyVaultUtils {
   @throws[CloudException]
   @throws[IOException]
   def getAadParamsFromKeyVaultAppAuth(clientID: String, clientPassword: String, uri: String): AadApplicationAuthentication = {
-      var client: KeyVaultClient = new KeyVaultADALAuthenticator(clientID, clientPassword).getAuthenticatedClient
+      val client: KeyVaultClient = new KeyVaultADALAuthenticator(clientID, clientPassword).getAuthenticatedClient
       getAadParamsFromClient(client, uri)
   }
 

--- a/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -1,0 +1,28 @@
+package com.microsoft.kusto.spark.utils
+import com.microsoft.azure.kusto.data.{Client, ClientFactory, ConnectionStringBuilder}
+import com.microsoft.azure.kusto.ingest.{IngestClient, IngestClientFactory}
+import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
+
+object KustoClient {
+  private[kusto] def getAdmin(
+                               cluster: String,
+                               appId: String,
+                               appKey: String,
+                               aadAuthority: String
+                             ): Client = {
+    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://$cluster.kusto.windows.net", appId, appKey, aadAuthority)
+    engineKcsb.setClientVersionForTracing(KDSU.ClientName)
+    ClientFactory.createClient(engineKcsb)
+  }
+
+  private[kusto] def getIngest(
+                               cluster: String,
+                               appId: String,
+                               appKey: String,
+                               aadAuthority: String
+                             ): IngestClient = {
+    val ingestKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://ingest-$cluster.kusto.windows.net", appId, appKey, aadAuthority)
+    ingestKcsb.setClientVersionForTracing(KDSU.ClientName)
+    IngestClientFactory.createClient(ingestKcsb)
+  }
+}

--- a/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -1,9 +1,11 @@
 package com.microsoft.kusto.spark.utils
 
 import java.security.InvalidParameterException
-import java.util.{NoSuchElementException, StringJoiner}
+import java.util
+import java.util.concurrent.{CountDownLatch, TimeUnit, TimeoutException}
+import java.util.{NoSuchElementException, StringJoiner, Timer, TimerTask}
 
-import com.microsoft.azure.kusto.data.Client
+import com.microsoft.azure.kusto.data.{Client, Results}
 import com.microsoft.kusto.spark.datasource._
 import com.microsoft.kusto.spark.datasource.KustoOptions.SinkTableCreationMode
 import com.microsoft.kusto.spark.datasource.KustoOptions.SinkTableCreationMode.SinkTableCreationMode
@@ -11,6 +13,8 @@ import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.types.StructType
 import org.json4s.jackson.JsonMethods.parse
+
+import scala.concurrent.duration.FiniteDuration
 
 object KustoDataSourceUtils{
   private val klog = Logger.getLogger("KustoConnector")
@@ -141,6 +145,79 @@ object KustoDataSourceUtils{
       case app: AadApplicationAuthentication => app
       case app: KeyVaultAppAuthentiaction => KeyVaultUtils.getAadParamsFromKeyVaultAppAuth(app.keyVaultAppID, app.keyVaultAppKey, app.uri)
       case app: KeyVaultCertificateAuthentication => KeyVaultUtils.getAadParamsFromKeyVaultCertAuth
+    }
+  }
+
+  /**
+    * A function to run sequentially async work on TimerTask using a Timer.
+    * The function passed is scheduled sequentially by the timer, until last calculated returned value by func does not
+    * satisfy the condition of doWhile or a given number of times has passed.
+    * After one of these conditions was held true the finalWork function is called over the last returned value by func.
+    * Returns a CountDownLatch object use to countdown times and await on it synchronously if needed
+    *
+    * @param func - the function to run
+    * @param delay - delay before first job
+    * @param runEvery - delay between jobs
+    * @param numberOfTimesToRun - stop jobs after numberOfTimesToRun.
+    *                            set negative value to run infinitely
+    * @param doWhile - stop jobs if condition holds for the func.apply output
+    * @param finalWork - do final work with the last func.apply output
+    */
+  def runSequentially[A](func: () => A, delay: Int, runEvery: Int, numberOfTimesToRun: Int, doWhile: A => Boolean, finalWork: A => Unit): CountDownLatch = {
+    val latch = new CountDownLatch(if (numberOfTimesToRun > 0) numberOfTimesToRun else 1)
+    val t = new Timer()
+    val task = new TimerTask() {
+      def run(): Unit = {
+        val res = func.apply()
+        if(numberOfTimesToRun > 0){
+          latch.countDown()
+        }
+
+        if (latch.getCount == 0)
+        {
+          throw new TimeoutException(s"runSequentially: Reached maximal allowed repetitions ($numberOfTimesToRun), aborting")
+        }
+
+        if (!doWhile.apply(res)){
+          t.cancel()
+          finalWork.apply(res)
+          while (latch.getCount > 0){
+            latch.countDown()
+          }
+        }
+      }
+    }
+    t.schedule(task, delay, runEvery)
+    latch
+  }
+
+  def verifyAsyncCommandCompletion(client: Client, database: String, samplePeriod: FiniteDuration, timeOut: FiniteDuration, commandResult: Results): Unit = {
+    val operationId = commandResult.getValues.get(0).get(0)
+    val operationsShowCommand = CslCommandsGenerator.generateOperationsShowCommand(operationId)
+    val sampleInMillis = samplePeriod.toMillis.toInt
+    val timeoutInMillis = timeOut.toMillis
+    val delayPeriodBetweenCalls = if (sampleInMillis < 1) 1 else sampleInMillis
+    val timesToRun = (timeoutInMillis/(delayPeriodBetweenCalls) + 5).toInt
+
+    val stateCol = "State"
+    val statusCol = "Status"
+    val showCommandResult = client.execute(database, operationsShowCommand)
+    val stateIdx = showCommandResult.getColumnNameToIndex.get(stateCol)
+    val statusIdx = showCommandResult.getColumnNameToIndex.get(statusCol)
+
+    val success = runSequentially[util.ArrayList[String]](
+      func = () => client.execute(database, operationsShowCommand).getValues.get(0), delay = 0, runEvery = delayPeriodBetweenCalls, numberOfTimesToRun = timesToRun,
+      doWhile = result => {
+        result.get(stateIdx) == "InProgress"
+      },
+      finalWork = result => {
+        if (result.get(stateIdx) != "Completed") {
+          throw new RuntimeException(s"Failed to execute Kusto operation with OperationId '$operationId', State: '${result.get(stateIdx)}', Status: '${result.get(statusIdx)}'")
+        }
+      }).await(timeoutInMillis, TimeUnit.MILLISECONDS)
+
+    if (!success) {
+      throw new RuntimeException(s"Timed out while waiting for operation with OperationId '$operationId'")
     }
   }
 }

--- a/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
+++ b/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
@@ -3,9 +3,9 @@ package com.microsoft.kusto.spark.utils
 object KustoQueryUtils {
 
   def normalizeQuery(query: String): String = {
-    val trimedQuery = query.trim
+    val trimmedQuery = query.trim
     // We don't use concatenation of query statements, so no need in the semicolon separator
-    if (trimedQuery.endsWith(";")) trimedQuery.dropRight(1) else trimedQuery
+    if (trimmedQuery.endsWith(";")) trimmedQuery.dropRight(1) else trimmedQuery
   }
 
   def limitQuery(query: String, limit: Int): String = {

--- a/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
@@ -7,9 +7,9 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 class KustoQueryUtilsTest extends FlatSpec with MockFactory with Matchers with BeforeAndAfterAll {
 
   "normalizeQuery" should "remove redundant query separator" in {
-    val stardardQuery = "Table | where column1 == 'abc';"
+    val standardQuery = "Table | where column1 == 'abc';"
 
-    KustoQueryUtils.normalizeQuery(stardardQuery) should be ("Table | where column1 == 'abc'")
+    KustoQueryUtils.normalizeQuery(standardQuery) should be ("Table | where column1 == 'abc'")
   }
 
   "getQuerySchemaQuery" should "add suffix" in {

--- a/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -62,7 +62,7 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
   val authority: String = System.getProperty(KustoOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
   val cluster: String = System.getProperty(KustoOptions.KUSTO_CLUSTER)
   val database: String = System.getProperty(KustoOptions.KUSTO_DATABASE)
-  val expectedNumberOfRows: Int =  1* 1000 * 1000
+  val expectedNumberOfRows: Int =  1 * 1000
   val rows: immutable.IndexedSeq[(String, Int)] = (1 to expectedNumberOfRows).map(v => (newRow(), v))
 
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
@@ -98,7 +98,8 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
 
     val conf: Map[String, String] = Map(
       KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
-      KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey
+      KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
+      KustoOptions.KUSTO_READ_MODE->"lean"
     )
 
     val dfResult: DataFrame = spark.read.kusto(cluster, database, table, conf)
@@ -145,7 +146,7 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
     KDSU.logInfo(myName, s"KustoBatchSinkDataTypesTest: Ingestion results validated for table '$table'")
   }
 
-    "KustoBatchSinkSync" should "ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
+  "KustoBatchSinkSync" should "also ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
     import spark.implicits._
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2E_Ingest"
@@ -170,7 +171,7 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
     KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, database, expectedNumberOfRows, timeoutMs, tableCleanupPrefix = prefix)
   }
 
-  "KustoBatchSinkAsync" should "ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
+  "KustoBatchSinkAsync" should "ingest structured data to a Kusto cluster in async mode" taggedAs KustoE2E in {
     import spark.implicits._
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2EIngestAsync"

--- a/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -53,7 +53,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
 //  "KustoSource"
   ignore should "execute a read query on Kusto cluster in default (lean) mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
-    var query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1000 == 0) | distinct ColA ")
+    val query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1000 == 0) | distinct ColA ")
 
     val conf: Map[String, String] = Map(
       KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
@@ -66,7 +66,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
 
   "KustoSource" should "execute a read query on Kusto cluster in scale mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
-    var query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1 == 0)")
+    val query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1 == 0)")
 
     val storageAccount: String = System.getProperty("storageAccount")
     val container: String = System.getProperty("container")

--- a/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -50,7 +50,8 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
   if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
 
-  "KustoSource" should "execute a read query on Kusto cluster in default (lean) mode" taggedAs KustoE2E in {
+//  "KustoSource"
+  ignore should "execute a read query on Kusto cluster in default (lean) mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
     var query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1000 == 0) | distinct ColA ")
 
@@ -85,7 +86,8 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
     spark.read.kusto(cluster, database, query, conf).show(20)
   }
 
-  "KustoConnector" should "write to a kusto table and read it back in lean mode" taggedAs KustoE2E in {
+//  "KustoConnector"
+  ignore should "write to a kusto table and read it back in lean mode" taggedAs KustoE2E in {
     import spark.implicits._
 
     val rowId = new AtomicInteger(1)

--- a/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -50,7 +50,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
   if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
 
-  "KustoSource" should "execute a read query on Kusto cluster" taggedAs KustoE2E in {
+  "KustoSource" should "execute a read query on Kusto cluster in default (lean) mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
     var query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1000 == 0) | distinct ColA ")
 
@@ -63,7 +63,29 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
     df.show()
   }
 
-  "KustoConnector" should "write to a kusto table and read it back" taggedAs KustoE2E in {
+  "KustoSource" should "execute a read query on Kusto cluster in scale mode" taggedAs KustoE2E in {
+    val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
+    var query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1 == 0)")
+
+    val storageAccount: String = System.getProperty("storageAccount")
+    val container: String = System.getProperty("container")
+    val blobKey: String = System.getProperty("blobKey")
+    val blobSas: String = System.getProperty("blobSas")
+    val blobSasConnectionString: String = System.getProperty("blobSasQuery")
+
+    val conf: Map[String, String] = Map(
+      KustoOptions.KUSTO_READ_MODE -> "scale",
+      KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
+      KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
+      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_NAME -> storageAccount,
+      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_KEY -> blobKey,
+      KustoOptions.KUSTO_BLOB_CONTAINER -> container
+    )
+
+    spark.read.kusto(cluster, database, query, conf).show(20)
+  }
+
+  "KustoConnector" should "write to a kusto table and read it back in lean mode" taggedAs KustoE2E in {
     import spark.implicits._
 
     val rowId = new AtomicInteger(1)
@@ -87,6 +109,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
       .option(KustoOptions.KUSTO_AAD_CLIENT_ID, appId)
       .option(KustoOptions.KUSTO_AAD_CLIENT_PASSWORD, appKey)
       .option(KustoOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoOptions.KUSTO_READ_MODE, "lean")
       .save()
 
     val conf: Map[String, String] = Map(

--- a/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
+++ b/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
@@ -44,9 +44,6 @@ class KustoSourceTests extends FlatSpec with MockFactory with Matchers with Befo
     sc.stop()
   }
 
-  private val rowId = new AtomicInteger(1)
-  private def newRow(): String = s"row-${rowId.getAndIncrement()}"
-
   "KustoDataSource" should "recognize Kusto and get the correct schema" in {
     val spark: SparkSession = SparkSession.builder()
       .appName("KustoSource")


### PR DESCRIPTION
Note: RDD is not created.
Instead, data is parallel-exported.
If you're up to F2F review just ask :)

Below is a TODO-list that mention some items not covered in this review, on top of planned items such as pruned/filtered scan:
----------------------------------
Add the possibility to specify multiple storage accounts
		• Add possibility to configure storage parameters externally as in https://docs.databricks.com/spark/latest/data-sources/azure/azure-storage.html#access-azure-blob-storage-using-the-rdd-api (and not by the connector every time as now)
		• Review Redshift, Kafka etc. Finalize the decision whether KustoRDD implementation is required
		• Check parquet format partitioning options and consider exposing them 
		• Add Databricks example, including deleting transient storage
		• Consider: run async-export command and check (future) operation status
		• Long(er) term:
			§ Implement cache on blob storage, so that export command is not rerun if exported data is fresh (configurable), unless forced
			§ (Check applicability/value/effort) Consider adding capability to export command of adding partitioning information on the parquet file


