### PR TITLE
Fix a few bugs that prevent compilation in Scala 2.11.11

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -213,6 +213,10 @@
                     <artifactId>jackson-module-scala_2.12</artifactId>
                     <groupId>com.fasterxml.jackson.module</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>scala-library</artifactId>
+                    <groupId>org.scala-lang</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -228,6 +232,10 @@
                 <exclusion>
                     <artifactId>jsr305</artifactId>
                     <groupId>com.google.code.findbugs</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>scala-library</artifactId>
+                    <groupId>org.scala-lang</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -249,12 +257,24 @@
             <artifactId>scalatest_${scala.version.major}</artifactId>
             <version>3.0.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>scala-library</artifactId>
+                    <groupId>org.scala-lang</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_${scala.version.major}</artifactId>
             <version>4.1.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>scala-library</artifactId>
+                    <groupId>org.scala-lang</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoBlobStorageUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoBlobStorageUtils.scala
@@ -4,6 +4,9 @@ import com.microsoft.azure.storage.CloudStorageAccount
 import com.microsoft.azure.storage.blob.CloudBlockBlob
 import com.microsoft.kusto.spark.datasource.TransientStorageCredentials
 
+import scala.collection.JavaConverters._
+
+
 object KustoBlobStorageUtils {
   def deleteFromBlob(account: String, directory: String, container: String, secret: String, keyIsSas: Boolean = false): Unit = {
     val storageConnectionString = if (keyIsSas) {
@@ -37,9 +40,9 @@ object KustoBlobStorageUtils {
     val blobContainer = blobClient.getContainerReference(container)
     val blobsWithPrefix = blobContainer.listBlobs(directory)
 
-    blobsWithPrefix.forEach(blob => {
+    for (blob <- blobsWithPrefix.asScala) {
       val cloudBlob = blobContainer.getBlockBlobReference(new CloudBlockBlob(blob.getUri).getName)
       cloudBlob.deleteIfExists()
-    })
+    }
   }
 }

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -81,7 +81,7 @@ that is using it. Please verify the following before using Kusto connector:
     
     - csvMappingNameReference: String - a reference to a name of a csvMapping pre-created for the table  
     
-    - flushImmediately: Boolean - use with caution - flushes the data immidiatly upon ingestion without aggregation.
+    - flushImmediately: Boolean - use with caution - flushes the data immediately upon ingestion without aggregation.
 
  * **KUSTO_TIMEOUT_LIMIT**:
    'timeoutLimit' - After the dataframe is processed a polling operation begins, this integer number corresponding to the period in seconds after which the polling
@@ -117,7 +117,7 @@ that is using it. Please verify the following before using Kusto connector:
 ### Performance Considerations
 
 Write performance depends on multiple factors, such as cluster scale of both Spark and Kusto clusters.
-WIth regards to Kusto target cluster configuration, one of the factors that impacts performance and latency 
+Regarding Kusto target cluster configuration, one of the factors that impacts performance and latency 
 is [Ingestion Batching Policy](https://docs.microsoft.com/en-us/azure/kusto/concepts/batchingpolicy). Default policy 
 works well for typical scenarios, especially when writing large amounts of data as batch. For reduced latency,
 consider altering the policy to a relatively low value (minimal allowed is 10 seconds).

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <azure-storage.version>8.6.5</azure-storage.version>
-        <azure-storage.version>8.6.5</azure-storage.version>
         <keyvault-secrets.version>4.1.5</keyvault-secrets.version>
         <azure-identity.version>1.2.4</azure-identity.version>
         <commons-lang3.version>3.9</commons-lang3.version>


### PR DESCRIPTION
#### Pull Request Description

Fix a few bugs that prevent compilation in Scala 2.11.11

---

#### Future Release Comment
**Fixes:**
- Excluded many duplicate scala-library dependencies that may cause conflicts
- Added method to convert a scala lambda to a Java Consumer so we can both create a Consumer[DeviceCode] and also use closures to update the device code locally (not idea solution, but improving it is for another release).
- Convert Java list to a scala list so we can iterate over it
