### PR TITLE
Setting operationId to easy track the operation

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -43,6 +43,9 @@ trait KustoOptions {
 
   // An integer number corresponding to the period in seconds after which the operation will timeout. Default: '5400' (90 minutes)
   val KUSTO_TIMEOUT_LIMIT: String = newOption("timeoutLimit")
+
+  // An id of the source used for tracing of the write operation
+  val KUSTO_OPERATION_ID: String = newOption("operationId")
 }
 
 case class KustoCoordinates(clusterUrl: String, clusterAlias:String, database: String, table: Option[String] = None)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
@@ -33,9 +33,6 @@ object KustoSinkOptions extends KustoOptions{
   // partition. Kusto's ingestion also aggregates data, default suggested by Kusto is 1GB but here we suggest to cut
   // it at 100MB to adjust it to spark pulling of data.
   val KUSTO_CLIENT_BATCHING_LIMIT: String = newOption("clientBatchingLimit")
-
-  // An id of the source used for tracing of the write operation
-  val KUSTO_SOURCE_ID: String = newOption("sourceId")
 }
 
 object SinkTableCreationMode extends Enumeration {
@@ -49,4 +46,4 @@ case class WriteOptions(tableCreateOptions: SinkTableCreationMode.SinkTableCreat
                         timeZone: String = "UTC", timeout: FiniteDuration,
                         IngestionProperties: Option[String] = None,
                         batchLimit: Int = 100,
-                        sourceId: UUID = UUID.randomUUID())
+                        operationId: String = UUID.randomUUID().toString)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
@@ -1,5 +1,7 @@
 package com.microsoft.kusto.spark.datasink
 
+import java.util.UUID
+
 import com.microsoft.kusto.spark.common.KustoOptions
 
 import scala.concurrent.duration.FiniteDuration
