### PR TITLE
Add ClientRequstProperties to Write + transient errors check on extents move retry

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -159,7 +159,8 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-azure</artifactId>
-            <version>2.7.0</version>
+            <version>3.2.0</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-lang</artifactId>

--- a/connector/scalastyle_config.xml
+++ b/connector/scalastyle_config.xml
@@ -104,7 +104,7 @@
  </check>
  <check class="org.scalastyle.scalariform.MethodLengthChecker" level="warning" enabled="true">
   <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
+   <parameter name="maxLength"><![CDATA[70]]></parameter>
   </parameters>
  </check>
  <check class="org.scalastyle.scalariform.MethodNamesChecker" level="warning" enabled="true">

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -49,7 +49,12 @@ trait KustoOptions {
   // polling on the ingestion results. Default 2 days
   val KUSTO_TIMEOUT_LIMIT: String = newOption("timeoutLimit")
 
-  // An id of the source used for tracing of the write operation
+
+  // A json representation of the ClientRequestProperties object used for reading from Kusto
+  var KUSTO_CLIENT_REQUEST_PROPERTIES_JSON: String = newOption("clientRequestPropertiesJson")
+
+  // An id of the source used for tracing of the write operation. Will override the clientRequestPropertiesJson
+  // request id if provided
   val KUSTO_REQUEST_ID: String = newOption("requestId")
 }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSink.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSink.scala
@@ -2,6 +2,7 @@ package com.microsoft.kusto.spark.datasink
 
 import java.io._
 
+import com.microsoft.azure.kusto.data.ClientRequestProperties
 import com.microsoft.kusto.spark.authentication.KustoAuthentication
 import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
 import com.microsoft.kusto.spark.common.KustoCoordinates
