### PR TITLE
Bugfix/fix retry semantics

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -25,8 +25,8 @@ object KustoConstants {
   val DefaultBatchingLimit: Int = 300
   val DefaultExtentsCountForSplitMergePerNode: Int = 400
   val DefaultMaxRetriesOnMoveExtents: Int = 10
-  val DefaultExecutionQueueing: Int = TimeUnit.SECONDS.toMillis(15).toInt
-  val DefaultTimeoutQueueing: Int = TimeUnit.SECONDS.toMillis(5).toInt
+  val DefaultExecutionQueueing: Int = TimeUnit.SECONDS.toMillis(60).toInt
+  val DefaultTimeoutQueueing: Int = TimeUnit.SECONDS.toMillis(40).toInt
   val MaxIngestRetryAttempts = 2
   val MaxCommandsRetryAttempts = 4
   val DefaultMaximumIngestionTime: FiniteDuration = FiniteDuration.apply(


### PR DESCRIPTION
Fix bug on second retry (used same blob uuid)
Increase timeout to storage 
Move extents retry logic is changed to overlook permanent errors, increased retries after first batch success (10->1000).