### PR TITLE
Expose Export options for distributed mode

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -92,9 +92,6 @@ private[kusto] object KustoDebugOptions {
   // This feature is experimental, to measure performance impact w/wo compression
   // Default: 'true'
   val KUSTO_DBG_BLOB_COMPRESS_ON_EXPORT: String = newOption("dbgBlobCompressOnExport")
-  // The size limit in MB (uncompressed) after which the export to blob command will create another file (split)
-  // Setting negative or zero value results in applying export command default
-  val KUSTO_DBG_BLOB_FILE_SIZE_LIMIT_MB: String = newOption("dbgBlobFileSizeLimitMb")
 
   // Partitioning parameters, CURRENTLY NOT USED
   // CURRENTLY NOT USED

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -21,7 +21,7 @@ class DefaultSource extends CreatableRelationProvider
   var keyVaultAuthentication: Option[KeyVaultAuthentication] = None
   var clientRequestProperties: Option[ClientRequestProperties] = None
   var requestId: Option[String] = None
-  val myName: String = this.getClass.getSimpleName
+  private val className: String = this.getClass.getSimpleName
 
   def initCommonParams(sourceParams: SourceParameters): Unit ={
     keyVaultAuthentication = sourceParams.keyVaultAuth
@@ -53,7 +53,8 @@ class DefaultSource extends CreatableRelationProvider
         Some(sinkParameters.writeOptions.writeResultLimit.toInt)
       }
       catch {
-        case _: Exception => throw new InvalidParameterException(s"KustoOptions.KUSTO_WRITE_RESULT_LIMIT is set to '${sinkParameters.writeOptions.writeResultLimit}'. Must be either 'none' or an integer value")
+        case _: Exception => throw new InvalidParameterException(s"KustoOptions.KUSTO_WRITE_RESULT_LIMIT is set " +
+          s"to '${sinkParameters.writeOptions.writeResultLimit}'. Must be either 'none' or an integer value")
       }
     }
 
@@ -109,9 +110,11 @@ class DefaultSource extends CreatableRelationProvider
       }
     }
 
-    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.DefaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)
+    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT,
+      KCONST.DefaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)
 
-    KDSU.logInfo(myName, s"Finished serializing parameters for reading: {requestId: $requestId, timeout: $timeout, readMode: ${readOptions.readMode.getOrElse("Default")}, clientRequestProperties: $clientRequestProperties")
+    KDSU.logInfo(className, s"Finished serializing parameters for reading: {requestId: $requestId, " +
+      s"timeout: $timeout, readMode: ${readOptions.readMode.getOrElse("Default")}, clientRequestProperties: $clientRequestProperties")
     KustoRelation(
       kustoCoordinates,
       kustoAuthentication.get,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/DefaultSource.scala
@@ -21,7 +21,7 @@ class DefaultSource extends CreatableRelationProvider
   var keyVaultAuthentication: Option[KeyVaultAuthentication] = None
   var clientRequestProperties: Option[ClientRequestProperties] = None
   var requestId: Option[String] = None
-  private val className: String = this.getClass.getSimpleName
+  val myName: String = this.getClass.getSimpleName
 
   def initCommonParams(sourceParams: SourceParameters): Unit ={
     keyVaultAuthentication = sourceParams.keyVaultAuth
@@ -53,8 +53,7 @@ class DefaultSource extends CreatableRelationProvider
         Some(sinkParameters.writeOptions.writeResultLimit.toInt)
       }
       catch {
-        case _: Exception => throw new InvalidParameterException(s"KustoOptions.KUSTO_WRITE_RESULT_LIMIT is set " +
-          s"to '${sinkParameters.writeOptions.writeResultLimit}'. Must be either 'none' or an integer value")
+        case _: Exception => throw new InvalidParameterException(s"KustoOptions.KUSTO_WRITE_RESULT_LIMIT is set to '${sinkParameters.writeOptions.writeResultLimit}'. Must be either 'none' or an integer value")
       }
     }
 
