### PR TITLE
Support non-public domains

### DIFF
--- a/connector/src/main/resources/app.properties
+++ b/connector/src/main/resources/app.properties
@@ -1,1 +1,7 @@
 application.version=${project.version}
+ingestPrefix=https://ingest-
+enginePrefix=https://
+defaultDomainPostfix=core.windows.net
+defaultClusterSuffix=kusto.windows.net
+ariaClustersPrefix=https://kusto.
+ariaClustersSuffix=microsoft.com

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -35,7 +35,7 @@ trait KustoOptions {
   val KUSTO_TIMEOUT_LIMIT: String = newOption("timeoutLimit")
 }
 
-case class KustoCoordinates(cluster: String, database: String, table: Option[String] = None)
+case class KustoCoordinates(clusterUrl: String, clusterAlias:String, database: String, table: Option[String] = None)
 
 /** **********************************************************************************/
 /*                                    NOTE!!!                                       */

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -79,7 +79,7 @@ object KustoWriter {
       asyncWork.onFailure {
         case exception: Exception =>
           kustoClient.cleanupIngestionByproducts(tableCoordinates.database, kustoClient.engineClient, tmpTableName)
-          KDSU.reportExceptionAndThrow(myName, exception, "writing data", tableCoordinates.clusterAlias, tableCoordinates.database, table, shouldNotThrow = true)
+          KDSU.reportExceptionAndThrow(myName, exception, "writing data", tableCoordinates.clusterUrl, tableCoordinates.database, table, shouldNotThrow = true)
           KDSU.logError(myName, "The exception is not visible in the driver since we're in async mode")
       }
     } else {
@@ -124,7 +124,7 @@ object KustoWriter {
         KDSU.reportExceptionAndThrow(
           myName,
           ex,
-          "trying to drop temporary tables", coordinates.clusterAlias, coordinates.database, coordinates.table.getOrElse("Unspecified table name"),
+          "trying to drop temporary tables", coordinates.clusterUrl, coordinates.database, coordinates.table.getOrElse("Unspecified table name"),
           shouldNotThrow = true
         )
     }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -41,11 +41,11 @@ object KustoWriter {
                            authentication: KustoAuthentication,
                            writeOptions: WriteOptions): Unit = {
     val batchIdIfExists = batchId.filter(_ != 0).map(_.toString).getOrElse("")
-    val kustoClient = KustoClientCache.getClient(tableCoordinates.cluster, authentication)
+    val kustoClient = KustoClientCache.getClient(tableCoordinates.clusterAlias, tableCoordinates.clusterUrl, authentication)
 
     if (tableCoordinates.table.isEmpty) {
       KDSU.reportExceptionAndThrow(myName, new InvalidParameterException("Table name not specified"), "writing data",
-        tableCoordinates.cluster, tableCoordinates.database)
+        tableCoordinates.clusterUrl, tableCoordinates.database)
     }
 
     val table = tableCoordinates.table.get
@@ -79,7 +79,7 @@ object KustoWriter {
       asyncWork.onFailure {
         case exception: Exception =>
           kustoClient.cleanupIngestionByproducts(tableCoordinates.database, kustoClient.engineClient, tmpTableName)
-          KDSU.reportExceptionAndThrow(myName, exception, "writing data", tableCoordinates.cluster, tableCoordinates.database, table, shouldNotThrow = true)
+          KDSU.reportExceptionAndThrow(myName, exception, "writing data", tableCoordinates.clusterAlias, tableCoordinates.database, table, shouldNotThrow = true)
           KDSU.logError(myName, "The exception is not visible in the driver since we're in async mode")
       }
     } else {
@@ -124,7 +124,7 @@ object KustoWriter {
         KDSU.reportExceptionAndThrow(
           myName,
           ex,
-          "trying to drop temporary tables", coordinates.cluster, coordinates.database, coordinates.table.getOrElse("Unspecified table name"),
+          "trying to drop temporary tables", coordinates.clusterAlias, coordinates.database, coordinates.table.getOrElse("Unspecified table name"),
           shouldNotThrow = true
         )
     }
@@ -169,7 +169,7 @@ object KustoWriter {
     import parameters._
     val partitionId = TaskContext.getPartitionId
     KDSU.logInfo(myName, s"Ingesting partition '$partitionId'")
-    val ingestClient = KustoClientCache.getClient(coordinates.cluster, authentication).ingestClient
+    val ingestClient = KustoClientCache.getClient(coordinates.clusterAlias, coordinates.clusterUrl, authentication).ingestClient
 
     // We force blocking here, since the driver can only complete the ingestion process
     // once all partitions are ingested into the temporary table
@@ -221,7 +221,7 @@ object KustoWriter {
 
     import parameters._
 
-    val kustoClient = KustoClientCache.getClient(coordinates.cluster, authentication)
+    val kustoClient = KustoClientCache.getClient(coordinates.clusterAlias, coordinates.clusterUrl, authentication)
     val maxBlobSize = writeOptions.batchLimit * KCONST.oneMega
     //This blobWriter will be used later to write the rows to blob storage from which it will be ingested to Kusto
     val initialBlobWriter: BlobWriteResource = createBlobWriter(schema, coordinates, tmpTableName, kustoClient)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -107,7 +107,8 @@ class DefaultSource extends CreatableRelationProvider
           parameters.get(KustoSourceOptions.KUSTO_BLOB_STORAGE_ACCOUNT_NAME),
           parameters.get(KustoSourceOptions.KUSTO_BLOB_CONTAINER),
           storageSecret,
-          storageSecretIsAccountKey))
+          storageSecretIsAccountKey,
+          parameters.get(KustoSourceOptions.KUSTO_BLOB_STORAGE_DOMAIN_POSTFIX)))
       }
 
     val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.defaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -108,7 +108,7 @@ class DefaultSource extends CreatableRelationProvider
           parameters.get(KustoSourceOptions.KUSTO_BLOB_CONTAINER),
           storageSecret,
           storageSecretIsAccountKey,
