### PR TITLE
Default config values + new java version

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -184,6 +184,9 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>*.properties</include>
+                </includes>
             </resource>
         </resources>
         <testSourceDirectory>src/test/scala</testSourceDirectory>

--- a/connector/src/main/resources/app.properties
+++ b/connector/src/main/resources/app.properties
@@ -1,7 +1,6 @@
 application.version=${project.version}
-ingestPrefix=https://ingest-
+ingestPrefix=ingest-
 enginePrefix=https://
 defaultDomainPostfix=core.windows.net
 defaultClusterSuffix=kusto.windows.net
-ariaClustersPrefix=https://kusto.
 ariaClustersProxy=https://kusto.aria.microsoft.com

--- a/connector/src/main/resources/app.properties
+++ b/connector/src/main/resources/app.properties
@@ -4,4 +4,4 @@ enginePrefix=https://
 defaultDomainPostfix=core.windows.net
 defaultClusterSuffix=kusto.windows.net
 ariaClustersPrefix=https://kusto.
-ariaClustersSuffix=microsoft.com
+ariaClustersProxy=https://kusto.aria.microsoft.com

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
@@ -1,11 +1,13 @@
 package com.microsoft.kusto.spark.utils
 
+import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function
 
 import com.microsoft.azure.kusto.data.ConnectionStringBuilder
 import com.microsoft.kusto.spark.authentication.{AadApplicationAuthentication, KeyVaultAuthentication, KustoAccessTokenAuthentication, KustoAuthentication}
 import com.microsoft.kusto.spark.utils.{KustoConstants => KCONST}
