### PR TITLE
Make it case sensitive when get partition columns

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -134,7 +134,7 @@ private[kusto] case class KustoRelation(kustoCoordinates: KustoCoordinates,
 
   private def getPartitioningColumn: String = {
     if (partitioningColumn.isDefined) {
-      val requestedColumn = partitioningColumn.get.toLowerCase(Locale.ROOT)
+      val requestedColumn = partitioningColumn.get
       if (!schema.contains(requestedColumn)) {
         throw new InvalidParameterException(
           s"Cannot partition by column '$requestedColumn' since it is not part of the query schema: ${KDSU.NewLine}${schema.mkString(", ")}")


### PR DESCRIPTION
#### Pull Request Description
Make is case sensitive when get partition column, since kusto take schema as case sensitive if I understand this right.
If I specify a partition column while the schema itself has upper letters, the query will fail.

---

#### Future Release Comment
- None

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