@@ -31,6 +33,9 @@ object KustoSinkOptions extends KustoOptions{
   // partition. Kusto's ingestion also aggregates data, default suggested by Kusto is 1GB but here we suggest to cut
   // it at 100MB to adjust it to spark pulling of data.
   val KUSTO_CLIENT_BATCHING_LIMIT: String = newOption("clientBatchingLimit")
+
+  // An id of the source used for tracing of the write operation
+  val KUSTO_SOURCE_ID: String = newOption("sourceId")
 }
 
 object SinkTableCreationMode extends Enumeration {
@@ -43,4 +48,5 @@ case class WriteOptions(tableCreateOptions: SinkTableCreationMode.SinkTableCreat
                         writeResultLimit: String = KustoSinkOptions.NONE_RESULT_LIMIT,
                         timeZone: String = "UTC", timeout: FiniteDuration,
                         IngestionProperties: Option[String] = None,
-                        batchLimit: Int = 100)
+                        batchLimit: Int = 100,
+                        sourceId: UUID = UUID.randomUUID())

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -188,13 +188,14 @@ object KustoDataSourceUtils {
     var isAsync: Boolean = false
     var isAsyncParam: String = ""
     var batchLimit: Int = 0
-
+    var sourceId: Option[String] = None
     try {
       isAsyncParam = parameters.getOrElse(KustoSinkOptions.KUSTO_WRITE_ENABLE_ASYNC, "false")
       isAsync = parameters.getOrElse(KustoSinkOptions.KUSTO_WRITE_ENABLE_ASYNC, "false").trim.toBoolean
       tableCreationParam = parameters.get(KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS)
       tableCreation = if (tableCreationParam.isEmpty) SinkTableCreationMode.FailIfNotExist else SinkTableCreationMode.withName(tableCreationParam.get)
       batchLimit = parameters.getOrElse(KustoSinkOptions.KUSTO_CLIENT_BATCHING_LIMIT, "100").trim.toInt
+      sourceId = parameters.get(KustoSinkOptions.KUSTO_SOURCE_ID)
     } catch {
       case _: NoSuchElementException => throw new InvalidParameterException(s"No such SinkTableCreationMode option: '${tableCreationParam.get}'")
       case _: java.lang.IllegalArgumentException => throw new InvalidParameterException(s"KUSTO_WRITE_ENABLE_ASYNC is expecting either 'true' or 'false', got: '$isAsyncParam'")
@@ -211,7 +212,8 @@ object KustoDataSourceUtils {
       parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, "UTC"),
       timeout,
       ingestionPropertiesAsJson,
-      batchLimit
+      batchLimit,
+      if (sourceId.isDefined) UUID.fromString(sourceId.get) else UUID.randomUUID()
     )
 
     val sourceParameters = parseSourceParameters(parameters)

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -108,6 +108,9 @@ that is using it. Please verify the following before using Kusto connector:
     this is done for each partition. The ingestion Kusto also aggregates data, default suggested by Kusto is 1GB but here
     we suggest to cut it at 100MB to adjust it to spark pulling of data.
     
+* **KUSTO_SOURCE_ID**:
+    A unique identifier UUID for this ingestion command
+    
  >**Note:**
  For both synchronous and asynchronous operation, 'write' is an atomic transaction, i.e. 
  either all data is written to Kusto, or no data is written. 

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -108,7 +108,7 @@ that is using it. Please verify the following before using Kusto connector:
     this is done for each partition. The ingestion Kusto also aggregates data, default suggested by Kusto is 1GB but here
     we suggest to cut it at 100MB to adjust it to spark pulling of data.
     
-* **KUSTO_SOURCE_ID**:
+* **KUSTO_OPERATION_ID**:
     A unique identifier UUID for this ingestion command
     
  >**Note:**

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -109,7 +109,7 @@ that is using it. Please verify the following before using Kusto connector:
     we suggest to cut it at 100MB to adjust it to spark pulling of data.
     
 * **KUSTO_OPERATION_ID**:
-    A unique identifier UUID for this ingestion command
+    'operationId' - A unique identifier UUID for this ingestion command
     
  >**Note:**
  For both synchronous and asynchronous operation, 'write' is an atomic transaction, i.e. 

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -90,7 +90,10 @@ All the options that can be use in the Kusto source are under the object KustoSo
 * **KUSTO_CLIENT_REQUEST_PROPERTIES_JSON**:
   'clientRequestPropertiesJson' - A json representation for [ClientRequestProperties](https://github.com/Azure/azure-kusto-java/blob/master/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java)
    used in the call for reading from Kusto (used in the single query for 'single' mode or for the export command for 'distributed' mode). Use toString to create the json.
-    
+
+* **KUSTO_OPERATION_ID**:
+    A unique identifier UUID for this reading operation. Setting this will override the ClientRequestId on the
+    ClientRequestProperties object if set.
     
 #### Transient Storage Parameters
 When reading data from Kusto in 'distributed' mode, the data is exported from Kusto into a blob storage every time the corresponding RDD is materialized. 

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -92,7 +92,7 @@ All the options that can be use in the Kusto source are under the object KustoSo
    used in the call for reading from Kusto (used in the single query for 'single' mode or for the export command for 'distributed' mode). Use toString to create the json.
 
 * **KUSTO_OPERATION_ID**:
-    A unique identifier UUID for this reading operation. Setting this will override the ClientRequestId on the
+    'operationId' - A unique identifier UUID for this reading operation. Setting this will override the ClientRequestId on the
     ClientRequestProperties object if set.
     
 #### Transient Storage Parameters

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <scala.version>2.11</scala.version>
         <specs2.version>3.6.5</specs2.version>
         <spark.version>[2.4.0,2.5.0)</spark.version>
-        <kusto-sdk.version>2.2.0</kusto-sdk.version>
+        <kusto-sdk.version>2.3.1</kusto-sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>


### PR DESCRIPTION
operationId 
---

Setting operationId to easy track the operation on the spark logs and for reading - set as clientRequestId, for write: set as part of the staging table name  

**Features:**
- New option - 'operationId'  