-          parameters.get(KustoSourceOptions.KUSTO_BLOB_STORAGE_DOMAIN_POSTFIX)))
+          parameters.get(KustoSourceOptions.KUSTO_BLOB_STORAGE_ENDPOINT_SUFFIX)))
       }
 
     val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.defaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -28,7 +28,8 @@ private[kusto] case class KustoPartitionParameters(num: Int, column: String, mod
 private[kusto] case class KustoStorageParameters(account: String,
                                                  secret: String,
                                                  container: String,
-                                                 secretIsAccountKey: Boolean)
+                                                 secretIsAccountKey: Boolean,
+                                                 domainPostfix: String = KDSU.defaultDomainPostfix)
 
 private[kusto] case class KustoFiltering(columns: Array[String] = Array.empty, filters: Array[Filter] = Array.empty)
 
@@ -85,13 +86,13 @@ private[kusto] object KustoReader {
 
     val directoryExists = (params: KustoStorageParameters) => {
       val container = if (params.secretIsAccountKey) {
-        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.windows.net/${params.container}"), new StorageCredentialsAccountAndKey(params.account,params.secret))
+        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.${params.domainPostfix}/${params.container}"), new StorageCredentialsAccountAndKey(params.account,params.secret))
       } else {
-        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.windows.net/${params.container}?${params.secret}"))
+        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.${params.domainPostfix}/${params.container}${params.secret}"))
       }
       container.getDirectoryReference(directory).listBlobsSegmented().getLength > 0
     }
-    val paths = storage.filter(directoryExists).map(params => s"wasbs://${params.container}@${params.account}.blob.core.windows.net/$directory")
+    val paths = storage.filter(directoryExists).map(params => s"wasbs://${params.container}@${params.account}.blob.core.${params.domainPostfix}/$directory")
     KDSU.logInfo(myName, s"Finished exporting from Kusto to '$paths'" +
       s", will start parquet reading now")
     val rdd = try {
@@ -130,12 +131,12 @@ private[kusto] object KustoReader {
     for(storage <- storageParameters) {
       if (storage.secretIsAccountKey) {
         if (!KustoAzureFsSetupCache.updateAndGetPrevStorageAccountAccess(storage.account, storage.secret, now)) {
-          config.set(s"fs.azure.account.key.${storage.account}.blob.core.windows.net", s"${storage.secret}")
+          config.set(s"fs.azure.account.key.${storage.account}.blob.core.${storage.domainPostfix}", s"${storage.secret}")
         }
       }
       else {
         if (!KustoAzureFsSetupCache.updateAndGetPrevSas(storage.container, storage.account, storage.secret, now)) {
-          config.set(s"fs.azure.sas.${storage.container}.${storage.account}.blob.core.windows.net", s"${storage.secret}")
+          config.set(s"fs.azure.sas.${storage.container}.${storage.account}.blob.core.${storage.domainPostfix}", s"${storage.secret}")
         }
       }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -29,7 +29,7 @@ private[kusto] case class KustoStorageParameters(account: String,
                                                  secret: String,
                                                  container: String,
                                                  secretIsAccountKey: Boolean,
-                                                 domainPostfix: String = KDSU.defaultDomainPostfix)
+                                                 endpointSuffix: String = KDSU.defaultDomainPostfix)
 
 private[kusto] case class KustoFiltering(columns: Array[String] = Array.empty, filters: Array[Filter] = Array.empty)
 
@@ -86,14 +86,14 @@ private[kusto] object KustoReader {
 
     val directoryExists = (params: KustoStorageParameters) => {
       val container = if (params.secretIsAccountKey) {
-        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.${params.domainPostfix}/${params.container}"), new StorageCredentialsAccountAndKey(params.account,params.secret))
+        new CloudBlobContainer(new URI(s"https://${params.account}.blob.${params.endpointSuffix}/${params.container}"), new StorageCredentialsAccountAndKey(params.account,params.secret))
       } else {
-        new CloudBlobContainer(new URI(s"https://${params.account}.blob.core.${params.domainPostfix}/${params.container}${params.secret}"))
+        new CloudBlobContainer(new URI(s"https://${params.account}.blob.${params.endpointSuffix}/${params.container}${params.secret}"))
       }
       container.getDirectoryReference(directory).listBlobsSegmented().getLength > 0
     }
-    val paths = storage.filter(directoryExists).map(params => s"wasbs://${params.container}@${params.account}.blob.core.${params.domainPostfix}/$directory")
-    KDSU.logInfo(myName, s"Finished exporting from Kusto to '$paths'" +
+    val paths = storage.filter(directoryExists).map(params => s"wasbs://${params.container}@${params.account}.blob.${params.endpointSuffix}/$directory")
+    KDSU.logInfo(myName, s"Finished exporting from Kusto to '${paths.toString()}'" +
       s", will start parquet reading now")
     val rdd = try {
       request.sparkSession.read.parquet(paths:_*).rdd
@@ -111,7 +111,7 @@ private[kusto] object KustoReader {
         }
     }
 
-    KDSU.logInfo(myName, "Transaction data written to blob storage, paths:" + paths)
+    KDSU.logInfo(myName, "Transaction data read from blob storage, paths:" + paths)
     rdd
   }
 
@@ -131,12 +131,12 @@ private[kusto] object KustoReader {
     for(storage <- storageParameters) {
       if (storage.secretIsAccountKey) {
         if (!KustoAzureFsSetupCache.updateAndGetPrevStorageAccountAccess(storage.account, storage.secret, now)) {
-          config.set(s"fs.azure.account.key.${storage.account}.blob.core.${storage.domainPostfix}", s"${storage.secret}")
+          config.set(s"fs.azure.account.key.${storage.account}.blob.${storage.endpointSuffix}", s"${storage.secret}")
         }
       }
       else {
         if (!KustoAzureFsSetupCache.updateAndGetPrevSas(storage.container, storage.account, storage.secret, now)) {
-          config.set(s"fs.azure.sas.${storage.container}.${storage.account}.blob.core.${storage.domainPostfix}", s"${storage.secret}")
+          config.set(s"fs.azure.sas.${storage.container}.${storage.account}.blob.${storage.endpointSuffix}", s"${storage.secret}")
         }
       }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -52,7 +52,7 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
   }
 
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
-    val kustoClient = KustoClientCache.getClient(kustoCoordinates.cluster, authentication).engineClient
+    val kustoClient = KustoClientCache.getClient(kustoCoordinates.clusterAlias, kustoCoordinates.clusterUrl, authentication).engineClient
     var timedOutCounting = false
     val forceSingleMode = readOptions.readMode.isDefined && readOptions.readMode.get == ReadMode.ForceSingleMode
     var useSingleMode = forceSingleMode
@@ -100,7 +100,7 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
           kustoClient,
           KustoReadRequest(sparkSession, cachedSchema, kustoCoordinates, query, authentication, timeout, clientRequestProperties),
           if (storageParameters.isDefined) Seq(storageParameters.get) else
-            KustoClientCache.getClient(kustoCoordinates.cluster, authentication).getTempBlobsForExport,
+            KustoClientCache.getClient(kustoCoordinates.clusterAlias, kustoCoordinates.clusterUrl, authentication).getTempBlobsForExport,
           KustoPartitionParameters(numPartitions, getPartitioningColumn, getPartitioningMode),
           readOptions,
           KustoFiltering(requiredColumns, filters))
@@ -127,7 +127,7 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
       throw new RuntimeException("Spark connector cannot run Kusto commands. Please provide a valid query")
     }
 
-    KDSU.getSchema(kustoCoordinates.database, getSchemaQuery, KustoClientCache.getClient(kustoCoordinates.cluster, authentication).engineClient)
+    KDSU.getSchema(kustoCoordinates.database, getSchemaQuery, KustoClientCache.getClient(kustoCoordinates.clusterAlias, kustoCoordinates.clusterUrl, authentication).engineClient)
   }
 
   private def getPartitioningColumn: String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -15,6 +15,8 @@ object KustoSourceOptions extends KustoOptions {
   // Blob Storage access parameters for source connector when working in 'distributed' mode (read)
   // These parameters will not be needed once we move to automatic blob provisioning
 
+  // Blob container name
+  val KUSTO_BLOB_CONTAINER: String = newOption("blobContainer")
   // Transient storage account when reading from Kusto
   val KUSTO_BLOB_STORAGE_ACCOUNT_NAME: String = newOption("blobStorageAccountName")
   // Storage account key. Use either this or SAS key to access the storage account
@@ -22,11 +24,9 @@ object KustoSourceOptions extends KustoOptions {
   // SAS access key: a complete query string of the SAS as a container
   // Use either this or storage account key to access the storage account
   val KUSTO_BLOB_STORAGE_SAS_URL: String = newOption("blobStorageSasUrl")
-  // Blob domain postfix - default: windows.net
-  val KUSTO_BLOB_STORAGE_DOMAIN_POSTFIX: String = newOption("blobStorageDomainPostfix")
-  // Blob container name
-  val KUSTO_BLOB_CONTAINER: String = newOption("blobContainer")
 
+  // Blob domain endpoint suffix - default: core.windows.net
+  val KUSTO_BLOB_STORAGE_ENDPOINT_SUFFIX: String = newOption("blobStorageEndpointSuffix")
   // By default an estimation of the rows count is first being made, if the count is lower than 5000 records a simple
   // query is made, else - if storage params were provided they are used for 'distributed' reading and if not - the connector
   // tries to use storage from the kusto ingest service.

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -22,6 +22,8 @@ object KustoSourceOptions extends KustoOptions {
   // SAS access key: a complete query string of the SAS as a container
   // Use either this or storage account key to access the storage account
   val KUSTO_BLOB_STORAGE_SAS_URL: String = newOption("blobStorageSasUrl")
+  // Blob domain postfix - default: windows.net
+  val KUSTO_BLOB_STORAGE_DOMAIN_POSTFIX: String = newOption("blobStorageDomainPostfix")
   // Blob container name
   val KUSTO_BLOB_CONTAINER: String = newOption("blobContainer")
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -76,7 +76,7 @@ private[kusto] object CslCommandsGenerator {
     val getFullUrlFromParams = (storage: KustoStorageParameters) => {
       val secret = storage.secret
       val secretString = if (storage.secretIsAccountKey) s""";" h@"$secret"""" else if (secret(0) == '?') s"""" h@"$secret"""" else s"""?" h@"$secret""""
-      val blobUri = s"https://${storage.account}.blob.core.windows.net"
+      val blobUri = s"https://${storage.account}.blob.core.${storage.domainPostfix}"
       s"$blobUri/${storage.container}$secretString"
     }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -76,7 +76,7 @@ private[kusto] object CslCommandsGenerator {
     val getFullUrlFromParams = (storage: KustoStorageParameters) => {
       val secret = storage.secret
       val secretString = if (storage.secretIsAccountKey) s""";" h@"$secret"""" else if (secret(0) == '?') s"""" h@"$secret"""" else s"""?" h@"$secret""""
-      val blobUri = s"https://${storage.account}.blob.core.${storage.domainPostfix}"
+      val blobUri = s"https://${storage.account}.blob.${storage.endpointSuffix}"
       s"$blobUri/${storage.container}$secretString"
     }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -52,7 +52,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
     if (schemaShowCommandResult.count() == 0) {
       // Table Does not exist
       if (tableCreation == SinkTableCreationMode.FailIfNotExist) {
-        throw new RuntimeException("Table '" + table + "' doesn't exist in database '" + database + "', in cluster '" + tableCoordinates.cluster + "'")
+        throw new RuntimeException("Table '" + table + "' doesn't exist in database '" + database + "', in cluster '" + tableCoordinates.clusterAlias + "'")
       } else {
         // Parse dataframe schema and create a destination table with that schema
         val tableSchemaBuilder = new StringJoiner(",")
@@ -109,16 +109,16 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
 
             finalRes.status match {
               case OperationStatus.Pending =>
-                throw new RuntimeException(s"Ingestion to Kusto failed on timeout failure. Cluster: '${coordinates.cluster}', " +
+                throw new RuntimeException(s"Ingestion to Kusto failed on timeout failure. Cluster: '${coordinates.clusterAlias}', " +
                   s"database: '${coordinates.database}', table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}'")
               case OperationStatus.Succeeded =>
                 KDSU.logInfo(myName, s"Ingestion to Kusto succeeded. " +
-                  s"Cluster: '${coordinates.cluster}', " +
+                  s"Cluster: '${coordinates.clusterAlias}', " +
                   s"database: '${coordinates.database}', " +
                   s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}'', from: '${finalRes.ingestionSourcePath}', Operation ${finalRes.operationId}")
               case otherStatus =>
                 throw new RuntimeException(s"Ingestion to Kusto failed with status '$otherStatus'." +
-                  s" Cluster: '${coordinates.cluster}', database: '${coordinates.database}', " +
+                  s" Cluster: '${coordinates.clusterAlias}', database: '${coordinates.database}', " +
                   s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}''. Ingestion info: '${readIngestionResult(finalRes)}'")
             }
           }
@@ -138,7 +138,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
           KDSU.reportExceptionAndThrow(
             myName,
             ex,
-            "Trying to poll on pending ingestions", coordinates.cluster, coordinates.database, coordinates.table.getOrElse("Unspecified table name")
+            "Trying to poll on pending ingestions", coordinates.clusterAlias, coordinates.database, coordinates.table.getOrElse("Unspecified table name")
           )
       } finally {
         cleanupIngestionByproducts(database, kustoAdminClient, tmpTableName)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -138,7 +138,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
           KDSU.reportExceptionAndThrow(
             myName,
             ex,
-            "Trying to poll on pending ingestions", coordinates.clusterAlias, coordinates.database, coordinates.table.getOrElse("Unspecified table name")
+            "Trying to poll on pending ingestions", coordinates.clusterUrl, coordinates.database, coordinates.table.getOrElse("Unspecified table name")
           )
       } finally {
         cleanupIngestionByproducts(database, kustoAdminClient, tmpTableName)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -7,7 +7,7 @@ object KustoConstants {
   val defaultWaitingIntervalLongRunning: String = (2 days).toSeconds.toString
   val defaultPeriodicSamplePeriod: FiniteDuration = 1 seconds
   val defaultIngestionTaskTime: FiniteDuration = 20 seconds
-  val clientName: String = KustoDataSourceUtils.ClientName
+  val clientName: String = KustoDataSourceUtils.clientName
   val defaultBufferSize: Int = 16 * 1024
   val storageExpiryMinutes: Int = 120
   val sparkSettingsRefreshMinutes: Int = 120

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -29,10 +29,10 @@ import org.apache.commons.lang3.StringUtils
 object KustoDataSourceUtils {
   private val klog = Logger.getLogger("KustoConnector")
 
-  val sasPattern: Regex = raw"(?:https://)?([^.]+).blob.core.(.+)/([^?]+)?(.+)".r
+  val sasPattern: Regex = raw"(?:https://)?([^.]+).blob.([^/]+)/([^?]+)?(.+)".r
   val ingestPrefix = "https://ingest-"
   val enginePrefix = "https://"
-  val defaultDomainPostfix = "windows.net"
+  val defaultDomainPostfix = "core.windows.net"
   val oldClustersPrefix = "https://kusto."
   val oldClusterSuffix = "microsoft.com"
 
@@ -362,7 +362,7 @@ object KustoDataSourceUtils {
     url match {
       case sasPattern(storageAccountId, cloud, container, sasKey) => KustoStorageParameters(storageAccountId, sasKey, container, secretIsAccountKey = false, cloud)
       case _ => throw new InvalidParameterException(
-        "SAS url couldn't be parsed. Should be https://<storage-account>.blob.core.windows.net/<container>?<SAS-Token>"
+        "SAS url couldn't be parsed. Should be https://<storage-account>.blob.<domainEndpointSuffix>/<container>?<SAS-Token>"
       )
     }
   }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
@@ -68,6 +68,16 @@ class KustoSourceTests extends FlatSpec with MockFactory with Matchers with Befo
     assert(df.schema.equals(expected))
   }
 
+  "KustoDataSource" should "parse sas" in {
+    val sas = "https://storage.blob.core.customDom/upload/?<secret>"
+    val params = KDSU.parseSas(sas)
+    assert(params.endpointSuffix.equals("core.customDom"))
+    assert(params.account.equals("storage"))
+    assert(params.secret.equals("?<secret>"))
+    assert(params.container.equals("upload/"))
+    assert(params.secretIsAccountKey.equals(false))
+  }
+
   "KustoDataSource" should "match cluster default url pattern" in {
     val ingestUrl = "https://ingest-ohbitton.dev.kusto.windows.net"
     val engineUrl = "https://ohbitton.dev.kusto.windows.net"
@@ -94,6 +104,5 @@ class KustoSourceTests extends FlatSpec with MockFactory with Matchers with Befo
     val expectedAriaAlias = "aria"
     val ariaAlias = KDSU.getClusterNameFromUrlIfNeeded(ariaEngineUrl)
     assert(ariaAlias.equals(expectedAriaAlias))
-
   }
 }


### PR DESCRIPTION
#### Pull Request Description
Support non-public domains - writing and reading
---

#### Future Release Comment

**Features:**
- Added new option 
-  KUSTO_BLOB_STORAGE_ENDPOINT_SUFFIX "blobStorageEndpointSuffix" - when providing the storage yourself and using storage key for storage parameters, user can provide this option so that the created config will use the right domain

**Fixes:**
- Non-public domains were not parsed right
- Extract domain from blob SAS so that it is set right to the spark config

This goes along with our current Java support for authentication providing login url of the cloud in the environment variable : AadAuthorityUri
