### PR TITLE
* Fix decimals to new scales 38,18 the default in Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,32 +32,32 @@ link your application with the artifact below to use the Azure Data Explorer Con
 ```
 groupId = com.microsoft.azure.kusto
 artifactId = kusto-spark_3.0_2.12
-version = 3.0.0
+version = 3.1.3
 ```
 
 **In Maven**:
 
 Look for the following coordinates: 
 ```
-com.microsoft.azure.kusto:kusto-spark_3.0_2.12:3.0.0
+com.microsoft.azure.kusto:kusto-spark_3.0_2.12:3.1.3
 ```
 
 Or clone this repository and build it locally to add it to your local maven repository,.
 The jar can also be found under the [released package](https://github.com/Azure/azure-kusto-spark/releases)
 
  ```xml
-   <dependency>
-     <groupId>com.microsoft.azure.kusto</groupId>
-     <artifactId>spark-kusto-connector</artifactId>
-     <version>3.0.0</version>
-   </dependency>
+    <dependency>
+        <groupId>com.microsoft.azure.kusto</groupId>
+        <artifactId>kusto-spark_3.0_2.12</artifactId>
+        <version>3.1.3</version>
+    </dependency>
 ```
 
 **In SBT**:
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.microsoft.azure.kusto" %% "kusto-spark_3.0" % "3.0.0"
+  "com.microsoft.azure.kusto" %% "kusto-spark_3.0" % "3.1.3"
 )
 ```
 
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
 Libraries -> Install New -> Maven -> copy the following coordinates:
 
 ```
