### PR TITLE
Parse table schema in Kusto

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -79,11 +79,6 @@
             <version>1.6.5</version>
         </dependency>
         <dependency>
-            <groupId>org.json4s</groupId>
-            <artifactId>json4s-jackson_${scala.version}</artifactId>
-            <version>3.5.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.8.11.2</version>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -195,7 +195,7 @@ object KustoWriter {
       // Protect tmp table from merge/rebuild and move data to the table requested by customer. This operation is atomic.
       kustoAdminClient.execute(database, generateTableAlterMergePolicyCommand(tmpTableName, allowMerge = false, allowRebuild = false))
       kustoAdminClient.execute(database, generateTableMoveExtentsCommand(tmpTableName, table.get))
-      KDSU.logInfo(myName, s"write to Kusto table '$table' finished successfully $batchIdIfExists")
+      KDSU.logInfo(myName, s"write to Kusto table '${table.get}' finished successfully $batchIdIfExists")
     }
     catch {
       case exception: Exception =>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -75,6 +75,7 @@ object KustoWriter {
     // Only if all executors succeeded the table will be appended to the original destination table.
     KDSU.createTmpTableWithSameSchema(kustoAdminClient, tableCoordinates, tmpTableName, writeOptions.tableCreateOptions, data.schema)
     KDSU.logInfo(myName, s"Successfully created temporary table $tmpTableName, will be deleted after completing the operation")
+
     val ingestKcsb = KustoClient.getKcsb(authentication, s"https://ingest-${tableCoordinates.cluster}.kusto.windows.net")
     val storageUri = KustoTempIngestStorageCache.getNewTempBlobReference(tableCoordinates.cluster, ingestKcsb)
     val rdd = data.queryExecution.toRdd

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -78,7 +78,8 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
     if (getSchemaQuery.isEmpty) {
       throw new RuntimeException("Spark connector cannot run Kusto commands. Please provide a valid query")
     }
-    KustoResponseDeserializer(KustoClient.getAdmin(authentication, kustoCoordinates.cluster).execute(kustoCoordinates.database, getSchemaQuery)).getSchema
+
+    KDSU.getSchema(kustoCoordinates.database, getSchemaQuery, KustoClient.getAdmin(authentication, kustoCoordinates.cluster))
   }
 
   private def getPartitioningColumn: String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCache.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCache.scala
@@ -11,7 +11,7 @@ private[kusto] object KustoAzureFsSetupCache {
   // Return 'true' iff the entry exists in the cache. If it doesn't, or differs - update the cache
   // now is typically 'new DateTime(DateTimeZone.UTC)'
   def updateAndGetPrevStorageAccountAccess(account: String, secret: String, now: DateTime): Boolean = {
-    var secretCached = storageAccountKeyMap(account)
+    var secretCached = storageAccountKeyMap.getOrElse(account, "")
     if (!secretCached.isEmpty && (secretCached != secret)) {
       // Entry exists but with a different secret - remove it and update
       storageAccountKeyMap.remove(account)
@@ -19,7 +19,7 @@ private[kusto] object KustoAzureFsSetupCache {
     }
 
     if (secretCached.isEmpty || checkIfRefreshNeeded(now)) {
-      storageAccountKeyMap += (account -> secret)
+      storageAccountKeyMap.put(account, secret)
       lastRefresh = now
       false
     } else true
@@ -27,7 +27,7 @@ private[kusto] object KustoAzureFsSetupCache {
 
   def updateAndGetPrevSas(container: String, account: String, secret: String, now: DateTime): Boolean = {
     val key = container + "." + account
-    var secretCached = storageSasMap(key)
+    var secretCached = storageSasMap.getOrElse(key, "")
     if (!secretCached.isEmpty && (secretCached != secret)) {
       // Entry exists but with a different secret - remove it and update
       storageSasMap.remove(key)
@@ -35,7 +35,7 @@ private[kusto] object KustoAzureFsSetupCache {
     }
 
     if (secretCached.isEmpty || checkIfRefreshNeeded(now)) {
-      storageSasMap += (key -> secret)
+      storageSasMap.put(key, secret)
       lastRefresh = now
       false
     } else true

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
@@ -13,7 +13,7 @@ object KustoQueryUtils {
   }
 
   def getQuerySchemaQuery(query: String): String = {
-    limitQuery(query, 1)
+    limitQuery(query, 0)
   }
 
   def isCommand(query: String): Boolean = query.trim.startsWith(".")

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
@@ -15,7 +15,7 @@ class KustoQueryUtilsTest extends FlatSpec with MockFactory with Matchers with B
   "getQuerySchemaQuery" should "add suffix" in {
     val query = "Table | where column1 = 'abc' | summarize by count()"
 
-    KustoQueryUtils.getQuerySchemaQuery(query) should be ("Table | where column1 = 'abc' | summarize by count()| take 1")
+    KustoQueryUtils.getQuerySchemaQuery(query) should be ("Table | where column1 = 'abc' | summarize by count()| take 0")
   }
 
   "limitQuery" should "add limit" in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -141,8 +141,13 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
         isEqual = false
       }
     }
+
     assert(isEqual)
     KDSU.logInfo(myName, s"KustoBatchSinkDataTypesTest: Ingestion results validated for table '$table'")
+
+    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://$cluster.kusto.windows.net", appId, appKey, authority)
+    val engineClient = ClientFactory.createClient(engineKcsb)
+    KustoTestUtils.tryDropAllTablesByPrefix(engineClient, database, prefix)
   }
 
   "KustoBatchSinkSync" should "also ingest simple data to a Kusto cluster" taggedAs KustoE2E in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -74,7 +74,7 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
     KDSU.logFatal(myName,"******** fatal  ********. Use a 'logLevel' system variable to change the logging level.")
   }
 
-  "KustoBatchSinkDataTypesTest" should "ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
+  "KustoBatchSinkDataTypesTest" should "ingest structured data of all types to a Kusto cluster" taggedAs KustoE2E in {
     import spark.implicits._
 
     val prefix = "KustoBatchSinkDataTypesTest_Ingest"
@@ -146,7 +146,7 @@ class KustoSinkBatchE2E extends FlatSpec with BeforeAndAfterAll{
     KDSU.logInfo(myName, s"KustoBatchSinkDataTypesTest: Ingestion results validated for table '$table'")
   }
 
-  "KustoBatchSinkSync" should "also ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
+  "KustoBatchSinkSync" should "also ingest simple data to a Kusto cluster" taggedAs KustoE2E in {
     import spark.implicits._
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2E_Ingest"

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoWriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoWriterTests.scala
@@ -2,9 +2,11 @@ package com.microsoft.kusto.spark
 
 import java.io.BufferedWriter
 import java.nio.charset.StandardCharsets
+import java.util
 import java.util.zip.GZIPOutputStream
 
 import com.microsoft.kusto.spark.datasink.{BlobWriteResource, KustoWriter}
+import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
 import com.univocity.parsers.csv.{CsvWriter, CsvWriterSettings}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -24,12 +26,13 @@ class KustoWriterTests extends FlatSpec with Matchers {
     sparkSession.read.format("csv").option("header", "false").load("src/test/resources/ShortTestData/ShortTestData.csv")
   }
 
-  "convertRowToCSV" should "convert the row as expected" in {
+  "convertRowToCsv" should "convert the row as expected" in {
     val df: DataFrame = getDF()
     val dfRow: InternalRow = getDF().queryExecution.toRdd.collect().head
     KustoWriter.convertRowToCSV(dfRow, df.schema, "UTC").formattedRow shouldEqual Array("John Doe", "1")
   }
-  "convertRowToCSV" should "calculate row size as expected" in {
+
+  "convertRowToCsv" should "calculate row size as expected" in {
     val df: DataFrame = getDF()
     val dfRow: InternalRow = getDF().queryExecution.toRdd.collect().head
     val expectedSize = "John Doe,1\n".getBytes(StandardCharsets.UTF_8).length
@@ -37,7 +40,6 @@ class KustoWriterTests extends FlatSpec with Matchers {
   }
 
   "finalizeFileWrite" should "should flush and close buffers" in {
-
     val gzip = mock(classOf[GZIPOutputStream])
     val buffer = mock(classOf[BufferedWriter])
     val csvWriter = new CsvWriter(buffer, new CsvWriterSettings)
@@ -52,4 +54,31 @@ class KustoWriterTests extends FlatSpec with Matchers {
     verify(buffer, times(1)).close()
   }
 
+  "getColumnsSchema" should "parse table schema correctly" in {
+    //val columns = "{\"Name\":\"Subscriptions\",\"OrderedColumns\":[{\"Name\":\"SubscriptionGuid\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"Identifier\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"SomeNumber\",\"Type\":\"System.Int64\",\"CslType\":\"long\"},{\"Name\":\"IsCurrent\",\"Type\":\"System.SByte\",\"CslType\":\"bool\"},{\"Name\":\"LastModifiedOn\",\"Type\":\"System.DateTime\",\"CslType\":\"datetime\"},{\"Name\":\"IntegerValue\",\"Type\":\"System.Int32\",\"CslType\":\"int\"}]}"
+    val element1 = new util.ArrayList[String]
+    element1.add("SubscriptionGuid")
+    element1.add("string")
+    element1.add("System.String")
+
+    val element2 = new util.ArrayList[String]
+    element2.add("Identifier")
+    element2.add("string")
+    element2.add("System.String")
+
+    val element3 = new util.ArrayList[String]
+    element3.add("SomeNumber")
+    element3.add("long")
+    element3.add("System.Int64")
+
+    val resultTable =  new util.ArrayList[util.ArrayList[String]]
+    resultTable.add(element1)
+    resultTable.add(element2)
+    resultTable.add(element3)
+
+    //("SubscriptionGuid", "string", "System.String")
+    val parsedSchema = KDSU.extractSchemaFromResultTable(resultTable)
+    // We could add new elements for IsCurrent:bool,LastModifiedOn:datetime,IntegerValue:int
+    parsedSchema shouldEqual "SubscriptionGuid:string,Identifier:string,SomeNumber:long"
+  }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoWriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoWriterTests.scala
@@ -55,7 +55,8 @@ class KustoWriterTests extends FlatSpec with Matchers {
   }
 
   "getColumnsSchema" should "parse table schema correctly" in {
-    //val columns = "{\"Name\":\"Subscriptions\",\"OrderedColumns\":[{\"Name\":\"SubscriptionGuid\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"Identifier\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"SomeNumber\",\"Type\":\"System.Int64\",\"CslType\":\"long\"},{\"Name\":\"IsCurrent\",\"Type\":\"System.SByte\",\"CslType\":\"bool\"},{\"Name\":\"LastModifiedOn\",\"Type\":\"System.DateTime\",\"CslType\":\"datetime\"},{\"Name\":\"IntegerValue\",\"Type\":\"System.Int32\",\"CslType\":\"int\"}]}"
+    //Verify part of the following schema:
+    // "{\"Name\":\"Subscriptions\",\"OrderedColumns\":[{\"Name\":\"SubscriptionGuid\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"Identifier\",\"Type\":\"System.String\",\"CslType\":\"string\"},{\"Name\":\"SomeNumber\",\"Type\":\"System.Int64\",\"CslType\":\"long\"},{\"Name\":\"IsCurrent\",\"Type\":\"System.SByte\",\"CslType\":\"bool\"},{\"Name\":\"LastModifiedOn\",\"Type\":\"System.DateTime\",\"CslType\":\"datetime\"},{\"Name\":\"IntegerValue\",\"Type\":\"System.Int32\",\"CslType\":\"int\"}]}"
     val element1 = new util.ArrayList[String]
     element1.add("SubscriptionGuid")
     element1.add("string")


### PR DESCRIPTION
Parse table schema in kusto, and get the result as rows of name/csl-type/type.
This is both more efficient and reduces dependency on Jackson-core library.
Also, for query-schema it is sufficient to take 0 (instead of take 1).
All changes are pending validation