### PR TITLE
Handle ingestIfNotExists tags

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -61,7 +61,7 @@ object KustoWriter {
     val shouldIngest = kustoClient.shouldIngestData(tableCoordinates.database, table, writeOptions.IngestionProperties)
 
     if (!shouldIngest) {
-      KDSU.logInfo(myName, s"Ingestion skipped: IngestByTags were given and destination table ingest-by tags intersect with them.")
+      KDSU.logInfo(myName, s"Ingestion skipped: Provided ingest-by tags are present in the destination table '$table'")
     } else {
       kustoClient.cleanupTempTables(tableCoordinates)
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -1,9 +1,21 @@
 package com.microsoft.kusto.spark.utils
 
+import java.util
+
 import com.microsoft.kusto.spark.datasink.KustoWriter.TempIngestionTablePrefix
 import com.microsoft.kusto.spark.datasource.KustoStorageParameters
+import scala.collection.JavaConverters._
 
 private[kusto] object CslCommandsGenerator {
+  def generateFetchTableIngestByTagsCommand(table: String): String = {
+    s""".show table $table  extents;
+       $$command_results
+       | mv-apply split(Tags, "\\r\\n") on (
+         where Tags startswith "ingest-by" | project Tags = substring(Tags,10)
+         )
+       | summarize make_set(Tags)"""
+  }
+
 
   // Not used. Here in case we prefer this approach
   def generateFindOldTemporaryTablesCommand2(database: String): String = {
@@ -51,8 +63,24 @@ private[kusto] object CslCommandsGenerator {
     s".show export containers"
   }
 
-  def generateTableMoveExtentsCommand(sourceTableName: String, destinationTableName: String): String = {
-    s".move extents all from table $sourceTableName to table ${KustoQueryUtils.normalizeTableName(destinationTableName)}"
+  def generateTableMoveExtentsCommand(sourceTableName: String, destinationTableName: String, ingestIfNotExistsTags: util.ArrayList[String]): String = {
+    val quotedTags = ingestIfNotExistsTags.asScala.map((tag: String) => s""""$tag"""").asJava
+    s""".move extents to table $destinationTableName <|
+       .show tables ( $sourceTableName,  $destinationTableName) extents;
+        $$command_results
+       | where TableName ==  '$sourceTableName'
+       | extend extentsSource = todynamic('$quotedTags')
+       |extend extentsDest = toscalar(
+              $$command_results
+               | where TableName == '$destinationTableName'
+               | mv-apply Tags=split(Tags, '\\r\\n') on
+                (
+                 extend Tags = substring(Tags, ${KustoConstants.ingestByPrefix.length})
+                )
+                |summarize make_set(Tags)
+        )
+      | where array_length(set_intersect(extentsSource,extentsDest))==0
+      |  distinct ExtentId"""
   }
 
   def generateTableAlterMergePolicyCommand(table: String, allowMerge: Boolean, allowRebuild: Boolean): String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -4,14 +4,14 @@ import java.util
 import java.util.StringJoiner
 import java.util.concurrent.TimeUnit
 
-import com.microsoft.azure.kusto.data.{Client, ClientFactory, ConnectionStringBuilder}
+import com.microsoft.azure.kusto.data.{Client, ClientFactory, ConnectionStringBuilder, KustoResultSetTable}
 import com.microsoft.azure.kusto.ingest.result.{IngestionStatus, OperationStatus}
 import com.microsoft.azure.kusto.ingest.{IngestClient, IngestClientFactory, IngestionProperties}
 import com.microsoft.azure.storage.StorageException
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.KustoWriter.{TempIngestionTablePrefix, delayPeriodBetweenCalls}
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
-import com.microsoft.kusto.spark.datasink.{PartitionResult, SinkTableCreationMode}
+import com.microsoft.kusto.spark.datasink.{PartitionResult, SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.datasource.KustoStorageParameters
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
 import com.microsoft.kusto.spark.utils.KustoDataSourceUtils.extractSchemaFromResultTable
@@ -19,6 +19,7 @@ import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.CollectionAccumulator
+import org.json.JSONArray
 import shaded.parquet.org.codehaus.jackson.map.ObjectMapper
 
 import scala.collection.JavaConverters._
@@ -27,19 +28,17 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Future}
 
 class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuilder, val ingestKcsb: ConnectionStringBuilder) {
-  val engineClient: Client = ClientFactory.createClient(engineKcsb)
+  lazy val engineClient: Client = ClientFactory.createClient(engineKcsb)
 
   // Reading process does not require ingest client to start working
   lazy val dmClient: Client = ClientFactory.createClient(ingestKcsb)
   lazy val ingestClient: IngestClient = IngestClientFactory.createClient(ingestKcsb)
-
   private val exportProviderEntryCreator = (c: ContainerAndSas) => KDSU.parseSas(c.containerUrl + c.sas)
   private val ingestProviderEntryCreator = (c: ContainerAndSas) => c
   private lazy val  ingestContainersContainerProvider = new ContainerProvider(dmClient, clusterAlias, generateCreateTmpStorageCommand(), ingestProviderEntryCreator)
   private lazy val  exportContainersContainerProvider = new ContainerProvider(dmClient, clusterAlias, generateGetExportContainersCommand(), exportProviderEntryCreator)
 
   private val myName = this.getClass.getSimpleName
-
   def createTmpTableWithSameSchema(tableCoordinates: KustoCoordinates,
                                    tmpTableName: String,
                                    tableCreation: SinkTableCreationMode = SinkTableCreationMode.FailIfNotExist,
@@ -89,6 +88,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
                                                            partitionsResults: CollectionAccumulator[PartitionResult],
                                                            timeout: FiniteDuration,
                                                            requestId: String,
+                                                           ingestIfNotExistsTags: util.ArrayList[String],
                                                            isAsync: Boolean = false): Unit = {
     import coordinates._
 
@@ -141,8 +141,10 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
         if (partitionsResults.value.size > 0) {
           // Move data to real table
           // Protect tmp table from merge/rebuild and move data to the table requested by customer. This operation is atomic.
+          // We are using the ingestIfNotExists Tags here too (on top of the check at the start of the flow) so that if
+          // several flows started together only one of them would ingest
           kustoAdminClient.execute(database, generateTableAlterMergePolicyCommand(tmpTableName, allowMerge = false, allowRebuild = false))
-          kustoAdminClient.execute(database, generateTableMoveExtentsCommand(tmpTableName, table.get))
+          kustoAdminClient.execute(database, generateTableMoveExtentsCommand(tmpTableName, table.get ,ingestIfNotExistsTags))
           KDSU.logInfo(myName, s"write to Kusto table '${table.get}' finished successfully requestId: $requestId $batchIdIfExists")
         } else {
           KDSU.logWarn(myName, s"write to Kusto table '${table.get}' finished with no data written requestId: $requestId $batchIdIfExists")
@@ -221,6 +223,28 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
         }
       }
     }
+  }
+
+  def fetchTableExtentsTags(database: String, table: String): KustoResultSetTable = {
+    engineClient.execute(database, CslCommandsGenerator.generateFetchTableIngestByTagsCommand(table)).getPrimaryResults
+  }
+
+  def shouldIngestData(database: String, table: String, ingestionProperties: Option[String]): Boolean = {
+    var shouldIngest = true
+    if (ingestionProperties.isDefined){
+      val ingestIfNotExistsTags = SparkIngestionProperties.fromString(ingestionProperties.get).ingestIfNotExists
+      if (ingestIfNotExistsTags != null && !ingestIfNotExistsTags.isEmpty) {
+        val res = fetchTableExtentsTags(database, table)
+        if(res.next()) {
+          val tagsArray = res.getObject(0).asInstanceOf[JSONArray]
+          val tagsSeq = tagsArray.asScala.toSeq
+          if (tagsSeq.intersect(ingestIfNotExistsTags.asScala).nonEmpty){
+            shouldIngest = false
+          }
+        }
+      }
+    }
+    shouldIngest
   }
 
   private def readIngestionResult(statusRecord: IngestionStatus): String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -16,6 +16,6 @@ object KustoConstants {
   val oneGiga: Int = oneMega * 1024
   // The restriction from kusto is 50000 rows but 5000 can still be really big
   val directQueryUpperBoundRows = 5000
-  // less?
   val timeoutForCountCheck : FiniteDuration = 3 seconds
+  val ingestByPrefix = "ingest-by:"
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoClientTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoClientTests.scala
@@ -1,0 +1,43 @@
+package com.microsoft.kusto.spark
+
+import java.util
+
+import com.microsoft.azure.kusto.data.{ConnectionStringBuilder, KustoOperationResult, KustoResultSetTable}
+import com.microsoft.kusto.spark.datasink.SparkIngestionProperties
+import com.microsoft.kusto.spark.utils.KustoClient
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class KustoClientTests extends FlatSpec  with Matchers{
+  class KustoClientStub (override  val clusterAlias: String, override  val engineKcsb: ConnectionStringBuilder, override val ingestKcsb: ConnectionStringBuilder, var tagsToReturn: util.ArrayList[String]) extends KustoClient(clusterAlias, engineKcsb, ingestKcsb){
+    override def fetchTableExtentsTags(database: String, table: String): KustoResultSetTable = {
+      val response =
+        s"""{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"Tags","DataType":"Object","ColumnType":"dynamic"}],
+           "Rows":[[${if (tagsToReturn.isEmpty) "" else tagsToReturn.asScala.map(t=>"\""+t+"\"").asJava}]]}]}"""
+      new KustoOperationResult(response, "v1").getPrimaryResults
+    }
+  }
+
+  "IngestIfNotExists tags shouldIngest" should "return true if no extents given" in {
+    val emptyTags = new util.ArrayList[String]
+    val stubbedClient = new KustoClientStub("", null, null, null)
+    stubbedClient.tagsToReturn = emptyTags
+    val props = new SparkIngestionProperties
+    val shouldIngestWhenNoTags = stubbedClient.shouldIngestData("database","table", Some(props.toString) )
+
+    val tags = new util.ArrayList[String]
+    tags.add("tag")
+    stubbedClient.tagsToReturn = tags
+    props.ingestIfNotExists = new util.ArrayList[String](){{add("otherTag")}}
+    val shouldIngestWhenNoOverlap = stubbedClient.shouldIngestData("database","table", Some(props.toString) )
+    shouldIngestWhenNoOverlap shouldEqual true
+
+    tags.add("otherTag")
+    val shouldIngestWhenOverlap = stubbedClient.shouldIngestData("database","table", Some(props.toString) )
+    shouldIngestWhenOverlap shouldEqual false
+  }
+
+}


### PR DESCRIPTION
IngestIfNotExists tags can't be part of the regular flow as the data is ingested by multiple partitions into a staging table.
The solution here is dealing with the tags before and after the ingestion: First check the table before the ingestion into the staging table so as to skip it at all if the ingestBy tags itersect with the IngestIfNotExists ones. Second - when merging the tables - we do it in a single command that takes into consideration the current tags at this stage.

**Fixes:**
- Handle ingestIfNotExists tags