### PR TITLE
Catch transient exceptions on status polling

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -194,6 +194,6 @@ private[kusto] class KustoReader(client: Client, request: KustoReadRequest, stor
     val commandResult: KustoResultSetTable = client.execute(request.kustoCoordinates.database,
       exportCommand,
       clientRequestProperties.orNull).getPrimaryResults
-    KDSU.verifyAsyncCommandCompletion(client, request.kustoCoordinates.database, commandResult, timeOut = request.timeout)
+    KDSU.verifyAsyncCommandCompletion(client, request.kustoCoordinates.database, commandResult, directory, timeOut = request.timeout)
   }
 }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit
 import com.microsoft.azure.kusto.data.{Client, ClientFactory, ConnectionStringBuilder}
 import com.microsoft.azure.kusto.ingest.result.{IngestionStatus, OperationStatus}
 import com.microsoft.azure.kusto.ingest.{IngestClient, IngestClientFactory, IngestionProperties}
+import com.microsoft.azure.storage.StorageException
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.KustoWriter.delayPeriodBetweenCalls
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
@@ -96,18 +97,26 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
       try {
         partitionsResults.value.asScala.foreach {
           partitionResult => {
-            var finalRes: IngestionStatus = null
-            KDSU.doWhile[IngestionStatus](
+            var finalRes: Option[IngestionStatus] = None
+            KDSU.doWhile[Option[IngestionStatus]](
               () => {
-                finalRes = partitionResult.ingestionResult.getIngestionStatusCollection.get(0); finalRes
+                try {
+                  finalRes = Some(partitionResult.ingestionResult.getIngestionStatusCollection.get(0)); finalRes
+                } catch {
+                  case e: StorageException =>
+                    KDSU.logWarn(myName, "Failed to fetch operation status transiently - will keep polling")
+                    None
+                  case e: Exception => KDSU.reportExceptionAndThrow(myName, e, "Failed to fetch operation status"); None
+                }
               },
               0,
               delayPeriodBetweenCalls,
               (timeout.toMillis / delayPeriodBetweenCalls + 5).toInt,
-              res => res.status == OperationStatus.Pending,
+              res => res.isDefined && res.get.status == OperationStatus.Pending,
               res => finalRes = res).await(timeout.toMillis, TimeUnit.MILLISECONDS)
 
-            finalRes.status match {
+            if (finalRes.isDefined) {
+              finalRes.get.status match {
               case OperationStatus.Pending =>
                 throw new RuntimeException(s"Ingestion to Kusto failed on timeout failure. Cluster: '${coordinates.clusterAlias}', " +
                   s"database: '${coordinates.database}', table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}'")
@@ -115,11 +124,14 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
                 KDSU.logInfo(myName, s"Ingestion to Kusto succeeded. " +
                   s"Cluster: '${coordinates.clusterAlias}', " +
                   s"database: '${coordinates.database}', " +
-                  s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}'', from: '${finalRes.ingestionSourcePath}', Operation ${finalRes.operationId}")
+                  s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}'', from: '${finalRes.get.ingestionSourcePath}', Operation ${finalRes.get.operationId}")
               case otherStatus =>
                 throw new RuntimeException(s"Ingestion to Kusto failed with status '$otherStatus'." +
                   s" Cluster: '${coordinates.clusterAlias}', database: '${coordinates.database}', " +
-                  s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}''. Ingestion info: '${readIngestionResult(finalRes)}'")
+                  s"table: '$tmpTableName', batch: '$batchIdIfExists', partition: '${partitionResult.partitionId}''. Ingestion info: '${readIngestionResult(finalRes.get)}'")
+              }
+            } else {
+              throw new RuntimeException("Failed to poll on ingestion status.")
             }
           }
         }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -113,7 +113,8 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
               delayPeriodBetweenCalls,
               (timeout.toMillis / delayPeriodBetweenCalls + 5).toInt,
               res => res.isDefined && res.get.status == OperationStatus.Pending,
-              res => finalRes = res).await(timeout.toMillis, TimeUnit.MILLISECONDS)
+              res => finalRes = res,
+              maxWaitTimeBetweenCalls = KDSU.WriteMaxWaitTime.toMillis.toInt).await(timeout.toMillis, TimeUnit.MILLISECONDS)
 
             if (finalRes.isDefined) {
               finalRes.get.status match {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -5,9 +5,10 @@ import java.net.URI
 import java.security.InvalidParameterException
 import java.util
 import java.util.concurrent.{Callable, CountDownLatch, TimeUnit, TimeoutException}
-import java.util.{NoSuchElementException, StringJoiner, Timer, TimerTask}
+import java.util.{NoSuchElementException, StringJoiner, Timer, TimerTask, UUID}
 
 import com.microsoft.azure.kusto.data.{Client, ClientRequestProperties, KustoResultSetTable}
+import com.microsoft.azure.kusto.data.exceptions.{DataClientException, DataServiceException}
 import com.microsoft.kusto.spark.authentication._
 import com.microsoft.kusto.spark.common.{KustoCoordinates, KustoDebugOptions}
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
@@ -28,6 +29,7 @@ import scala.concurrent.duration._
 import scala.util.matching.Regex
 import org.apache.commons.lang3.StringUtils
 import org.apache.http.client.utils.URIBuilder
+import org.json.JSONObject
 
 object KustoDataSourceUtils {
   private val klog = Logger.getLogger("KustoConnector")
@@ -152,7 +154,7 @@ object KustoDataSourceUtils {
       if(!applicationKey.isEmpty){
         authentication = AadApplicationAuthentication(applicationId, applicationKey, parameters.getOrElse(KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com"))
       } else if(!applicationCertPath.isEmpty){
-        authentication = AadApplicationCertificateAuthentication(applicationId, applicationCertPath, applicationCertPassword);
+        authentication = AadApplicationCertificateAuthentication(applicationId, applicationCertPath, applicationCertPassword)
       }
     } else if (!accessToken.isEmpty) {
       // Authentication by token
@@ -343,6 +345,7 @@ object KustoDataSourceUtils {
   def verifyAsyncCommandCompletion(client: Client,
                                    database: String,
                                    commandResult: KustoResultSetTable,
+                                   directory: String,
                                    samplePeriod: FiniteDuration = KCONST.defaultPeriodicSamplePeriod,
                                    timeOut: FiniteDuration): Unit = {
     commandResult.next()
@@ -355,29 +358,45 @@ object KustoDataSourceUtils {
 
     val stateCol = "State"
     val statusCol = "Status"
-
+    val statusCheck: () => Option[KustoResultSetTable] = () => {
+      try {
+        Some(client.execute(database, operationsShowCommand).getPrimaryResults)
+      }
+      catch{
+        case e: DataServiceException => {
+          val error = new JSONObject(e.getCause.getMessage).getJSONObject("error")
+          val isPermanent = error.getBoolean("@permanent")
+          if (isPermanent) {
+            val message = s"Couldn't monitor the progress of the export command from the service, operationId:$operationId" +
+              s"and read from the blob directory: ('$directory'), once it completes."
+            logError("verifyAsyncCommandCompletion", message)
+            throw new Exception(message, e)
+          }
+          logWarn("verifyAsyncCommandCompletion", "Failed transiently to retrieve export status, trying again in a few seconds")
+          None
+        }
+        case _: DataClientException => None
+      }}
     var lastResponse: Option[KustoResultSetTable] = None
-    val task = doWhile[KustoResultSetTable](
-      func = () => client.execute(database, operationsShowCommand).getPrimaryResults,
+    val task = doWhile[Option[KustoResultSetTable]](
+      func = statusCheck,
       delayBeforeStart = 0, delayBeforeEach = delayPeriodBetweenCalls, timesToRun = timesToRun,
-      stopCondition = (result: KustoResultSetTable) => {
-        result.next()
-        result.getString(stateCol) == "InProgress"
-      },
-      finalWork = result => {
-        lastResponse = Some(result)
+      stopCondition = (result: Option[KustoResultSetTable]) =>
+        result.isEmpty || (result.get.next() && result.get.getString(stateCol) == "InProgress"),
+      finalWork = (result: Option[KustoResultSetTable]) => {
+        lastResponse = result
       })
     var success = true
     if (timeOut < FiniteDuration.apply(0, SECONDS)) {
       task.await()
     } else {
-      if (!task.await(timeoutInMillis, TimeUnit.SECONDS)) {
+      if (!task.await(timeoutInMillis, TimeUnit.MILLISECONDS)) {
         // Timed out
         success = false
       }
     }
 
-    if (lastResponse.isDefined && lastResponse.get.getString(stateCol) != "Completed") {
+    if (lastResponse.isEmpty || lastResponse.get.getString(stateCol) != "Completed") {
       throw new RuntimeException(
         s"Failed to execute Kusto operation with OperationId '$operationId', State: '${lastResponse.get.getString(stateCol)}'," +
           s" Status: '${lastResponse.get.getString(statusCol)}'"

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <scala.version>2.11</scala.version>
         <specs2.version>3.6.5</specs2.version>
         <spark.version>[2.4.0,2.5.0)</spark.version>
-        <kusto-sdk.version>2.2.0</kusto-sdk.version>
+        <kusto-sdk.version>2.3.1</kusto-sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>2.2.0</revision>
+        <revision>2.3.0</revision>
         <scala.version>2.11</scala.version>
         <specs2.version>3.6.5</specs2.version>
         <spark.version>[2.4.0,2.5.0)</spark.version>


### PR DESCRIPTION
In both Read and Write operation we failed on polling the operation status for every kind of exception. In read java client now returns if failure is permanent and if so we stop the polling, in write we continue polling if failure is from StroageException.
** Bug fix **
 - Catch transient exceptions on status polling