### PR TITLE
set connector as insertable

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -15,24 +15,24 @@
     <dependencies>
         <!-- Compile Scope -->
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>adal4j</artifactId>
-            <version>1.6.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.6,)</version>
+            <version>[2.9.6, 2.10.0)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>[2.9.6,)</version>
+            <version>[2.9.6, 2.10.0)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>[2.9.6,)</version>
+            <version>[2.9.6, 2.10.0)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>adal4j</artifactId>
+            <version>1.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -20,6 +20,21 @@
             <version>1.6.3</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>[2.9.6,)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>[2.9.6,)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>[2.9.6,)</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
@@ -68,11 +83,6 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault-webkey</artifactId>
             <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>[2.9.9,)</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -12,7 +12,6 @@ trait KustoOptions {
 
   // KeyVault options. Relevant only if credentials need to be retrieved from Key Vault
   val KEY_VAULT_URI = "keyVaultUri"
-  val KEY_VAULT_CREDENTIALS = "keyVaultCredentials"
   val KEY_VAULT_APP_ID = "keyVaultAppId"
   val KEY_VAULT_APP_KEY = "keyVaultAppKey"
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -107,7 +107,7 @@ class DefaultSource extends CreatableRelationProvider
           storageSecretIsAccountKey))
       }
 
