### PR TITLE
Added Managed Identity authentication 

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/authentication/KustoAuthentication.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/authentication/KustoAuthentication.scala
@@ -26,6 +26,17 @@ case class AadApplicationAuthentication(ID: String, password: String, authority:
   override def hashCode(): Int = ID.hashCode + (if (authority == null) 0 else (authority.hashCode))
 }
 
+case class ManagedIdentityAuthentication(clientId : Option[String]) extends KustoAuthentication {
+  def canEqual(that: Any): Boolean = that.isInstanceOf[ManagedIdentityAuthentication]
+
+  override def equals(that: Any): Boolean = that match {
+    case auth: ManagedIdentityAuthentication => clientId == auth.clientId
+    case _ => false
+  }
+
+  override def hashCode(): Int = if (clientId.isDefined) clientId.hashCode() else 0
+}
+
 case class AadApplicationCertificateAuthentication(appId: String, certFilePath: String, certPassword: String, authority: String) extends KustoAuthentication {
   def canEqual(that: Any): Boolean = that.isInstanceOf[AadApplicationCertificateAuthentication]
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -49,6 +49,9 @@ trait KustoOptions {
   // The provider will be called for every request to the kusto service
   val KUSTO_TOKEN_PROVIDER_CALLBACK_CLASSPATH: String = newOption("tokenProviderCallbackClasspath")
 
+  val KUSTO_MANAGED_IDENTITY_AUTH : String = newOption("managedIdentityAuth")
+  val KUSTO_MANAGED_CLIENT_ID : String = newOption("managedClientId")
+
   /** Optional parameters */
   // it merge origin/aKusto ingestion cluster URL for reading data - provide this if ingestion URL cannot be deduced
   // from adding

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -50,7 +50,7 @@ trait KustoOptions {
   val KUSTO_TOKEN_PROVIDER_CALLBACK_CLASSPATH: String = newOption("tokenProviderCallbackClasspath")
 
   val KUSTO_MANAGED_IDENTITY_AUTH : String = newOption("managedIdentityAuth")
-  val KUSTO_MANAGED_CLIENT_ID : String = newOption("managedClientId")
+  val KUSTO_MANAGED_IDENTITY_CLIENT_ID : String = newOption("managedIdentityClientId")
 
   /** Optional parameters */
   // it merge origin/aKusto ingestion cluster URL for reading data - provide this if ingestion URL cannot be deduced

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
@@ -33,6 +33,19 @@ object KustoClientCache {
           ConnectionStringBuilder.createWithAadApplicationCertificate(clusterAndAuth.engineUri, app.appId, keyCert.cert, keyCert.key, app.authority),
           ConnectionStringBuilder.createWithAadApplicationCertificate(clusterAndAuth.ingestUri, app.appId, keyCert.cert, keyCert.key, app.authority)
         )
+      case app: ManagedIdentityAuthentication =>
+        app.clientId match {
+          case Some(clientId) =>
+            (
+              ConnectionStringBuilder.createWithAadManagedIdentity(clusterAndAuth.engineUri, clientId),
+              ConnectionStringBuilder.createWithAadManagedIdentity(clusterAndAuth.ingestUri, clientId)
+            )
+          case None =>
+            (
+              ConnectionStringBuilder.createWithAadManagedIdentity(clusterAndAuth.engineUri),
+              ConnectionStringBuilder.createWithAadManagedIdentity(clusterAndAuth.ingestUri)
+            )
+        }
       case keyVaultParams: KeyVaultAuthentication =>
         val app = KeyVaultUtils.getAadAppParametersFromKeyVault(keyVaultParams)
         (

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -171,6 +171,9 @@ object KustoDataSourceUtils {
     var authentication: KustoAuthentication = null
     var keyVaultAuthentication: Option[KeyVaultAuthentication] = None
 
+    val managedIdentityAuth : Boolean = parameters.getOrElse(KustoSourceOptions.KUSTO_MANAGED_IDENTITY_AUTH,"false").toBoolean
+    val maybeManagedClientId : Option[String] = parameters.get(KustoSourceOptions.KUSTO_MANAGED_CLIENT_ID)
+
     val authorityId: String = parameters.getOrElse(KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID, DefaultMicrosoftTenant)
 
     // Check KeyVault Authentication
@@ -206,7 +209,10 @@ object KustoDataSourceUtils {
       } else if (applicationCertPath.nonEmpty) {
         authentication = AadApplicationCertificateAuthentication(applicationId, applicationCertPath, applicationCertPassword, authorityId)
       }
-    } else if (accessToken.nonEmpty) {
+    }else if( managedIdentityAuth){
+      // Authentication for managed Identity
+      authentication = ManagedIdentityAuthentication(maybeManagedClientId)
+    }else if (accessToken.nonEmpty) {
       // Authentication by token
       authentication = KustoAccessTokenAuthentication(accessToken)
     } else if (tokenProviderCoordinates.nonEmpty) {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -172,7 +172,7 @@ object KustoDataSourceUtils {
     var keyVaultAuthentication: Option[KeyVaultAuthentication] = None
 
     val managedIdentityAuth : Boolean = parameters.getOrElse(KustoSourceOptions.KUSTO_MANAGED_IDENTITY_AUTH,"false").toBoolean
-    val maybeManagedClientId : Option[String] = parameters.get(KustoSourceOptions.KUSTO_MANAGED_CLIENT_ID)
+    val maybeManagedClientId : Option[String] = parameters.get(KustoSourceOptions.KUSTO_MANAGED_IDENTITY_CLIENT_ID)
 
     val authorityId: String = parameters.getOrElse(KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID, DefaultMicrosoftTenant)
 
@@ -209,10 +209,10 @@ object KustoDataSourceUtils {
       } else if (applicationCertPath.nonEmpty) {
         authentication = AadApplicationCertificateAuthentication(applicationId, applicationCertPath, applicationCertPassword, authorityId)
       }
-    }else if( managedIdentityAuth){
+    } else if (managedIdentityAuth) {
       // Authentication for managed Identity
       authentication = ManagedIdentityAuthentication(maybeManagedClientId)
-    }else if (accessToken.nonEmpty) {
+    } else if (accessToken.nonEmpty) {
       // Authentication by token
       authentication = KustoAccessTokenAuthentication(accessToken)
     } else if (tokenProviderCoordinates.nonEmpty) {

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -181,13 +181,14 @@ The provider will be called for every request to the kusto service
     'tokenProviderCallbackClasspath' - The classpath to the class
 ## Managed Identity Authentication
 This authentication method can use [managed identities](https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) to obtain Azure AD tokens without having to manage any credentials.
-Supports System-assigned as well as User-assigned managed identities 
+Supports System-assigned as well as User-assigned managed identities. 
+>Read about configuring managed identities for ADX [here](https://learn.microsoft.com/azure/data-explorer/configure-managed-identities-cluster?tabs=portal).
 
 * **KUSTO_MANAGED_IDENTITY_AUTH**:
   'managedIdentityAuth' - Can be set to "true" or "false" if managed identity authentication is required or not.
 
-* **KUSTO_MANAGED_CLIENT_ID**:
-  'managedClientId' - ClientId for user assigned managed identity. In case it is not provided, System-assigned will be considered as default.
+* **KUSTO_MANAGED_IDENTITY_CLIENT_ID**:
+  'managedIdentityClientId' - ClientId for user assigned managed identity. In case it is not provided, System-assigned will be considered as default.
 
 
 #### Example
@@ -199,7 +200,7 @@ df.write
       .option(KustoSinkOptions.KUSTO_DATABASE, "MyDatabase")
       .option(KustoSinkOptions.KUSTO_TABLE, "MyTable")
       .option(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_AUTH, true.toString)
-      .option(KustoSinkOptions.KUSTO_MANAGED_CLIENT_ID, "xxxx-xxxx-xxxxx-xxxx")
+      .option(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_CLIENT_ID, "xxxx-xxxx-xxxxx-xxxx")
       .mode(SaveMode.Append)
       .save()
 ```

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -179,3 +179,27 @@ The provider will be called for every request to the kusto service
 
 * **KUSTO_TOKEN_PROVIDER_CALLBACK_CLASSPATH**: 
     'tokenProviderCallbackClasspath' - The classpath to the class
+## Managed Identity Authentication
+This authentication method can use [managed identities](https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) to obtain Azure AD tokens without having to manage any credentials.
+Supports System-assigned as well as User-assigned managed identities 
+
+* **KUSTO_MANAGED_IDENTITY_AUTH**:
+  'managedIdentityAuth' - Can be set to "true" or "false" if managed identity authentication is required or not.
+
+* **KUSTO_MANAGED_CLIENT_ID**:
+  'managedClientId' - ClientId for user assigned managed identity. In case it is not provided, System-assigned will be considered as default.
+
+
+#### Example
+```
+df.write
+  .format("com.microsoft.kusto.spark.datasource")
+      .format("com.microsoft.kusto.spark.datasource")
+      .option(KustoSinkOptions.KUSTO_CLUSTER, "MyCluster")
+      .option(KustoSinkOptions.KUSTO_DATABASE, "MyDatabase")
+      .option(KustoSinkOptions.KUSTO_TABLE, "MyTable")
+      .option(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_AUTH, true.toString)
+      .option(KustoSinkOptions.KUSTO_MANAGED_CLIENT_ID, "xxxx-xxxx-xxxxx-xxxx")
+      .mode(SaveMode.Append)
+      .save()
+```


### PR DESCRIPTION
#### Pull Request Description

_[managed identity](https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) authentication support_

---
**Breaking Changes:**
- None

**Features:**
- Managed Identity authentication

**Fixes:**
- None

Examples:
1) If System-assigned Managed Identity( no need to pass KUSTO_MANAGED_CLIENT_ID):

```
df.write
  .format("com.microsoft.kusto.spark.datasource")
      .format("com.microsoft.kusto.spark.datasource")
      .option(KustoSinkOptions.KUSTO_CLUSTER, "MyCluster")
      .option(KustoSinkOptions.KUSTO_DATABASE, "MyDatabase")
      .option(KustoSinkOptions.KUSTO_TABLE, "MyTable")
      .option(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_AUTH, true.toString)
      .mode(SaveMode.Append)
      .save()
```

2) User-assigned Managed identity:
```
df.write
  .format("com.microsoft.kusto.spark.datasource")
      .format("com.microsoft.kusto.spark.datasource")
      .option(KustoSinkOptions.KUSTO_CLUSTER, "MyCluster")
      .option(KustoSinkOptions.KUSTO_DATABASE, "MyDatabase")
      .option(KustoSinkOptions.KUSTO_TABLE, "MyTable")
      .option(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_AUTH, true.toString)
      .option(KustoSinkOptions.KUSTO_MANAGED_CLIENT_ID, "xxxx-xxxx-xxxxx-xxxx")
      .mode(SaveMode.Append)
      .save()
```
