### PR TITLE
Fix writer skipping rows

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -291,8 +291,8 @@ object KustoWriter {
     }
 
     if (currentFileSize > 0) {
-      finalizeBlobWrite(blobWriter)
-      blobsToIngest :+ blobWriter.blob
+      finalizeBlobWrite(currentBlobWriter)
+      blobsToIngest :+ currentBlobWriter.blob
     }
 
     blobsToIngest

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -68,7 +68,7 @@ private[kusto] object CslCommandsGenerator{
     val blobUri = s"https://$storageAccountName.blob.core.windows.net"
     val async = if (isAsync) "async " else ""
     val compress = if (isCompressed) "compressed " else ""
-    val sizeLimitIfDefined = if (sizeLimit.isDefined) s"sizeLimit=${sizeLimit.get}, " else ""
+    val sizeLimitIfDefined = if (sizeLimit.isDefined) s"sizeLimit=${sizeLimit.get * 1024 * 1024}, " else ""
 
     var command = s""".export $async${compress}to parquet ("$blobUri/$container$secretString)""" +
       s""" with (${sizeLimitIfDefined}namePrefix="${directory}part$partitionId", fileExtension=parquet) <| $query"""

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -9,5 +9,7 @@ object KustoConstants {
   val clientName = "Kusto.Spark.Connector"
   val defaultBufferSize: Int = 16 * 1024
   val storageExpiryMinutes: Int = 120
-  val defaultMaxBlobSize: Int = 1024 * 1024 * 1024
+  val oneKilo: Int = 1024
+  val oneMega: Int = oneKilo * 1024
+  val oneGiga: Int = oneMega * 1024
 }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -217,7 +217,7 @@ object KustoDataSourceUtils {
     * The function passed is scheduled sequentially by the timer, until last calculated returned value by func does not
     * satisfy the condition of doWhile or a given number of times has passed.
     * After one of these conditions was held true the finalWork function is called over the last returned value by func.
-    * Returns a CountDownLatch object use to countdown times and await on it synchronously if needed
+    * Returns a CountDownLatch object used to count down iterations and await on it synchronously if needed
     *
     * @param func               - the function to run
     * @param delay              - delay before first job

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -50,61 +50,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
   if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
 
-  "PerformanceDebug" should "read large amounts of data and write back" taggedAs KustoE2E in {
-
-    import java.sql.Timestamp
-    import java.text.SimpleDateFormat;
-
-    val storageAccount: String = System.getProperty("storageAccount")
-    val container: String = System.getProperty("container")
-    val blobKey: String = System.getProperty("blobKey")
-//    val blobSas: String = System.getProperty("blobSas")
-    val blobSasConnectionString: String = System.getProperty("blobSasQuery")
-
-    val conf: Map[String, String] = Map(
-      KustoOptions.KUSTO_AAD_CLIENT_ID -> appId,
-      KustoOptions.KUSTO_AAD_CLIENT_PASSWORD -> appKey,
-      KustoOptions.KUSTO_BLOB_CONTAINER -> container,
-      //KustoOptions.KUSTO_BLOB_STORAGE_SAS_URL -> storageSas,
-      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_NAME -> storageAccount,
-      //KustoOptions.KUSTO_BLOB_SET_FS_CONFIG -> "false",
-      //KustoOptions.KUSTO_BLOB_COMPRESS_ON_EXPORT -> "true",
-      KustoOptions.KUSTO_BLOB_STORAGE_ACCOUNT_KEY -> blobKey
-    )
-
-    spark.conf.set(s"fs.azure.account.key.$storageAccount.blob.core.windows.net", s"$blobKey")
-
-//    val dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss:SSS")
-//    val startDate=dateFormat.parse("2019-03-04 00:00:00:000")
-//    val startDateTime=new Timestamp(startDate.getTime())
-//    val endDate=dateFormat.parse("2019-03-19 00:00:00:000") // Corresponds to 490GB
-//    val endDateTime=new Timestamp(endDate.getTime())
-
-    val srcCluster = "kustoppe"
-    val srcDatabase = "Kuskus"
-    val srcQuery = "AsmIfxAuditApp | where PreciseTimeStamp >=  datetime(2019-03-20 12:00:00) and PreciseTimeStamp  <= datetime(2019-03-20 12:40:00)"
-
-    val df = spark.read.kusto(srcCluster, srcDatabase, srcQuery, conf)
-
-    val numberOfRows = df.count()
-    print(numberOfRows)
-
-    //spark.conf.set("spark.sql.codegen.wholeStage","false")
-
-    df.write
-      .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoOptions.KUSTO_DATABASE, database)
-      .option(KustoOptions.KUSTO_TABLE, "PerformanceDebugTable")
-      .option(KustoOptions.KUSTO_AAD_CLIENT_ID, appId)
-      .option(KustoOptions.KUSTO_AAD_CLIENT_PASSWORD, appKey)
-      .option(KustoOptions.KUSTO_AAD_AUTHORITY_ID, authority)
-      .option(KustoOptions.KUSTO_TABLE_CREATE_OPTIONS, "CreateIfNotExist")
-      .save()
-  }
-
-//  "KustoSource"
-  ignore should "execute a read query on Kusto cluster in lean mode" taggedAs KustoE2E in {
+  "KustoSource"should "execute a read query on Kusto cluster in lean mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
     val query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1000 == 0) | distinct ColA ")
 
@@ -118,8 +64,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
     df.show()
   }
 
-//  "KustoSource"
-  ignore should "execute a read query on Kusto cluster in scale mode" taggedAs KustoE2E in {
+  "KustoSource" should "execute a read query on Kusto cluster in scale mode" taggedAs KustoE2E in {
     val table: String = System.getProperty(KustoOptions.KUSTO_TABLE)
     val query: String = System.getProperty(KustoOptions.KUSTO_QUERY, s"$table | where (toint(ColB) % 1 == 0)")
 
@@ -141,8 +86,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
     spark.read.kusto(cluster, database, query, conf).show(20)
   }
 
-//  "KustoConnector"
-  ignore should "write to a kusto table and read it back in lean mode" taggedAs KustoE2E in {
+  "KustoConnector" should "write to a kusto table and read it back in lean mode" taggedAs KustoE2E in {
     import spark.implicits._
 
     val rowId = new AtomicInteger(1)


### PR DESCRIPTION
Fixes the following (unless I don't read the code correctly):
- All rows must be converted to csv. Originally the row that lead to cross maxBlobSize limit was not converted
- Al non-empty blobs must be finalized. Originally the blob that was currently written (and not added to the list of blobs to ingest) was not finalized

Also fix incorrect setting of the export file size limit in scalable read.

Changes in Source E2E will be reverted before merging to dev, please ignore