@@ -11,7 +12,8 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 class KustoSink(sqlContext: SQLContext,
                 tableCoordinates: KustoCoordinates,
                 authentication: KustoAuthentication,
-                writeOptions: WriteOptions) extends Sink with Serializable {
+                writeOptions: WriteOptions,
+                clientRequestProperties: ClientRequestProperties) extends Sink with Serializable {
 
   private val myName = this.getClass.getSimpleName
   val MessageSource = "KustoSink"
@@ -23,7 +25,7 @@ class KustoSink(sqlContext: SQLContext,
     if (batchId <= latestBatchId) {
       KDSU.logInfo(myName, s"Skipping already committed batch $batchId")
     } else {
-      KustoWriter.write(Option(batchId), data, tableCoordinates, authentication, writeOptions)
+      KustoWriter.write(Option(batchId), data, tableCoordinates, authentication, writeOptions, clientRequestProperties)
       latestBatchId = batchId
     }
   }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkProvider.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkProvider.scala
@@ -23,7 +23,8 @@ class KustoSinkProvider extends StreamSinkProvider with DataSourceRegister {
         val paramsFromKeyVault = KeyVaultUtils.getAadAppParametersFromKeyVault(sinkParameters.sourceParametersResults.keyVaultAuth.get)
         KustoDataSourceUtils.mergeKeyVaultAndOptionsAuthentication(paramsFromKeyVault, Some(sinkParameters.sourceParametersResults.authenticationParameters))
       } else sinkParameters.sourceParametersResults.authenticationParameters,
-      sinkParameters.writeOptions
+      sinkParameters.writeOptions,
+      sinkParameters.sourceParametersResults.clientRequestProperties
     )
   }
 }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -28,7 +28,6 @@ import org.json.JSONObject
 import scala.collection.Iterator
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Future, TimeoutException}
 
 object KustoWriter {
@@ -42,7 +41,8 @@ object KustoWriter {
                            data: DataFrame,
                            tableCoordinates: KustoCoordinates,
                            authentication: KustoAuthentication,
-                           writeOptions: WriteOptions): Unit = {
+                           writeOptions: WriteOptions,
+                           crp: ClientRequestProperties): Unit = {
     val batchIdIfExists = batchId.map(b => s",batch: ${b.toString}").getOrElse("")
     val kustoClient = KustoClientCache.getClient(tableCoordinates.clusterAlias, tableCoordinates.clusterUrl, authentication)
 
@@ -51,16 +51,14 @@ object KustoWriter {
         tableCoordinates.clusterUrl, tableCoordinates.database)
     }
 
-    val crp = new ClientRequestProperties
-    crp.setClientRequestId(writeOptions.requestId)
-
     val table = tableCoordinates.table.get
     val tmpTableName: String = KustoQueryUtils.simplifyName(TempIngestionTablePrefix +
       data.sparkSession.sparkContext.appName +
       "_" + table + batchId.map(b => s"_${b.toString}").getOrElse("") + "_" + writeOptions.requestId)
 
     val stagingTableIngestionProperties = getSparkIngestionProperties(writeOptions)
-    val schemaShowCommandResult = kustoClient.engineClient.execute(tableCoordinates.database, generateTableGetSchemaAsRowsCommand(tableCoordinates.table.get), crp).getPrimaryResults
+    val schemaShowCommandResult = kustoClient.engineClient.execute(tableCoordinates.database,
+      generateTableGetSchemaAsRowsCommand(tableCoordinates.table.get), crp).getPrimaryResults
     val targetSchema = schemaShowCommandResult.getData.asScala.map(c => c.get(0).asInstanceOf[JSONObject]).toArray
     KustoIngestionUtils.adjustSchema(writeOptions.adjustSchema, data.schema, targetSchema, stagingTableIngestionProperties)
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -161,9 +161,10 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    KustoWriter.write(Some(0), data, kustoCoordinates, authentication, writeOptions =
+    KustoWriter.write(None, data, kustoCoordinates, authentication, writeOptions =
       WriteOptions.apply(timeout = new FiniteDuration(KustoConstants.DefaultWaitingIntervalLongRunning.toInt,
         TimeUnit.SECONDS), autoCleanupTime = new FiniteDuration(KustoConstants.DefaultCleaningInterval.toInt,
-        TimeUnit.SECONDS)))
+        TimeUnit.SECONDS)),
+      clientRequestProperties.get)
   }
 }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -9,9 +9,6 @@ object KustoSourceOptions extends KustoOptions {
   //TODO - impl retries?
   val KUSTO_QUERY_RETRY_TIMES: String = newOption("kustoQueryRetryTimes")
 
-  // A json representation of the ClientRequestProperties object used for reading from Kusto
-  var KUSTO_CLIENT_REQUEST_PROPERTIES_JSON: String = newOption("clientRequestPropertiesJson")
-
   // Blob Storage access parameters for source connector when working in 'distributed' mode (read)
   // These parameters will not be needed once we move to automatic blob provisioning
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -125,7 +125,7 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
   }
 
   def findErrorInResult(res: KustoResultSetTable): (Boolean, Object) = {
-    var error:Object = null
+    var error: Object = null
     var failed = false
     if (KDSU.getLoggingLevel == Level.DEBUG) {
       var i = 0
@@ -154,8 +154,8 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
     (failed, error)
   }
 
-  def moveExtentsWithRetries(batchSize: Int, totalAmount: Int, database: String, tmpTableName: String, targetTable: String, crp: ClientRequestProperties,
-                             writeOptions: WriteOptions): Unit = {
+  def moveExtentsWithRetries(batchSize: Int, totalAmount: Int, database: String, tmpTableName: String, targetTable: String,
+                             crp: ClientRequestProperties, writeOptions: WriteOptions): Unit = {
     var extentsProcessed = 0
     var retry = 0
     var curBatchSize = batchSize
@@ -179,7 +179,6 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
           }
         }
       } catch {
-        case e:RetriesExhaustedException => throw e
         case ex:KustoDataException =>
           if (ex.getCause.isInstanceOf[SocketTimeoutException] || !ex.isPermanent) {
             error = ExceptionUtils.getStackTrace(ex)
@@ -192,7 +191,9 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
 
       // When some node fails the move - it will put "failed" as the target extent id
       if (res.isDefined && error == null) {
-        error = findErrorInResult(res.get)
+        val errorInResult = findErrorInResult(res.get)
+        failed = errorInResult._1
+        error = errorInResult._2
       }
 
       if (failed) {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClient.scala
@@ -1,13 +1,15 @@
 package com.microsoft.kusto.spark.utils
 
+import java.net.SocketTimeoutException
 import java.time.Instant
 import java.util.StringJoiner
 import java.util.concurrent.TimeUnit
+
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
-import com.microsoft.azure.kusto.data.exceptions.DataServiceException
+import com.microsoft.azure.kusto.data.exceptions.KustoDataException
 import com.microsoft.azure.kusto.data.{Client, ClientFactory, ClientRequestProperties, KustoResultSetTable}
 import com.microsoft.azure.kusto.ingest.result.{IngestionStatus, OperationStatus}
-import com.microsoft.azure.kusto.ingest.{IngestClient, IngestClientFactory, IngestionProperties}
+import com.microsoft.azure.kusto.ingest.{IngestClient, IngestClientFactory}
 import com.microsoft.azure.storage.StorageException
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.KustoWriter.DelayPeriodBetweenCalls
@@ -93,8 +95,12 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
     exportContainersContainerProvider.getAllContainers
   }
 
-  def handleRetryFail(curBatchSize: Int, retry: Int, currentSleepTime: Int): (Int, Int) = {
-    KDSU.logWarn(myName, s"Failed moving extents, retry number '$retry'. Sleeping for: $currentSleepTime")
+  def handleRetryFail(curBatchSize: Int, retry: Int, currentSleepTime: Int, targetTable: String, error: Object): (Int, Int)
+  = {
+    KDSU.logWarn(myName,
+      s"""moving extents to '$targetTable' failed,
+        retry number: $retry ${if (error == null) "" else s", error: ${error.asInstanceOf[String]}"}.
+        Sleeping for: $currentSleepTime""")
     Thread.sleep(currentSleepTime)
     val increasedSleepTime = Math.min(MaxSleepOnMoveExtentsMillis, currentSleepTime * 2)
     if (retry % 2 == 1) {
@@ -118,56 +124,78 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
     extentsLeftRes.getInt(0) != 0
   }
 
+  def findErrorInResult(res: KustoResultSetTable): (Boolean, Object) = {
+    var error:Object = null
+    var failed = false
+    if (KDSU.getLoggingLevel == Level.DEBUG) {
+      var i = 0
+      while (res.next() && !failed) {
+        val targetExtent = res.getString(1)
+        error = res.getObject(2)
+        if (targetExtent == "Failed" || StringUtils.isNotBlank(error.asInstanceOf[String])) {
+          failed = true
+          if (i > 0) {
+            KDSU.logFatal(myName, "Failed extent was not reported on all extents!." +
+              "Please open issue if you see this trace. At: https://github.com/Azure/azure-kusto-spark/issues")
+          }
+        }
+        i += 1
+      }
+    } else {
+      if (res.next()) {
+        val targetExtent = res.getString(1)
+        error = res.getObject(2)
+        if (targetExtent == "Failed" || StringUtils.isNotBlank(error.asInstanceOf[String])) {
+          failed = true
+        }
+        // TODO handle specific errors
+      }
+    }
+    (failed, error)
+  }
+
   def moveExtentsWithRetries(batchSize: Int, totalAmount: Int, database: String, tmpTableName: String, targetTable: String, crp: ClientRequestProperties,
-                             cluster: String, writeOptions: WriteOptions): Unit = {
+                             writeOptions: WriteOptions): Unit = {
     var extentsProcessed = 0
     var retry = 0
     var curBatchSize = batchSize
     var delayPeriodBetweenCalls = DelayPeriodBetweenCalls
     var consecutiveSuccesses = 0
     while (extentsProcessed < totalAmount) {
+      var error: Object = null
+      var res: Option[KustoResultSetTable] = None
+      var failed = false
+
+      // Execute move batch and keep any transient error for handling
       try {
-        var failed = false
+        res = Some(engineClient.execute(database, generateTableMoveExtentsCommand(tmpTableName, targetTable,
+          curBatchSize), crp).getPrimaryResults)
 
-        val res = engineClient.execute(database, generateTableMoveExtentsCommand(tmpTableName, targetTable,
-          curBatchSize), crp).getPrimaryResults
-
-        if (res.count() == 0) {
+        if (res.get.count() == 0) {
           failed = handleNoResults(totalAmount, extentsProcessed, database, tmpTableName, crp)
-          if (!failed){
+          if (!failed) {
             // No more extents to move - succeeded
             extentsProcessed = totalAmount
           }
         }
-
-        // When some node fails move it will put "failed" as target extent id
-        var error: Object = null
-        if (KDSU.getLoggingLevel == Level.DEBUG) {
-          var i = 0
-          while (res.next() && !failed) {
-            val targetExtent = res.getString(1)
-            error = res.getObject(2)
-            if (targetExtent == "Failed" || StringUtils.isNotBlank(error.asInstanceOf[String])) {
-              failed = true
-              if (i > 0) {
-                KDSU.logFatal(myName, "Failed extent was not reported on all extents!." +
-                  "Please open issue if you see this trace. At: https://github.com/Azure/azure-kusto-spark/issues")
-              }
-            }
-            i += 1
+      } catch {
+        case e:RetriesExhaustedException => throw e
+        case ex:KustoDataException =>
+          if (ex.getCause.isInstanceOf[SocketTimeoutException] || !ex.isPermanent) {
+            error = ExceptionUtils.getStackTrace(ex)
+            failed = true
+            retry += 1
+          } else {
+            throw ex
           }
-        } else {
-          if (res.next()) {
-            val targetExtent = res.getString(1)
-            error = res.getObject(2)
-            if (targetExtent == "Failed" || StringUtils.isNotBlank(error.asInstanceOf[String])) {
-              failed = true
-            }
-            // TODO handle specific errors
-          }
-        }
+      }
 
-        if (failed) {
+      // When some node fails the move - it will put "failed" as the target extent id
+      if (res.isDefined && error == null) {
+        error = findErrorInResult(res.get)
+      }
+
+      if (failed) {
           consecutiveSuccesses = 0
           retry += 1
           if (retry > writeOptions.maxRetriesOnMoveExtents) {
@@ -175,10 +203,8 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
           }
 
           // Lower batch size, increase delay
-          val params = handleRetryFail(curBatchSize, retry, delayPeriodBetweenCalls)
-          KDSU.logWarn(myName,
-            s"moving extents to '$targetTable' failed, " +
-              s"retry number: $retry ${if (error == null) "" else s", error: ${error.asInstanceOf[String]}"}")
+          val params = handleRetryFail(curBatchSize, retry, delayPeriodBetweenCalls, targetTable, error)
+
           curBatchSize = params._1
           delayPeriodBetweenCalls = params._2
         } else {
@@ -187,28 +213,15 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
             curBatchSize = Math.min(curBatchSize * 2, batchSize)
           }
 
-          extentsProcessed += res.count()
-          KDSU.logDebug(myName, s"Moving extents succeeded at retry: $retry," +
+          extentsProcessed += res.get.count()
+          KDSU.logDebug(myName, s"Moving extents batch succeeded at retry: $retry," +
             s" maxBatch: $curBatchSize, consecutive successfull batches: $consecutiveSuccesses, successes this " +
-            s"batch: ${res.count()}," +
+            s"batch: ${res.get.count()}," +
             s" extentsProcessed: $extentsProcessed, backoff: $delayPeriodBetweenCalls, total:$totalAmount")
 
           retry = 0
-          // should we reset the curBatchSize to batchSize?
           delayPeriodBetweenCalls = DelayPeriodBetweenCalls
         }
-      } catch {
-        case e:RetriesExhaustedException => throw e
-        case e: DataServiceException => {
-          // Probably a permanent exception - try less then regular back
-          consecutiveSuccesses = 0
-          retry += 1
-          KDSU.reportExceptionAndThrow(myName, e, s"moving extents, retry number: $retry", cluster, database, targetTable,
-            shouldNotThrow = retry < 2)// && !e.isPermanent)
-          val params = handleRetryFail(curBatchSize, retry, delayPeriodBetweenCalls)
-          curBatchSize = params._1
-          delayPeriodBetweenCalls = params._2
-        }}
     }
   }
 
@@ -222,10 +235,10 @@ class KustoClient(val clusterAlias: String, val engineKcsb: ConnectionStringBuil
       nodeCountQuery.next()
       val nodeCount = nodeCountQuery.getInt(0)
       moveExtentsWithRetries(nodeCount * writeOptions.minimalExtentsCountForSplitMerge, extentsCount, database,
-        tmpTableName, targetTable, crp, cluster, writeOptions)
+        tmpTableName, targetTable, crp, writeOptions)
     } else {
       moveExtentsWithRetries(extentsCount, extentsCount, database,
-        tmpTableName, targetTable, crp, cluster, writeOptions)
+        tmpTableName, targetTable, crp, writeOptions)
     }
   }
 


### PR DESCRIPTION
ClientRequstProperties option can be used on write operations (used for schema check operation, table creation and move extents)
Transient errors check on extents move retry + specific handling of timeout until changed from SDK side