@@ -110,11 +109,9 @@ class DefaultSource extends CreatableRelationProvider
       }
     }
 
-    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT,
-      KCONST.DefaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)
+    val timeout = new FiniteDuration(parameters.getOrElse(KustoSourceOptions.KUSTO_TIMEOUT_LIMIT, KCONST.DefaultWaitingIntervalLongRunning).toLong, TimeUnit.SECONDS)
 
-    KDSU.logInfo(className, s"Finished serializing parameters for reading: {requestId: $requestId, " +
-      s"timeout: $timeout, readMode: ${readOptions.readMode.getOrElse("Default")}, clientRequestProperties: $clientRequestProperties")
+    KDSU.logInfo(myName, s"Finished serializing parameters for reading: {requestId: $requestId, timeout: $timeout, readMode: ${readOptions.readMode.getOrElse("Default")}, clientRequestProperties: $clientRequestProperties")
     KustoRelation(
       kustoCoordinates,
       kustoAuthentication.get,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -146,7 +146,8 @@ private[kusto] object KustoReader {
 
     val directoryExists = (params: TransientStorageCredentials) => {
       val container = if (params.sasDefined) {
-        new CloudBlobContainer(new URI(s"https://${params.storageAccountName}.blob.${storage.endpointSuffix}/${params.blobContainer}${params.sasKey}"))
+        val sas = if (params.sasKey(0) == '?') params.sasKey else s"?${params.sasKey}"
+        new CloudBlobContainer(new URI(s"https://${params.storageAccountName}.blob.${storage.endpointSuffix}/${params.blobContainer}$sas"))
       } else {
         new CloudBlobContainer(new URI(s"https://${params.storageAccountName}.blob.${storage.endpointSuffix}/${params.blobContainer}"),
           new StorageCredentialsAccountAndKey(params.storageAccountName, params.storageAccountKey))

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -36,7 +36,6 @@ private[kusto] case class KustoReadRequest(sparkSession: SparkSession,
 
 private[kusto] case class KustoReadOptions(readMode: Option[ReadMode] = None,
                                            shouldCompressOnExport: Boolean = true,
-                                           exportSplitLimitMb: Long = 1024,
                                            partitionOptions: PartitionOptions,
                                            distributedReadModeTransientCacheEnabled: Boolean = false,
                                            queryFilterPushDown: Option[Boolean],
@@ -226,16 +225,12 @@ private[kusto] class KustoReader(client: ExtendedKustoClient) {
                                            directory: String,
                                            options: KustoReadOptions,
                                            filtering: KustoFiltering): Unit = {
-
-    val limit = if (options.exportSplitLimitMb <= 0) None else Some(options.exportSplitLimitMb)
-
     val exportCommand = CslCommandsGenerator.generateExportDataCommand(
       KustoFilter.pruneAndFilter(request.schema, request.query, filtering),
       directory,
       partition.idx,
       storage,
       partition.predicate,
-      limit,
       isCompressed = options.shouldCompressOnExport
     )
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -30,6 +30,10 @@ object KustoSourceOptions extends KustoOptions {
   // Defaults to 'true' if KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE=false
   // Defaults to 'false' if KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE=true
   val KUSTO_QUERY_FILTER_PUSH_DOWN: String = newOption("queryFilterPushDown")
+  // When a large dataset has to be exported with Kusto as a source (or) when forcing a distributed mode read (or) when
+  // query limits are hit the connector uses the export option to export data (.export data).With newer options being
+  // rolled-out for export, this additional parameter can be used as options for the export
+  val KUSTO_EXPORT_OPTIONS_JSON: String = newOption("kustoExportOptionsJson")
 }
 
 object ReadMode extends Enumeration {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
@@ -8,8 +8,7 @@ import org.codehaus.jackson.map.ObjectMapper
 
 import java.security.InvalidParameterException
 import scala.util.matching.Regex
-
-class TransientStorageParameters(val storageCredentials: Array[TransientStorageCredentials],
+class TransientStorageParameters(val storageCredentials: scala.Array[TransientStorageCredentials],
                                  var endpointSuffix: String = KustoDataSourceUtils.DefaultDomainPostfix){
 
   // C'tor for serialization

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -142,9 +142,9 @@ private[kusto] object CslCommandsGenerator {
     val compress = if (isCompressed) "compressed " else ""
     val sizeLimitIfDefined = if (sizeLimit.isDefined) s"sizeLimit=${sizeLimit.get * 1024 * 1024}, " else ""
     val additionalOptionsString = additionalExportOptions.map {
-      case (k,v) => s"$k=$v"
-    }
-    //TODO compressionType can be configured too
+      case (k,v) => s"""$k="$v""""
+    }.mkString(",")
+    // TODO compressionType can be configured too and passed as an option
     var command =
       s""".export $async${compress}to parquet ("${storageParameters.storageCredentials.map(getFullUrlFromParams).reduce((s, s1) => s + ",\"" + s1)})""" +
         s""" with (${sizeLimitIfDefined}namePrefix="${directory}part$partitionId", compressionType=snappy,$additionalOptionsString) <| $query"""

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -60,8 +60,6 @@ object KustoDataSourceUtils {
     val numPartitions = setNumPartitions(sqlContext, requestedPartitions, partitioningMode)
     val shouldCompressOnExport = parameters.getOrElse(KustoDebugOptions.KUSTO_DBG_BLOB_COMPRESS_ON_EXPORT, "true").trim.toBoolean
     // Set default export split limit as 1GB, maximal allowed
-    val exportSplitLimitMb = parameters.getOrElse(KustoDebugOptions.KUSTO_DBG_BLOB_FILE_SIZE_LIMIT_MB, "1024").trim.toInt
-
     val readModeOption = parameters.get(KustoSourceOptions.KUSTO_READ_MODE)
     val readMode: Option[ReadMode] = if (readModeOption.isDefined) {
       Some(ReadMode.withName(readModeOption.get))
@@ -84,7 +82,7 @@ object KustoDataSourceUtils {
       }
       case None => Map.empty()
     }
-    KustoReadOptions(readMode, shouldCompressOnExport, exportSplitLimitMb, partitionOptions,
+    KustoReadOptions(readMode, shouldCompressOnExport, partitionOptions,
       distributedReadModeTransientCacheEnabled, queryFilterPushDown,additionalExportOptions)
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -39,6 +39,7 @@ import scala.util.{Failure, Success, Try}
 
 object KustoDataSourceUtils {
 
+  private final val className = this.getClass.getSimpleName
   private final val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
   def getDedupTagsPrefix(requestId: String, batchId: String):String = s"${requestId}_$batchId"
 
@@ -76,7 +77,10 @@ object KustoDataSourceUtils {
       case Some(exportOptionsJsonString) => Try(objectMapper.readValue(exportOptionsJsonString, new TypeReference[Map[String, String]] {})) match {
         case Success(exportConfigMap) => exportConfigMap
         // TODO check if we should throw an exception or warn the user.
-        case Failure(exception) => throw exception
+        case Failure(exception) =>
+          logError(className, "The configuration " +
+            s"for ${KustoSourceOptions.KUSTO_EXPORT_OPTIONS_JSON} has a value $exportOptionsJsonString that cannot be parsed as Map")
+          throw exception
       }
       case None => Map.empty()
     }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -76,11 +76,16 @@ object KustoDataSourceUtils {
         case Failure(exception) =>
           val errorMessage = s"The configuration for ${KustoSourceOptions.KUSTO_EXPORT_OPTIONS_JSON} has a value " +
             s"$exportOptionsJsonString that cannot be parsed as Map"
-          logError(className,errorMessage )
+          logError(className, errorMessage)
           throw new IllegalArgumentException(errorMessage)
       }
       case None => Map.empty[String,String]
     }
+    val userNamePrefix = additionalExportOptions.get("namePrefix")
+    if (userNamePrefix.isDefined) {
+      logWarn(className, "User cannot specify namePrefix for additionalExportOptions as it can lead to unexpected behavior in reading output")
+    }
+
     KustoReadOptions(readMode, partitionOptions,
       distributedReadModeTransientCacheEnabled, queryFilterPushDown,additionalExportOptions)
   }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -43,6 +43,7 @@ object KustoDataSourceUtils {
   def getDedupTagsPrefix(requestId: String, batchId: String):String = s"${requestId}_$batchId"
 
   def generateTempTableName(appName: String, destinationTableName: String, requestId:String,
+
                             batchIdAsString: String, userTempTableName: Option[String]): String = {
     if (userTempTableName.isDefined) {
       userTempTableName.get

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoBlobAccessE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoBlobAccessE2E.scala
@@ -123,8 +123,7 @@ class KustoBlobAccessE2E extends FlatSpec with BeforeAndAfterAll {
       directory,
       partitionId,
       new TransientStorageParameters(Array(new TransientStorageCredentials(storageAccount, secret, container))),
-      Some(partitionPredicate),
-      None
+      Some(partitionPredicate)
     )
 
     val blobs = kustoAdminClient.execute(database, exportCommand)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -11,14 +11,14 @@ import org.scalatest.prop.Tables.Table
 class CslCommandsGeneratorTest extends FlatSpec{
   val dataCombinations =
     Table(
-      ("sizeLimit", "additionalExportOptions", "expectedOptions","iteration"),
-      (Some(1000L), Map("key1" -> "value1", "exportOption2" -> "eo2"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
+      ("additionalExportOptions", "expectedOptions","iteration"),
+      (Map("key1" -> "value1", "exportOption2" -> "eo2","sizeLimit"->"1"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
         "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")",1),
-      (None, Map("key1" -> "value1", "exportOption2" -> "eo2", "namePrefix" -> "Np-2","compressionType"->"gz"),
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "namePrefix" -> "Np-2","compressionType"->"gz"),
         "with ( namePrefix=\"Np-2\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")",2)
     )
 
-  forAll(dataCombinations) { (sizeLimit, additionalExportOptions, expectedOptions ,iteration)=>
+  forAll(dataCombinations) { (additionalExportOptions, expectedOptions ,iteration)=>
     "TestGenerateExportDataCommand" should s"generate command with additional options-$iteration" in {
       val query = "Storms | take 100"
       val directory = "storms/data/"
@@ -28,9 +28,8 @@ class CslCommandsGeneratorTest extends FlatSpec{
         "test-storage-account-key",
         "test-storage-account-container")
       val transientStorageParameters = new TransientStorageParameters(Array(transientStorageCredentials))
-      // val additionalExportOptions = Map("key1" -> "value1", "exportOption2" -> "eo2")
       val commandResult = CslCommandsGenerator.generateExportDataCommand(query, directory, partitionId,
-        transientStorageParameters, Option.empty[String], sizeLimit, isCompressed = true, additionalExportOptions = additionalExportOptions)
+        transientStorageParameters, Option.empty[String], isCompressed = true, additionalExportOptions = additionalExportOptions)
       assert(commandResult.nonEmpty)
       val expectedResult = ".export async compressed to parquet " +
         "(\"https://test-storage-account.blob.core.windows.net/test-storage-account-container;\" h@\"test-storage-account-key\") " +

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -2,23 +2,34 @@ package com.microsoft.kusto.spark.utils
 
 import com.microsoft.kusto.spark.datasource.{TransientStorageCredentials, TransientStorageParameters}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 
 @RunWith(classOf[JUnitRunner])
-class CslCommandsGeneratorTest extends FlatSpec{
-  val dataCombinations =
+class CslCommandsGeneratorTest extends FlatSpec {
+  private val dataCombinations =
     Table(
-      ("additionalExportOptions", "expectedOptions","iteration"),
-      (Map("key1" -> "value1", "exportOption2" -> "eo2","sizeLimit"->"1"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
-        "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")",1),
-      (Map("key1" -> "value1", "exportOption2" -> "eo2", "namePrefix" -> "Np-2","compressionType"->"gz"),
-        "with ( namePrefix=\"Np-2\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")",2)
+      ("additionalExportOptions", "expectedOptions", "compressed", "async", "iteration"),
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "sizeLimit" -> "1000"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
+        "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async", 1),
+      // size is not provided. Hence this will fallback to default without size
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz"),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async" ,2),
+      // Though namePrefix is specified, we do not use this option and ignore this. This has downstream implications
+      // where we read the exported data, better to lock this option atleast for now
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "namePrefix" -> "Np-2"),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async", 3),
+      // when compressed is set as none, this should not appear in the command
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "compressed" -> "none"),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "","async", 4),
+      // when async and compressed are none , they should not be in the command
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "compressed" -> "none", "async" -> "none"),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",exportOption2=\"eo2\",key1=\"value1\")", "", "",5)
     )
 
-  forAll(dataCombinations) { (additionalExportOptions, expectedOptions ,iteration)=>
+  forAll(dataCombinations) { (additionalExportOptions, expectedOptions, compressed, async, iteration) =>
     "TestGenerateExportDataCommand" should s"generate command with additional options-$iteration" in {
       val query = "Storms | take 100"
       val directory = "storms/data/"
@@ -29,9 +40,9 @@ class CslCommandsGeneratorTest extends FlatSpec{
         "test-storage-account-container")
       val transientStorageParameters = new TransientStorageParameters(Array(transientStorageCredentials))
       val commandResult = CslCommandsGenerator.generateExportDataCommand(query, directory, partitionId,
-        transientStorageParameters, Option.empty[String], isCompressed = true, additionalExportOptions = additionalExportOptions)
+        transientStorageParameters, Option.empty[String], additionalExportOptions = additionalExportOptions)
       assert(commandResult.nonEmpty)
-      val expectedResult = ".export async compressed to parquet " +
+      val expectedResult = s".export $async $compressed to parquet " +
         "(\"https://test-storage-account.blob.core.windows.net/test-storage-account-container;\" h@\"test-storage-account-key\") " +
         s"$expectedOptions <| Storms | take 100"
       assert(commandResult == expectedResult)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -11,25 +11,25 @@ import org.scalatest.prop.Tables.Table
 class CslCommandsGeneratorTest extends FlatSpec {
   private val dataCombinations =
     Table(
-      ("additionalExportOptions", "expectedOptions", "compressed", "async", "iteration"),
+      ("additionalExportOptions", "expectedOptions", "compressed", "iteration"),
       (Map("key1" -> "value1", "exportOption2" -> "eo2", "sizeLimit" -> "1000"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
-        "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async", 1),
+        "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")", "compressed", 1),
       // size is not provided. Hence this will fallback to default without size
       (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz"),
-        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async" ,2),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed" ,2),
       // Though namePrefix is specified, we do not use this option and ignore this. This has downstream implications
       // where we read the exported data, better to lock this option atleast for now
       (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "namePrefix" -> "Np-2"),
-        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed","async", 3),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "compressed", 3),
       // when compressed is set as none, this should not appear in the command
       (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "compressed" -> "none"),
-        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "","async", 4),
-      // when async and compressed are none , they should not be in the command
-      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "compressed" -> "none", "async" -> "none"),
-        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",exportOption2=\"eo2\",key1=\"value1\")", "", "",5)
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "", 4),
+      // when compressed is none , it should not be in the command
+      (Map("key1" -> "value1", "exportOption2" -> "eo2", "compressionType" -> "gz", "compressed" -> "none"),
+        "with ( namePrefix=\"storms/data/part1\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")", "",5)
     )
 
-  forAll(dataCombinations) { (additionalExportOptions, expectedOptions, compressed, async, iteration) =>
+  forAll(dataCombinations) { (additionalExportOptions, expectedOptions, compressed, iteration) =>
     "TestGenerateExportDataCommand" should s"generate command with additional options-$iteration" in {
       val query = "Storms | take 100"
       val directory = "storms/data/"
@@ -42,7 +42,7 @@ class CslCommandsGeneratorTest extends FlatSpec {
       val commandResult = CslCommandsGenerator.generateExportDataCommand(query, directory, partitionId,
         transientStorageParameters, Option.empty[String], additionalExportOptions = additionalExportOptions)
       assert(commandResult.nonEmpty)
-      val expectedResult = s".export $async $compressed to parquet " +
+      val expectedResult = s".export async $compressed to parquet " +
         "(\"https://test-storage-account.blob.core.windows.net/test-storage-account-container;\" h@\"test-storage-account-key\") " +
         s"$expectedOptions <| Storms | take 100"
       assert(commandResult == expectedResult)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -1,0 +1,41 @@
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.kusto.spark.datasource.{TransientStorageCredentials, TransientStorageParameters}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.prop.TableDrivenPropertyChecks.forAll
+import org.scalatest.prop.Tables.Table
+
+@RunWith(classOf[JUnitRunner])
+class CslCommandsGeneratorTest extends FlatSpec{
+  val dataCombinations =
+    Table(
+      ("sizeLimit", "additionalExportOptions", "expectedOptions","iteration"),
+      (Some(1000L), Map("key1" -> "value1", "exportOption2" -> "eo2"), "with (sizeLimit=1048576000 , namePrefix=\"storms/data/part1\", " +
+        "compressionType=\"snappy\",key1=\"value1\",exportOption2=\"eo2\")",1),
+      (None, Map("key1" -> "value1", "exportOption2" -> "eo2", "namePrefix" -> "Np-2","compressionType"->"gz"),
+        "with ( namePrefix=\"Np-2\", compressionType=\"gz\",key1=\"value1\",exportOption2=\"eo2\")",2)
+    )
+
+  forAll(dataCombinations) { (sizeLimit, additionalExportOptions, expectedOptions ,iteration)=>
+    "TestGenerateExportDataCommand" should s"generate command with additional options-$iteration" in {
+      val query = "Storms | take 100"
+      val directory = "storms/data/"
+      val partitionId = 1
+      val transientStorageCredentials = new TransientStorageCredentials(
+        "test-storage-account",
+        "test-storage-account-key",
+        "test-storage-account-container")
+      val transientStorageParameters = new TransientStorageParameters(Array(transientStorageCredentials))
+      // val additionalExportOptions = Map("key1" -> "value1", "exportOption2" -> "eo2")
+      val commandResult = CslCommandsGenerator.generateExportDataCommand(query, directory, partitionId,
+        transientStorageParameters, Option.empty[String], sizeLimit, isCompressed = true, additionalExportOptions = additionalExportOptions)
+      assert(commandResult.nonEmpty)
+      val expectedResult = ".export async compressed to parquet " +
+        "(\"https://test-storage-account.blob.core.windows.net/test-storage-account-container;\" h@\"test-storage-account-key\") " +
+        s"$expectedOptions <| Storms | take 100"
+      assert(commandResult == expectedResult)
+    }
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtilsTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtilsTest.scala
@@ -1,0 +1,39 @@
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.kusto.spark.datasource.ReadMode.ForceDistributedMode
+import com.microsoft.kusto.spark.datasource.{KustoReadOptions, KustoSourceOptions, PartitionOptions, ReadMode}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FlatSpec
+
+class KustoDataSourceUtilsTest extends FlatSpec with MockFactory {
+  "ReadParameters" should "KustoReadOptions with passed in options" in {
+    val conf: Map[String, String] = Map(
+      KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceDistributedMode.toString,
+      KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE -> true.toString,
+      KustoSourceOptions.KUSTO_AAD_APP_ID -> "AppId",
+      KustoSourceOptions.KUSTO_AAD_APP_SECRET -> "AppKey",
+      KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID -> "Tenant",
+      KustoSourceOptions.KUSTO_EXPORT_OPTIONS_JSON -> "{\"sizeLimit\":250,\"compressionType\":\"gzip\",\"async\":\"none\"}"
+    )
+    // a no interaction mock only for test
+    val actualReadOptions = KustoDataSourceUtils.getReadParameters(conf, null)
+    val expectedResult = KustoReadOptions(Some(ForceDistributedMode), PartitionOptions(1, None, None),
+      distributedReadModeTransientCacheEnabled = true, None, Map("sizeLimit" -> "250", "compressionType" -> "gzip","async" -> "none"))
+    assert(actualReadOptions != null)
+    assert(actualReadOptions == expectedResult)
+  }
+
+  "ReadParameters" should "throw an exception when an invalid export options is passed" in {
+    val conf: Map[String, String] = Map(
+      KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceDistributedMode.toString,
+      KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE -> true.toString,
+      KustoSourceOptions.KUSTO_AAD_APP_ID -> "AppId",
+      KustoSourceOptions.KUSTO_AAD_APP_SECRET -> "AppKey",
+      KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID -> "Tenant",
+      KustoSourceOptions.KUSTO_EXPORT_OPTIONS_JSON -> "\"sizeLimit\":250,\"compressionType\":\"gzip\",\"async\":\"none\"}"
+    )
+    val illegalArgumentException = intercept[IllegalArgumentException](KustoDataSourceUtils.getReadParameters(conf, null))
+    assert(illegalArgumentException.getMessage == "The configuration for kustoExportOptionsJson has " +
+      "a value \"sizeLimit\":250,\"compressionType\":\"gzip\",\"async\":\"none\"} that cannot be parsed as Map")
+  }
+}

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -113,7 +113,11 @@ It's recommended to set this flag to true in production scenarios, so that the w
     
  * **KUSTO_REQUEST_ID**:
     'requestId' - A unique identifier UUID for this ingestion command. Will be used as part of the staging table name as well.
-    
+
+ * **KUSTO_EXPORT_OPTIONS_JSON**:
+    'kustoExportOptionsJson' - JSON that provides the list of [export options](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/data-export/export-data-to-storage) in case of distributed read (either because of query limits getting hit or user request for ForceDistributed mode). The export options do not support the _OutputDataFormat_ which is defaulted to _parquet_, _namePrefix_ which is defaulted based on the
+    partition of the export. _async_ is defaulted to true (implying the export will be export async) and _compressed_ is defaulted to snappy.To turn these options off these values can be set to _none_ (**not recommended**)
+     
  >**Note:**
  For both synchronous and asynchronous operation, 'write' is an atomic transaction, i.e. 
  either all data is written to Kusto, or no data is written. 

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -95,29 +95,6 @@ All the options that can be used in the Kusto Source can be found in KustoSource
     'requestId' - A unique identifier UUID for this reading operation. Setting this will override the ClientRequestId on the
     ClientRequestProperties object if set.
     
-#### Transient Storage Parameters
-When reading data from Kusto in 'distributed' mode, the data is exported from Kusto into a blob storage every time the corresponding RDD is materialized. 
-If the user doesn't specify storage parameters and a 'Distributed' read mode is chosen - the storage used will be provided by Kusto ingest service. 
-
->Note: If the user provides the blob storage - the blobs created are the caller's responsibility. This includes provisioning the storage, rotating access keys, 
-deleting transient artifacts etc. KustoBlobStorageUtils module contains helper functions for deleting blobs based on either account and container 
-coordinates and account credentials, or a full SAS URL with write, read and list permissions once the corresponding RDD is no longer needed. Each transaction stores transient blob 
-artifacts in a separate directory. This directory is captured as part of read-transaction information logs reported on the Spark Driver node. 
-
-* **KUSTO_BLOB_STORAGE_ACCOUNT_NAME**
-'blobStorageAccountName' - Transient storage account name. Either this, or a SAS URL, must be provided to access the storage account
-
-* **KUSTO_BLOB_STORAGE_ACCOUNT_KEY**
-'blobStorageAccountKey' - Storage account key. Either this, or a SAS URL, must be provided to access the storage account
-
-* **KUSTO_BLOB_STORAGE_SAS_URL**
-'sasUrl' - SAS URL: a complete SAS URL to access the container. Either this, or a storage account name and key, must be provided
-  to access the storage account
-  
-* **KUSTO_BLOB_CONTAINER**
-'blobContainer' - Blob container name. This container will be used to store all transient artifacts created every time the corresponding RDD is materialized. 
-Once the RDD is no longer required by the caller application, the container and/or all its contents can be deleted by the caller.
-
 * **KUSTO_READ_MODE**
 'readMode' - Override the connector heuristic to choose between 'Single' and 'Distributed' mode.
 Options are - 'ForceSingleMode', 'ForceDistributedMode'.
@@ -130,9 +107,35 @@ When 'Distributed' read mode is used and this is set to 'true', the request quer
 If set to 'true', query executed on kusto cluster will include the filters.
   'false' by default if KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE=true, and
   'true' by default if KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE=false
-  
-  
- ### Examples
+
+* **KUSTO_EXPORT_OPTIONS_JSON**:
+  'kustoExportOptionsJson' - JSON that provides the list of [export options](https://learn.microsoft.com/azure/data-explorer/kusto/management/data-export/export-data-to-storage) in case of distributed read (either because of query limits getting hit or user request for ForceDistributed mode). The export options do not support the _OutputDataFormat_ which is defaulted to _parquet_, _namePrefix_ which is defaulted based on the
+  partition of the export. _compressionType_ is defaulted to snappy and the command also specifies _compressed_ (to create .snappy.gz files), to turn extra compression off - it can be set to _none_ (**not recommended**)
+  i.e .option("kustoExportOptionsJson", "{\"distribution\":\"per_node\"}")
+* 
+#### Transient Storage Parameters
+When reading data from Kusto in 'distributed' mode, the data is exported from Kusto into a blob storage every time the corresponding RDD is materialized.
+If the user doesn't specify storage parameters and a 'Distributed' read mode is chosen - the storage used will be provided by Kusto ingest service.
+
+>Note: If the user provides the blob storage - the blobs created are the caller's responsibility. This includes provisioning the storage, rotating access keys,
+deleting transient artifacts etc. KustoBlobStorageUtils module contains helper functions for deleting blobs based on either account and container
+coordinates and account credentials, or a full SAS URL with write, read and list permissions once the corresponding RDD is no longer needed. Each transaction stores transient blob
+artifacts in a separate directory. This directory is captured as part of read-transaction information logs reported on the Spark Driver node.
+
+* ** KUSTO_TRANSIENT_STORAGE **:
+ 'transientStorage' KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> new TransientStorageParameters(Array(new TransientStorageCredentials(blobSas)))
+ ```python
+transientStorage = "{ \"storageCredentials\" : [ { \
+    \"storageAccountName\": \"1jdldsdke2etestcluster01\",\
+    \"blobContainer\": \"20221225-exportresults-0\",\
+    \"sasUrl\" : \"https://1jdldsdke2etestcluster01.blob.core.windows.net/20221225-exportresults-0\", \
+  \"sasKey\" : \"?sv=2018-03-28&sr=c&sig=IpdreLgIV7nZyLdENdukhRS3gdS5IxPapiKJa6j40Ig%3D&st=2022-12-25T13%3A45%3A12Z&se=2022-12-29T14%3A45%3A12Z&sp=rwdl\"\
+  } ] }"
+  ...
+  option("transientStorage", transientStorage). \
+ ```
+
+### Examples
  
  **Using simplified syntax**
  


### PR DESCRIPTION
#### Pull Request Description

Add support for passing in additional options when using the **.export** model in ForceDistributedMode. Since there are lot of new options that can be passed in this is a map of options, passed in as a JSON

for example 
**'{"exportOption1":"e1", "exportOptionForCompression":"none"}'** 

When the **.export** is called in the ForceDistributedMode or because of limits getting hit these options will be added in the **with** clause

**.export async ..... with ( ..... , exportOption1="e1",exportOptionForCompression="none")**

Idea would be to take this as a KustoSourceOption and then validate it (has to be a proper name value pair as a parsable JSON)
and then use the map to provide options in export

Tests are WIP

**Features:**
- #276 

