### PR TITLE
Update Jackson to fix security vulnerability

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
Addresses a known high severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind >= 2.8.0, < 2.8.11.2