-com.microsoft.azure.kusto:kusto-spark_3.0_2.12:3.0.0
+com.microsoft.azure.kusto:kusto-spark_3.0_2.12:3.1.3
 ```
 
 #### Building Samples Module

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/DataTypeMapping.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/DataTypeMapping.scala
@@ -8,12 +8,17 @@ object DataTypeMapping {
   val KustoTypeToSparkTypeMap: Map[String, DataType] = Map(
     "string" -> StringType,
     "long" -> LongType,
-    "datetime" -> TimestampType,// Kusto datetime is equivalent to TimestampType
+    "datetime" -> TimestampType, // Kusto datetime is equivalent to TimestampType
     "timespan" -> StringType,
     "bool" -> BooleanType,
     "real" -> DoubleType,
-    // Can be partitioned differently between precision and scale, total must be 34 to match .Net SqlDecimal
-    "decimal" -> DataTypes.createDecimalType(20,14),
+
+    /*
+    Kusto uses floating decimal points and spark uses fixed decimal points. The compromise scenario is to use the system
+    default of 38,18 used in the spark framework.https://github.com/apache/spark/blob
+    /1439d9b275e844b5b595126bc97d2b44f6e859ed/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L131
+    */
+    "decimal" -> DecimalType.SYSTEM_DEFAULT,
     "guid" -> StringType,
     "int" -> IntegerType,
     "dynamic" -> StringType
@@ -26,14 +31,14 @@ object DataTypeMapping {
     "timespan" -> StringType,
     "sbyte" -> BooleanType,
     "double" -> DoubleType,
-    "sqldecimal" -> DataTypes.createDecimalType(20,14),
+    "sqldecimal" -> DecimalType.SYSTEM_DEFAULT,
     "guid" -> StringType,
     "int32" -> IntegerType,
     "object" -> StringType
   )
 
   val SparkTypeToKustoTypeMap: Map[DataType, String] = Map(
-    StringType ->  "string",
+    StringType -> "string",
     BooleanType -> "bool",
     DateType -> "datetime",
     TimestampType -> "datetime",
@@ -42,13 +47,13 @@ object DataTypeMapping {
     FloatType -> "real",
     ByteType -> "int",
     IntegerType -> "int",
-    LongType ->  "long",
-    ShortType ->  "int"
+    LongType -> "long",
+    ShortType -> "int"
   )
 
-  def getSparkTypeToKustoTypeMap(fieldType: DataType): String ={
-      if(fieldType.isInstanceOf[DecimalType]) "decimal"
-      else if (fieldType.isInstanceOf[ArrayType] || fieldType.isInstanceOf[StructType] || fieldType.isInstanceOf[MapType]) "dynamic"
-      else DataTypeMapping.SparkTypeToKustoTypeMap.getOrElse(fieldType, "string")
+  def getSparkTypeToKustoTypeMap(fieldType: DataType): String = {
+    if (fieldType.isInstanceOf[DecimalType]) "decimal"
+    else if (fieldType.isInstanceOf[ArrayType] || fieldType.isInstanceOf[StructType] || fieldType.isInstanceOf[MapType]) "dynamic"
+    else DataTypeMapping.SparkTypeToKustoTypeMap.getOrElse(fieldType, "string")
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -71,8 +71,13 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
 
   def newRow(): String = s"row-${rowId.getAndIncrement()}"
   val random = new Random()
-  val maxBigDecimalSupported:BigDecimal = 12345678901234567890.123456789012345678
+  val maxBigDecimalTest:BigDecimal = 12345678901234567890.123456789012345678
   val minBigDecimalTest:BigDecimal = -12345678901234567890.123456789012345678
+  /*
+    This is the test we have to pass eventually when precision exceeds 34
+    val maxBigDecimalTest:BigDecimal = BigDecimal("12345678901234567890.123456789012345678")
+    val minBigDecimalTest:BigDecimal = BigDecimal("-12345678901234567890.123456789012345678")
+   */
   val expectedNumberOfRows: Int = 100
   val rows: immutable.IndexedSeq[(String, Int,BigDecimal)] = (1 to expectedNumberOfRows).map(valueCol => {
     val nameCol = newRow()
@@ -80,7 +85,7 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
       minBigDecimalTest
     }
     else if(valueCol == expectedNumberOfRows){
-      maxBigDecimalSupported
+      maxBigDecimalTest
     }else{
       BigDecimal.decimal(random.nextDouble() * (valueCol * 9999 - valueCol * 100) + valueCol * 100)
     }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -19,6 +19,7 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 
 import java.nio.file.{Files, Paths}
 import scala.collection.immutable
+import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
 class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
@@ -69,10 +70,23 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
   val rowId = new AtomicInteger(1)
 
   def newRow(): String = s"row-${rowId.getAndIncrement()}"
-
+  val random = new Random()
+  val maxBigDecimalSupported:BigDecimal = 12345678901234567890.123456789012345678
+  val minBigDecimalTest:BigDecimal = -12345678901234567890.123456789012345678
   val expectedNumberOfRows: Int = 100
-  val rows: immutable.IndexedSeq[(String, Int)] = (1 to expectedNumberOfRows).map(v => (newRow(), v))
-  val dfOrig: DataFrame = rows.toDF("name", "value")
+  val rows: immutable.IndexedSeq[(String, Int,BigDecimal)] = (1 to expectedNumberOfRows).map(valueCol => {
+    val nameCol = newRow()
+    val decimalCol = if(valueCol==1){
+      minBigDecimalTest
+    }
+    else if(valueCol == expectedNumberOfRows){
+      maxBigDecimalSupported
+    }else{
+      BigDecimal.decimal(random.nextDouble() * (valueCol * 9999 - valueCol * 100) + valueCol * 100)
+    }
+    (nameCol,valueCol,decimalCol)
+  })
+  val dfOrig: DataFrame = rows.toDF("name", "value","dec")
 
   "KustoConnector" should "write to a kusto table and read it back in default mode"  in {
     // Create a new table.
@@ -97,12 +111,9 @@ class KustoSourceE2E extends FlatSpec with BeforeAndAfterAll {
       KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
       KustoSinkOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey
     )
-
     val dfResult = spark.read.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
-
-    val orig = dfOrig.select("name", "value").rdd.map(x => (x.getString(0), x.getInt(1))).collect().sortBy(_._2)
-    val result = dfResult.select("name", "value").rdd.map(x => (x.getString(0), x.getInt(1))).collect().sortBy(_._2)
-
+    val orig = dfOrig.select("name", "value","dec").rdd.map(x => (x.getString(0), x.getInt(1), x.getDecimal(2))).collect().sortBy(_._2)
+    val result = dfResult.select("name", "value","dec").rdd.map(x => (x.getString(0), x.getInt(1),x.getDecimal(2))).collect().sortBy(_._2)
     assert(orig.deep == result.deep)
   }
 

--- a/docs/Spark-Kusto DataTypes mapping.md
+++ b/docs/Spark-Kusto DataTypes mapping.md
@@ -3,49 +3,51 @@
 When writing to or reading from a Kusto table, the connector converts types from the original DataFrame type to Kusto type
 , and vice versa. Below is the mappings of these conversions.
 
-#####Spark DataTypes mapping to Kusto type
+##### Spark DataTypes mapping to Kusto type
 
-|Spark data type | Kusto data type
-|---|---
-|StringType |string
-|IntegerType |int
-|LongType |long
-|BooleanType |bool
-|ShortType |int
-|DoubleType |real
-|ByteType |int
-|FloatType |real
-|DecimalType |decimal
-|TimestampType |datetime
-|DateType |datetime
-|StructType |dynamic
-|MapType |dynamic
-|ArrayType |dynamic
+| Spark data type | Kusto data type |
+|-----------------|-----------------|
+| StringType      | string          |
+| IntegerType     | int             |
+| LongType        | long            |
+| BooleanType     | bool            |
+| ShortType       | int             |
+| DoubleType      | real            |
+| ByteType        | int             |
+| FloatType       | real            |
+| DecimalType     | decimal         |
+| TimestampType   | datetime        |
+| DateType        | datetime        |
+| StructType      | dynamic         |
+| MapType         | dynamic         |
+| ArrayType       | dynamic         |
 
-#####Kusto DataTypes mapping to Spark DataTypes
+##### Kusto DataTypes mapping to Spark DataTypes
 
-|Kusto data type |Spark data type  
-|---|---
-|string |String 
-|int |IntegerType
-|long |LongType 
-|bool |BooleanType 
-|int |ShortType 
-|real |DoubleType
-|int |Byte
-|real |FloatType 
-|decimal |DecimalType 
-|datetime |TimestampType
-|timespan |StringType
-|guid |String
-|dynamic |StringType
+| Kusto data type | Spark data type |
+|-----------------|-----------------|
+| string          | String          |
+| int             | IntegerType     |
+| long            | LongType        |
+| bool            | BooleanType     |
+| int             | ShortType       |
+| real            | DoubleType      |
+| int             | Byte            |
+| real            | FloatType       |
+| decimal         | DecimalType     |
+| datetime        | TimestampType   |
+| timespan        | StringType      |
+| guid            | String          |
+| dynamic         | StringType      |
 
-##Notes
+##### Notes
 
 
 Kusto **datetime** data type is always read in '%Y-%m-%d %H:%M:%s' format , while **timespan** format is '%H:%M:%s'. On the other
 hand spark **DateType** is of format '%Y-%m-%d' and **TimestampType** is of format '%Y-%m-%d %H:%M:%s'. This is why Kusto 'timespan' 
 type is translated into a string by the connector and **we recommend using only datetime and TimestampType**. 
 
-Kusto **decimal** type corresponds to .Net 'SqlDecimal' type, with a total size of 34 bits for precision and scale params.
+Kusto **decimal** type 
+- Kusto as a source : The precision and scale supported with Kusto as a source is (38,18) respectively.
+- Kusto as a sink : The precision and scale supported with Kusto as a source is (34,14) respectively.
     

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>3.1.2</revision>
+        <revision>3.1.3</revision>
 
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>


### PR DESCRIPTION
#### Pull Request Description
Kusto decimals are effectively floating point while Scala/Java are fixed point. Large decimals in Kusto are truncated or are marked as null in Spark  because we use 20,14 as Precision and scale.

The PR addresses this by using the Spark default scale (38,18) .  This is same Precision and Scale that in Parquet exports in ADX as well

**Fixes:**
- Change Decimal types to use 38,18 as the precision and scale (In line with the default in spark framework)