-    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.defaultTimeoutAsString).toLong, TimeUnit.SECONDS)
+    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.nonWaitingConst).toLong, TimeUnit.SECONDS)
 
     KustoRelation(
       kustoCoordinates,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -1,9 +1,10 @@
 package com.microsoft.kusto.spark.datasource
+
 import java.security.InvalidParameterException
 import java.util.UUID
 
-import com.microsoft.kusto.spark.authentication.KustoAuthentication
 import com.microsoft.azure.kusto.data.{Client, ClientRequestProperties}
+import com.microsoft.kusto.spark.authentication.KustoAuthentication
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.utils.{CslCommandsGenerator, KustoAzureFsSetupCache, KustoBlobStorageUtils, KustoQueryUtils, KustoDataSourceUtils => KDSU}
 import org.apache.spark.Partition
@@ -44,9 +45,9 @@ private[kusto] object KustoReader {
   private val myName = this.getClass.getSimpleName
 
   private[kusto] def leanBuildScan(
-    kustoClient: Client,
-    request: KustoReadRequest,
-    filtering: KustoFiltering): RDD[Row] = {
+                                    kustoClient: Client,
+                                    request: KustoReadRequest,
+                                    filtering: KustoFiltering): RDD[Row] = {
 
     val filteredQuery = KustoFilter.pruneAndFilter(request.schema, request.query, filtering)
     val kustoResult = kustoClient.execute(request.kustoCoordinates.database,
@@ -58,12 +59,12 @@ private[kusto] object KustoReader {
   }
 
   private[kusto] def scaleBuildScan(
-     kustoClient: Client,
-     request: KustoReadRequest,
-     storage: KustoStorageParameters,
-     partitionInfo: KustoPartitionParameters,
-     options: KustoReadOptions,
-     filtering: KustoFiltering): RDD[Row] = {
+                                     kustoClient: Client,
+                                     request: KustoReadRequest,
+                                     storage: KustoStorageParameters,
+                                     partitionInfo: KustoPartitionParameters,
+                                     options: KustoReadOptions,
+                                     filtering: KustoFiltering): RDD[Row] = {
 
     setupBlobAccess(request, storage)
     val partitions = calculatePartitions(partitionInfo)
@@ -96,7 +97,9 @@ private[kusto] object KustoReader {
 
         if (count == 0) {
           request.sparkSession.emptyDataFrame.rdd
-        } else { throw ex }
+        } else {
+          throw ex
+        }
     }
 
     KDSU.logInfo(myName, "Transaction data written to blob storage account " +
@@ -160,13 +163,13 @@ private[kusto] class KustoReader(client: Client, request: KustoReadRequest, stor
   // Export a single partition from Kusto to transient Blob storage.
   // Returns the directory path for these blobs
   private[kusto] def exportPartitionToBlob(
-    partition: KustoPartition,
-    request: KustoReadRequest,
-    storage: KustoStorageParameters,
-    directory: String,
-    options: KustoReadOptions,
-    filtering: KustoFiltering,
-    clientRequestProperties: Option[ClientRequestProperties]): Unit = {
+                                            partition: KustoPartition,
+                                            request: KustoReadRequest,
+                                            storage: KustoStorageParameters,
+                                            directory: String,
+                                            options: KustoReadOptions,
+                                            filtering: KustoFiltering,
+                                            clientRequestProperties: Option[ClientRequestProperties]): Unit = {
 
     val limit = if (options.exportSplitLimitMb <= 0) None else Some(options.exportSplitLimitMb)
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -44,10 +44,9 @@ private[kusto] case class KustoReadOptions(forcedReadMode: String = "",
 private[kusto] object KustoReader {
   private val myName = this.getClass.getSimpleName
 
-  private[kusto] def leanBuildScan(
-                                    kustoClient: Client,
-                                    request: KustoReadRequest,
-                                    filtering: KustoFiltering): RDD[Row] = {
+  private[kusto] def leanBuildScan(kustoClient: Client,
+                                   request: KustoReadRequest,
+                                   filtering: KustoFiltering): RDD[Row] = {
 
     val filteredQuery = KustoFilter.pruneAndFilter(request.schema, request.query, filtering)
     val kustoResult = kustoClient.execute(request.kustoCoordinates.database,
@@ -58,13 +57,12 @@ private[kusto] object KustoReader {
     request.sparkSession.createDataFrame(serializer.toRows, serializer.getSchema).rdd
   }
 
-  private[kusto] def scaleBuildScan(
-                                     kustoClient: Client,
-                                     request: KustoReadRequest,
-                                     storage: KustoStorageParameters,
-                                     partitionInfo: KustoPartitionParameters,
-                                     options: KustoReadOptions,
-                                     filtering: KustoFiltering): RDD[Row] = {
+  private[kusto] def scaleBuildScan(kustoClient: Client,
+                                    request: KustoReadRequest,
+                                    storage: KustoStorageParameters,
+                                    partitionInfo: KustoPartitionParameters,
+                                    options: KustoReadOptions,
+                                    filtering: KustoFiltering): RDD[Row] = {
 
     setupBlobAccess(request, storage)
     val partitions = calculatePartitions(partitionInfo)
@@ -162,14 +160,13 @@ private[kusto] class KustoReader(client: Client, request: KustoReadRequest, stor
 
   // Export a single partition from Kusto to transient Blob storage.
   // Returns the directory path for these blobs
-  private[kusto] def exportPartitionToBlob(
-                                            partition: KustoPartition,
-                                            request: KustoReadRequest,
-                                            storage: KustoStorageParameters,
-                                            directory: String,
-                                            options: KustoReadOptions,
-                                            filtering: KustoFiltering,
-                                            clientRequestProperties: Option[ClientRequestProperties]): Unit = {
+  private[kusto] def exportPartitionToBlob(partition: KustoPartition,
+                                           request: KustoReadRequest,
+                                           storage: KustoStorageParameters,
+                                           directory: String,
+                                           options: KustoReadOptions,
+                                           filtering: KustoFiltering,
+                                           clientRequestProperties: Option[ClientRequestProperties]): Unit = {
 
     val limit = if (options.exportSplitLimitMb <= 0) None else Some(options.exportSplitLimitMb)
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -3,8 +3,7 @@ package com.microsoft.kusto.spark.utils
 import scala.concurrent.duration._
 
 object KustoConstants {
-  val defaultTimeoutLongRunning: FiniteDuration = 90 minutes
-  val defaultTimeoutAsString: String = defaultTimeoutLongRunning.toSeconds.toString
+  val nonWaitingConst: String = (-1 seconds).toSeconds.toString
   val defaultPeriodicSamplePeriod: FiniteDuration = 1 seconds
   val clientName = "Kusto.Spark.Connector"
   val defaultBufferSize: Int = 16 * 1024

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkTests.scala
@@ -6,15 +6,17 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.microsoft.azure.kusto.ingest.IngestClient
 import com.microsoft.azure.kusto.ingest.result.{IngestionResult, IngestionStatus}
 import com.microsoft.kusto.spark.authentication.AadApplicationAuthentication
-import com.microsoft.kusto.spark.datasink.{KustoSink, KustoSinkOptions, WriteOptions}
 import com.microsoft.kusto.spark.common.KustoCoordinates
-import com.microsoft.kusto.spark.utils.{KustoConstants => KCONST, KustoDataSourceUtils => KDSU}
+import com.microsoft.kusto.spark.datasink.{KustoSink, KustoSinkOptions, WriteOptions}
+import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
 class KustoSinkTests extends FlatSpec with MockFactory with Matchers with BeforeAndAfterAll {
@@ -54,7 +56,7 @@ class KustoSinkTests extends FlatSpec with MockFactory with Matchers with Before
       sqlContext,
       KustoCoordinates(kustoCluster, kustoDatabase, Some(kustoTable)),
       AadApplicationAuthentication(appId, appKey, appAuthorityId),
-      WriteOptions(writeResultLimit = KustoSinkOptions.NONE_RESULT_LIMIT, timeout = KCONST.defaultTimeoutLongRunning))
+      WriteOptions(writeResultLimit = KustoSinkOptions.NONE_RESULT_LIMIT, timeout = 15 minutes))
 
   private val rowId = new AtomicInteger(1)
 


### PR DESCRIPTION
small changes in the reading part:
better conversion to rdd 
setting the connector as insertable (enable usage of sql INSERT command)
adding equals method (should be used by spark to cache results)