+import org.apache.http.client.utils.URIBuilder
 
 object KustoClientCache {
   var clientCache = new ConcurrentHashMap[AliasAndAuth, KustoClient]
@@ -46,7 +48,9 @@ object KustoClientCache {
 
   private[kusto] case class AliasAndAuth(clusterAlias: String, engineUrl: String, authentication: KustoAuthentication) {
     val engineUri: String = engineUrl
-    val ingestUri: String = engineUrl.replace("https://", KustoDataSourceUtils.ingestPrefix)
+    val ingestUri: String = new URIBuilder().setScheme("https")
+      .setHost(KustoDataSourceUtils.ingestPrefix + new URI(engineUrl).getHost)
+      .toString
 
     override def equals(that: Any): Boolean = that match {
       case aa: AliasAndAuth => clusterAlias == aa.clusterAlias && authentication == aa.authentication

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -38,14 +38,17 @@ object KustoDataSourceUtils {
   val input: InputStream = getClass.getClassLoader.getResourceAsStream("app.properties")
   val prop = new Properties( )
   prop.load(input)
-  val version: String = prop.getProperty("application.version")
+  var version: String = prop.getProperty("application.version")
+  if(version == null){
+    version = prop.getProperty("version")
+  }
   val clientName = s"Kusto.Spark.Connector:$version"
-  val ingestPrefix: String = prop.getProperty("ingestPrefix")
-  val enginePrefix: String = prop.getProperty("enginePrefix")
-  val defaultDomainPostfix: String = prop.getProperty("defaultDomainPostfix")
-  val defaultClusterSuffix: String = prop.getProperty("defaultClusterSuffix")
-  val ariaClustersPrefix: String = prop.getProperty("ariaClustersPrefix")
-  val ariaClustersSuffix: String = prop.getProperty("ariaClustersSuffix")
+  val ingestPrefix: String = prop.getProperty("ingestPrefix","http://ingest-")
+  val enginePrefix: String = prop.getProperty("enginePrefix","http://")
+  val defaultDomainPostfix: String = prop.getProperty("defaultDomainPostfix","core.windows.net")
+  val defaultClusterSuffix: String = prop.getProperty("defaultClusterSuffix","kusto.windows.net")
+  val ariaClustersPrefix: String = prop.getProperty("ariaClustersPrefix", "https://kusto")
+  val ariaClustersSuffix: String = prop.getProperty("ariaClustersSuffix", "microsoft.com")
 
   def setLoggingLevel(level: String): Unit = {
     setLoggingLevel(Level.toLevel(level))

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -50,7 +50,7 @@ object KustoDataSourceUtils {
   val defaultDomainPostfix: String = prop.getProperty("defaultDomainPostfix","core.windows.net")
   val defaultClusterSuffix: String = prop.getProperty("defaultClusterSuffix","kusto.windows.net")
   val ariaClustersProxy: String = prop.getProperty("ariaClustersProxy", "https://kusto.aria.microsoft.com")
-  val ariaClustersAlias: String = "aria"
+  val ariaClustersAlias: String = "Aria proxy"
 
   def setLoggingLevel(level: String): Unit = {
     setLoggingLevel(Level.toLevel(level))

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -1,6 +1,7 @@
 package com.microsoft.kusto.spark.utils
 
 import java.io.InputStream
+import java.net.URI
 import java.security.InvalidParameterException
 import java.util
 import java.util.concurrent.{CountDownLatch, TimeUnit, TimeoutException}
@@ -26,6 +27,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.util.matching.Regex
 import org.apache.commons.lang3.StringUtils
+import org.apache.http.client.utils.URIBuilder
 
 object KustoDataSourceUtils {
   private val klog = Logger.getLogger("KustoConnector")
@@ -43,12 +45,12 @@ object KustoDataSourceUtils {
     version = prop.getProperty("version")
   }
   val clientName = s"Kusto.Spark.Connector:$version"
-  val ingestPrefix: String = prop.getProperty("ingestPrefix","https://ingest-")
+  val ingestPrefix: String = prop.getProperty("ingestPrefix","ingest-")
   val enginePrefix: String = prop.getProperty("enginePrefix","https://")
   val defaultDomainPostfix: String = prop.getProperty("defaultDomainPostfix","core.windows.net")
   val defaultClusterSuffix: String = prop.getProperty("defaultClusterSuffix","kusto.windows.net")
-  val ariaClustersPrefix: String = prop.getProperty("ariaClustersPrefix", "https://kusto")
   val ariaClustersProxy: String = prop.getProperty("ariaClustersProxy", "https://kusto.aria.microsoft.com")
+  val ariaClustersAlias: String = "aria"
 
   def setLoggingLevel(level: String): Unit = {
     setLoggingLevel(Level.toLevel(level))
@@ -232,12 +234,12 @@ object KustoDataSourceUtils {
 
   private[kusto] def getClusterNameFromUrlIfNeeded(cluster: String): String = {
     if (cluster.equals(ariaClustersProxy)){
-      val secondDotIndex = cluster.indexOf(".",cluster.indexOf(".") + 1)
-      cluster.substring(ariaClustersPrefix.length,secondDotIndex)
+      ariaClustersAlias
     }
     else if (cluster.startsWith(enginePrefix) ){
-      val startIdx = if (cluster.startsWith(ingestPrefix)) ingestPrefix.length else enginePrefix.length
-      cluster.substring(startIdx,cluster.indexOf(".kusto."))
+      val host = new URI(cluster).getHost
+      val startIdx = if (host.startsWith(ingestPrefix)) ingestPrefix.length else 0
+      host.substring(startIdx,host.indexOf(".kusto."))
     } else {
       cluster
     }
@@ -245,13 +247,16 @@ object KustoDataSourceUtils {
 
   private[kusto] def getEngineUrlFromAliasIfNeeded(cluster: String): String = {
     if(cluster.startsWith(enginePrefix)){
-      if(cluster.startsWith(ingestPrefix)){
-        cluster.replace(ingestPrefix, "https://")
+      val host = new URI(cluster).getHost
+      if(host.startsWith(ingestPrefix)){
+        val uriBuilder = new URIBuilder()
+        uriBuilder.setHost(ingestPrefix + host).toString
       } else{
         cluster
       }
     } else {
-      s"https://$cluster.kusto.windows.net"
+      val uriBuilder = new URIBuilder()
+      uriBuilder.setScheme("https").setHost(s"$cluster.kusto.windows.net").toString
     }
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -43,12 +43,12 @@ object KustoDataSourceUtils {
     version = prop.getProperty("version")
   }
   val clientName = s"Kusto.Spark.Connector:$version"
-  val ingestPrefix: String = prop.getProperty("ingestPrefix","http://ingest-")
-  val enginePrefix: String = prop.getProperty("enginePrefix","http://")
+  val ingestPrefix: String = prop.getProperty("ingestPrefix","https://ingest-")
+  val enginePrefix: String = prop.getProperty("enginePrefix","https://")
   val defaultDomainPostfix: String = prop.getProperty("defaultDomainPostfix","core.windows.net")
   val defaultClusterSuffix: String = prop.getProperty("defaultClusterSuffix","kusto.windows.net")
   val ariaClustersPrefix: String = prop.getProperty("ariaClustersPrefix", "https://kusto")
-  val ariaClustersSuffix: String = prop.getProperty("ariaClustersSuffix", "microsoft.com")
+  val ariaClustersProxy: String = prop.getProperty("ariaClustersProxy", "https://kusto.aria.microsoft.com")
 
   def setLoggingLevel(level: String): Unit = {
     setLoggingLevel(Level.toLevel(level))
@@ -231,7 +231,7 @@ object KustoDataSourceUtils {
   }
 
   private[kusto] def getClusterNameFromUrlIfNeeded(cluster: String): String = {
-    if(cluster.startsWith(ariaClustersPrefix) && cluster.endsWith(ariaClustersSuffix)){
+    if (cluster.equals(ariaClustersProxy)){
       val secondDotIndex = cluster.indexOf(".",cluster.indexOf(".") + 1)
       cluster.substring(ariaClustersPrefix.length,secondDotIndex)
     }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceTests.scala
@@ -101,7 +101,7 @@ class KustoSourceTests extends FlatSpec with MockFactory with Matchers with Befo
     assert(url.equals(AliasAndAuth(alias,engineUrl,null).ingestUri))
 
     val ariaEngineUrl = "https://kusto.aria.microsoft.com"
-    val expectedAriaAlias = "aria"
+    val expectedAriaAlias = "Aria proxy"
     val ariaAlias = KDSU.getClusterNameFromUrlIfNeeded(ariaEngineUrl)
     assert(ariaAlias.equals(expectedAriaAlias))
   }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <scala.version>2.11</scala.version>
         <specs2.version>3.6.5</specs2.version>
         <spark.version>[2.4.0,2.5.0)</spark.version>
-        <kusto-sdk.version>2.1.1</kusto-sdk.version>
+        <kusto-sdk.version>2.1.2</kusto-sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>


### PR DESCRIPTION
#### Pull Request Description

Using the config file we just added does not work on databricks if the library is taken from a local JAR
---

#### Future Release Comment

**Features:**
- new java version

**Fixes:**
- Default config values (used for parsing cluster URL)
