### PR TITLE
Fix cleanup tables + table deletion exception should throw

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -11,11 +11,11 @@ private[kusto] object CslCommandsGenerator {
   }
 
   def generateFindOldTempTablesCommand(database: String): String = {
-    s""".show journal | where Event == 'CREATE-TABLE' | where Database == '$database' | where EntityName startswith '$TempIngestionTablePrefix' | where EventTimestamp < ago(1h) and EventTimestamp > ago(3d) | project EntityName """
+    s""".show journal | where Event == 'CREATE-TABLE' | where Database == '$database' | where EntityName startswith '$TempIngestionTablePrefix' | where EventTimestamp < ago(3d) | project EntityName """
   }
 
   def generateFindCurrentTempTablesCommand(prefix: String): String = {
-    s""".show tables | where TableName startswith '$prefix' | project TableName """
+    s""".show tables with (IncludeHiddenTables=true) | where TableName startswith '$prefix' | project TableName """
   }
 
   def generateDropTablesCommand(tables: String): String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -167,6 +167,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
   private[kusto] def cleanupIngestionByproducts(database: String, kustoAdminClient: Client, tmpTableName: String): Unit = {
     try {
       kustoAdminClient.execute(database, generateTableDropCommand(tmpTableName))
+      KDSU.logInfo(myName, s"Temporary table '$tmpTableName' deleted successfully")
     }
     catch {
       case exception: Exception =>


### PR DESCRIPTION
#### Pull Request Description

If the connector couldn't delete the temporary table it used to suppress it.
When the connector starts it has an initial check for old tables - this check did not include hidden tables (which we moved to using at some point) and also it could delete new tables.
---

#### Future Release Comment
**Breaking Changes:**
- Throw on temporary table deletion failure

**Fixes:**
- Initial cleanup of old temporary tables (older than three days)
