### PR TITLE
Kusto Stream Ingestion

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
@@ -57,6 +57,8 @@ object KustoSinkOptions extends KustoOptions{
   // after which it will move the data to the destination table (the last part is a metadata operation only)
   // If set to 'Queued', the write operation finishes after data is processed by the workers, the data may not be completely
   // available up until the service finishes loading it and failures on the service side will not propagate to Spark.
+  // If set to 'Stream', Kusto streaming ingestion will be used. Streaming ingestion should be used if latency of less than a few seconds is required
+  // or To optimize operational processing of many tables where the stream of data into each table is relatively small (a few records per second).
   val KUSTO_WRITE_MODE: String = newOption("writeMode")
 
   // Provide a temporary table name that will be used for this write operation to achieve transactional write and move
@@ -82,7 +84,7 @@ object SchemaAdjustmentMode extends Enumeration {
 
 object WriteMode extends Enumeration {
   type WriteMode = Value
-  val Transactional, Queued = Value
+  val Transactional, Queued, Stream = Value
 }
 
 case class WriteOptions(pollingOnDriver:Boolean = false,
@@ -100,7 +102,7 @@ case class WriteOptions(pollingOnDriver:Boolean = false,
                         maxRetriesOnMoveExtents: Int = 10,
                         minimalExtentsCountForSplitMerge: Int = 400,
                         adjustSchema: SchemaAdjustmentMode.SchemaAdjustmentMode = SchemaAdjustmentMode.NoAdjustment,
-                        isTransactionalMode: Boolean = true,
+                        writeMode: WriteMode.WriteMode = WriteMode.Transactional,
                         userTempTableName: Option[String] = None,
                         disableFlushImmediately:Boolean = false,
                         ensureNoDupBlobs: Boolean = false)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
@@ -59,6 +59,7 @@ object KustoSinkOptions extends KustoOptions{
   // available up until the service finishes loading it and failures on the service side will not propagate to Spark.
   // If set to 'Stream', Kusto streaming ingestion will be used. Streaming ingestion should be used if latency of less than a few seconds is required
   // or To optimize operational processing of many tables where the stream of data into each table is relatively small (a few records per second).
+  // If batch size exceeds the maximum allowed size for stream ingestion (4 mb) queued ingestion will be used.
   val KUSTO_WRITE_MODE: String = newOption("writeMode")
 
   // Provide a temporary table name that will be used for this write operation to achieve transactional write and move

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoSinkOptions.scala
@@ -59,7 +59,7 @@ object KustoSinkOptions extends KustoOptions{
   // available up until the service finishes loading it and failures on the service side will not propagate to Spark.
   // If set to 'Stream', Kusto streaming ingestion will be used. Streaming ingestion should be used if latency of less than a few seconds is required
   // or To optimize operational processing of many tables where the stream of data into each table is relatively small (a few records per second).
-  // If batch size exceeds the maximum allowed size for stream ingestion (4 mb) queued ingestion will be used.
+  // If a request exceeds 4 MB, it will be broken into multiple appropriately sized chunks.
   val KUSTO_WRITE_MODE: String = newOption("writeMode")
 
   // Provide a temporary table name that will be used for this write operation to achieve transactional write and move

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -7,7 +7,7 @@ import com.microsoft.azure.kusto.ingest.IngestionProperties.DataFormat
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
 import com.microsoft.azure.kusto.ingest.result.IngestionResult
 import com.microsoft.azure.kusto.ingest.source.{BlobSourceInfo, StreamSourceInfo}
-import com.microsoft.azure.kusto.ingest.{IngestClient, IngestionProperties}
+import com.microsoft.azure.kusto.ingest.{IngestClient, IngestionProperties, StreamingIngestClient}
 import com.microsoft.azure.storage.RetryNoRetry
 import com.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlockBlob}
 import com.microsoft.azure.storage.queue.QueueRequestOptions
@@ -175,7 +175,7 @@ object KustoWriter {
         s"on partition ${TaskContext.getPartitionId} $batchIdForTracing")
     }
     else if (parameters.writeOptions.writeMode == WriteMode.Stream) {
-      streamIntoKusto(batchIdForTracing, rows, partitionsResults, parameters)
+      streamRowsIntoKusto(batchIdForTracing, rows, parameters)
     }
     else {
       ingestToTemporaryTableByWorkers(batchIdForTracing, rows, partitionsResults,parameters)
@@ -226,10 +226,9 @@ object KustoWriter {
     ingestionProperties
   }
 
-  private def streamIntoKusto(batchIdForTracing: String,
+  private def streamRowsIntoKusto(batchIdForTracing: String,
                               rows: Iterator[InternalRow],
-                              partitionsResults: CollectionAccumulator[PartitionResult],
-                              parameters:KustoWriteResource): Unit = {
+                              parameters: KustoWriteResource): Unit = {
     val streamingClient = KustoClientCache.getClient(
       parameters.coordinates.clusterUrl,
       parameters.authentication,
@@ -241,33 +240,47 @@ object KustoWriter {
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
     val csvWriter = CountingWriter(writer)
+    var count = 1
+
     for (row <- rows) {
       RowCSVWriterUtils.writeRowAsCSV(row, parameters.schema, timeZone, csvWriter)
+      if (csvWriter.bytesCounter >= KCONST.MaxStreamingBytes) {
+        KDSU.logWarn(myName, s"Batch $batchIdForTracing exceeds the max streaming size (${KCONST.MaxStreamingBytes} bytes)! " +
+          s"Streaming ${csvWriter.bytesCounter} bytes from batch $batchIdForTracing ($count).")
+        writer.flush()
+        streamBytesIntoKusto(batchIdForTracing, byteArrayOutputStream.toByteArray, streamingClient, parameters)
+        csvWriter.resetCounter()
+        byteArrayOutputStream.reset()
+        count = count + 1
+      }
     }
 
     writer.flush()
     writer.close()
-    val bytes = byteArrayOutputStream.toByteArray
-    KDSU.logInfo(myName, s"Streaming batch $batchIdForTracing of ${bytes.length} bytes (max allowed is ${KCONST.MaxStreamingBytes} bytes)")
-    if (bytes.length > KCONST.MaxStreamingBytes) {
-      KDSU.logWarn(myName, s"Streaming micro-batch '$batchIdForTracing' exceeds streaming threshold '${KCONST.MaxStreamingBytes}' bytes. " +
-        "Falling back to queued ingestion.")
-      ingestToTemporaryTableByWorkers(batchIdForTracing, rows, partitionsResults, parameters)
+    if (csvWriter.bytesCounter > 0) {
+      KDSU.logInfo(myName, s"Streaming ${csvWriter.bytesCounter} bytes from batch $batchIdForTracing ($count).")
+      streamBytesIntoKusto(batchIdForTracing, byteArrayOutputStream.toByteArray, streamingClient, parameters)
     }
-    else {
-      val streamSourceInfo = new StreamSourceInfo(new ByteArrayInputStream(bytes))
-      val ingestionProperties = getIngestionProperties(parameters.writeOptions, parameters.coordinates.database, parameters.coordinates.table.get)
-      val status = streamingClient.ingestFromStream(streamSourceInfo, ingestionProperties)
-      status.getIngestionStatusCollection.forEach(
-        item => { KDSU.logInfo(
-        myName, s"BatchId $batchIdForTracing IngestionStatus { " +
+  }
+
+  private def streamBytesIntoKusto(batchIdForTracing: String,
+                              bytes: Array[Byte],
+                              streamingClient: StreamingIngestClient,
+                              parameters: KustoWriteResource): Unit = {
+    val streamSourceInfo = new StreamSourceInfo(new ByteArrayInputStream(bytes))
+    val ingestionProperties = getIngestionProperties(parameters.writeOptions, parameters.coordinates.database, parameters.coordinates.table.get)
+    val status = streamingClient.ingestFromStream(streamSourceInfo, ingestionProperties)
+    status.getIngestionStatusCollection.forEach(
+      item => {
+        KDSU.logInfo(
+          myName, s"BatchId $batchIdForTracing IngestionStatus { " +
             s"status: '${item.status.toString}', " +
             s"details: ${item.details}, " +
             s"activityId: ${item.activityId}, " +
             s"errorCode: ${item.errorCode}, " +
             s"errorCodeString: ${item.errorCodeString}" +
-        "}") })
-    }
+            "}")
+      })
   }
 
   private def ingestToTemporaryTableByWorkers(

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -251,7 +251,7 @@ object KustoWriter {
     KDSU.logInfo(myName, s"Streaming batch $batchIdForTracing of ${bytes.length} bytes (max allowed is ${KCONST.MaxStreamingBytes} bytes)")
     if (bytes.length > KCONST.MaxStreamingBytes) {
       KDSU.logWarn(myName, s"Streaming micro-batch '$batchIdForTracing' exceeds streaming threshold '${KCONST.MaxStreamingBytes}' bytes. " +
-        "Falling back to batch ingestion.")
+        "Falling back to queued ingestion.")
       ingestToTemporaryTableByWorkers(batchIdForTracing, rows, partitionsResults, parameters)
     }
     else {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -180,6 +180,10 @@ private[kusto] object CslCommandsGenerator {
     s""".alter table ${KustoQueryUtils.normalizeTableName(tmpTableName)} policy auto_delete @'{"ExpiryDate": "${expiryDate.toString}","DeleteIfNotEmpty": true }' """
   }
 
+  def generateTableAlterStreamIngestionCommand(tmpTableName: String): String = {
+    s""".alter table ${KustoQueryUtils.normalizeTableName(tmpTableName)} policy streamingingestion enable"""
+  }
+
   def generateShowTableMappingsCommand(tableName: String, kind: String): String = {
     s""".show table ${KustoQueryUtils.normalizeTableName(tableName)} ingestion ${kind.toLowerCase()} mappings"""
   }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -184,6 +184,10 @@ private[kusto] object CslCommandsGenerator {
     s""".alter table ${KustoQueryUtils.normalizeTableName(tmpTableName)} policy streamingingestion enable"""
   }
 
+  def generateClearStreamingIngestionCacheCommand(tmpTableName: String): String = {
+    s""".clear table ${KustoQueryUtils.normalizeTableName(tmpTableName)} cache streamingingestion schema"""
+  }
+
   def generateShowTableMappingsCommand(tableName: String, kind: String): String = {
     s""".show table ${KustoQueryUtils.normalizeTableName(tableName)} ingestion ${kind.toLowerCase()} mappings"""
   }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
@@ -93,6 +93,10 @@ class ExtendedKustoClient(val engineKcsb: ConnectionStringBuilder, val ingestKcs
         }
         tmpTableSchema = tableSchemaBuilder.toString
         executeEngine(database, generateTableCreateCommand(table, tmpTableSchema), crp)
+        if (writeOptions.writeMode == WriteMode.Stream) {
+          executeEngine(database, generateTableAlterStreamIngestionCommand(table), crp)
+          executeEngine(database, generateClearStreamingIngestionCacheCommand(table), crp)
+        }
       }
     } else {
       // Table exists. Parse kusto table schema and check if it matches the dataframes schema

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -29,6 +29,7 @@ object KustoConstants {
   val DefaultTimeoutQueueing: Int = TimeUnit.SECONDS.toMillis(40).toInt
   val MaxIngestRetryAttempts = 2
   val MaxCommandsRetryAttempts = 4
+  val MaxStreamingBytes: Int = 4 * OneMegaByte
   val EmptyString = ""
   val DefaultMaximumIngestionTime: FiniteDuration = FiniteDuration.apply(
     MaxIngestRetryAttempts * (DefaultExecutionQueueing + DefaultTimeoutQueueing) + 2000,"millis")

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -10,6 +10,7 @@ import com.microsoft.kusto.spark.authentication._
 import com.microsoft.kusto.spark.common.{KustoCoordinates, KustoDebugOptions}
 import com.microsoft.kusto.spark.datasink.KustoWriter.TempIngestionTablePrefix
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
+import com.microsoft.kusto.spark.datasink.WriteMode.WriteMode
 import com.microsoft.kusto.spark.datasink._
 import com.microsoft.kusto.spark.datasource.ReadMode.ReadMode
 import com.microsoft.kusto.spark.datasource._
@@ -308,7 +309,7 @@ object KustoDataSourceUtils {
     var tableCreation: SinkTableCreationMode = SinkTableCreationMode.FailIfNotExist
     var tableCreationParam: Option[String] = None
     var isAsync: Boolean = false
-    var isTransactionalMode: Boolean = false
+    var writeMode: WriteMode = WriteMode.Transactional
     var writeModeParam: Option[String] = None
     var batchLimit: Int = 0
     var minimalExtentsCountForSplitMergePerNode: Int = 0
@@ -321,13 +322,13 @@ object KustoDataSourceUtils {
     }
     try {
       writeModeParam = parameters.get(KustoSinkOptions.KUSTO_WRITE_MODE)
-      isTransactionalMode = if (writeModeParam.isEmpty) true else WriteMode.withName(writeModeParam.get) == WriteMode.Transactional
+      writeMode = if (writeModeParam.isEmpty) WriteMode.Transactional else WriteMode.withName(writeModeParam.get)
     } catch {
       case _: NoSuchElementException => throw new InvalidParameterException(s"No such WriteMode option: '${writeModeParam.get}'")
     }
     val userTempTableName = parameters.get(KustoSinkOptions.KUSTO_TEMP_TABLE_NAME)
-    if (userTempTableName.isDefined && (tableCreation == SinkTableCreationMode.CreateIfNotExist || !isTransactionalMode)) {
-      throw new InvalidParameterException("tempTableName can't be used with CreateIfNotExist or Queued write mode.")
+    if (userTempTableName.isDefined && (tableCreation == SinkTableCreationMode.CreateIfNotExist || writeMode != WriteMode.Transactional)) {
+      throw new InvalidParameterException("tempTableName can only be used with FailIfNotExists table create mode and Transactional write mode.")
     }
     isAsync = parameters.getOrElse(KustoSinkOptions.KUSTO_WRITE_ENABLE_ASYNC, "false").trim.toBoolean
     val pollingOnDriver = parameters.getOrElse(KustoSinkOptions.KUSTO_POLLING_ON_DRIVER, "false").trim.toBoolean
@@ -368,7 +369,7 @@ object KustoDataSourceUtils {
       maxRetriesOnMoveExtents,
       minimalExtentsCountForSplitMergePerNode,
       adjustSchema,
-      isTransactionalMode,
+      writeMode,
       userTempTableName,
       disableFlushImmediately,
       ensureNoDupBlobs
@@ -381,7 +382,7 @@ object KustoDataSourceUtils {
     logInfo("parseSinkParameters", s"Parsed write options for sink: {'table': '${
       sourceParameters.
         kustoCoordinates.table
-    }', 'timeout': '${writeOptions.timeout}, 'async': ${writeOptions.isAsync}, " +
+    }', 'timeout': '${writeOptions.timeout}, 'async': ${writeOptions.isAsync}, 'writeMode': ${writeOptions.writeMode}, " +
       s"'tableCreationMode': ${writeOptions.tableCreateOptions}, 'writeLimit': ${writeOptions.writeResultLimit}, 'batchLimit': ${writeOptions.batchLimit}" +
       s", 'timeout': ${writeOptions.timeout}, 'timezone': ${writeOptions.timeZone}, " +
       s"'ingestionProperties': $ingestionPropertiesAsJson, 'requestId': '${sourceParameters.requestId}', 'pollingOnDriver': ${writeOptions.pollingOnDriver}," +

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -309,7 +309,7 @@ object KustoDataSourceUtils {
     var tableCreation: SinkTableCreationMode = SinkTableCreationMode.FailIfNotExist
     var tableCreationParam: Option[String] = None
     var isAsync: Boolean = false
-    var writeMode: WriteMode = WriteMode.Transactional
+    var writeMode: WriteMode = WriteMode.Queued
     var writeModeParam: Option[String] = None
     var batchLimit: Int = 0
     var minimalExtentsCountForSplitMergePerNode: Int = 0

--- a/connector/src/test/scala/com/microsoft/kusto/spark/ExtendedKustoClientTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/ExtendedKustoClientTests.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.{Client, ClientRequestProperties, KustoOperationResult, KustoResultSetTable}
 import com.microsoft.kusto.spark.common.KustoCoordinates
-import com.microsoft.kusto.spark.datasink.{SparkIngestionProperties, WriteOptions}
+import com.microsoft.kusto.spark.datasink.{SparkIngestionProperties, WriteMode, WriteOptions}
 import com.microsoft.kusto.spark.utils.ExtendedKustoClient
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.mockito.Matchers.any
@@ -61,7 +61,7 @@ class ExtendedKustoClientTests extends AnyFlatSpec with Matchers {
     val stubbedClient = new ExtendedKustoClientStub(null, null, "", null)
     val struct = StructType(Array(StructField("colA", StringType, nullable = true)))
     stubbedClient.initializeTablesBySchema(kustoCoordinates, tempTable, struct,  Array(new ObjectMapper().readTree("""{"Type":"System.String",
-      "CslType":"string", "Name":"name"}""")), WriteOptions(isTransactionalMode = false), null, true)
+      "CslType":"string", "Name":"name"}""")), WriteOptions(writeMode = WriteMode.Queued), null, true)
     verify(stubbedClient.engineClient, times(0)).execute(any(), any(), any())
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -25,6 +25,8 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll{
   private val myName = this.getClass.getSimpleName
   private val rowId = new AtomicInteger(1)
   private val rowId2 = new AtomicInteger(1)
+  private val timeoutMs: Int = 8 * 60 * 1000 // 8 minutes
+  private val sleepTimeTillTableCreate: Int = 3 * 60 * 1000 // 2 minutes
 
   private def newRow(): String = s"row-${rowId.getAndIncrement()}"
   private def newAllDataTypesRow(v: Int): (String, Int, java.sql.Date, Boolean, Short, Byte, Float ,java.sql.Timestamp, Double, java.math.BigDecimal, Long) ={
@@ -181,8 +183,6 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll{
       .mode(SaveMode.Append)
       .save()
 
-    val timeoutMs: Int = 8 * 60 * 1000 // 8 minutes
-
     KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, database, expectedNumberOfRows, timeoutMs, tableCleanupPrefix = prefix)
   }
 
@@ -207,7 +207,32 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll{
       .mode(SaveMode.Append)
       .save()
 
-    val timeoutMs: Int = 8 * 60 * 1000 // 8 minutes
+    KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, database, expectedNumberOfRows, timeoutMs, tableCleanupPrefix = prefix)
+  }
+
+  "KustoBatchSinkStreaming" should "ingest structured data to a Kusto cluster in stream ingestion mode" taggedAs KustoE2E in {
+    import spark.implicits._
+    val df = rows.toDF("name", "value")
+    val prefix = "KustoBatchSinkE2EIngestStreamIngestion"
+    val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
+    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://$cluster.kusto.windows.net", appId, appKey, authority)
+    val kustoAdminClient = ClientFactory.createClient(engineKcsb)
+    kustoAdminClient.execute(database, generateTempTableCreateCommand(table, columnsTypesAndNames = "ColA:string, ColB:int"))
+    kustoAdminClient.execute(database, generateTableAlterStreamIngestionCommand(table))
+
+    Thread.sleep(sleepTimeTillTableCreate)
+
+    df.write
+      .format("com.microsoft.kusto.spark.datasource")
+      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_TABLE, table)
+      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
+      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
+      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_WRITE_MODE, "Stream")
+      .mode(SaveMode.Append)
+      .save()
 
     KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, database, expectedNumberOfRows, timeoutMs, tableCleanupPrefix = prefix)
   }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -4,7 +4,7 @@ import com.microsoft.azure.kusto.data.ClientFactory
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.kusto.spark.KustoTestUtils.KustoConnectionOptions
 import com.microsoft.kusto.spark.common.KustoDebugOptions
-import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties}
+import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties, WriteMode}
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.streaming.Trigger
@@ -132,5 +132,40 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
     kustoQ.start().awaitTermination()
 
     KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, kustoConnectionOptions.database, expectedNumberOfRows, timeoutMs, tableCleanupPrefix = prefix)
+  }
+
+  "KustoStreamingSinkStreamingIngestion" should "ingest structured data to a Kusto cluster using stream ingestion" taggedAs KustoE2E in {
+    val prefix = "KustoStreamingSparkE2E_StreamIngest"
+    val table = s"${prefix}_${UUID.randomUUID().toString.replace("-", "_")}"
+    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
+      kustoConnectionOptions.appId, kustoConnectionOptions.appKey, kustoConnectionOptions.authority)
+    val kustoAdminClient = ClientFactory.createClient(engineKcsb)
+    kustoAdminClient.execute(kustoConnectionOptions.database, generateTempTableCreateCommand(table, columnsTypesAndNames = "ColA:string, ColB:int"))
+    kustoAdminClient.execute(kustoConnectionOptions.database, generateTableAlterStreamIngestionCommand(table))
+    Thread.sleep(sleepTimeTillTableCreate)
+
+    val csvDf = spark
+      .readStream
+      .schema(customSchema)
+      .csv(csvPath)
+
+    spark.conf.set("spark.sql.streaming.checkpointLocation", "target/temp/checkpoint")
+
+    val kustoQ = csvDf
+      .writeStream
+      .format("com.microsoft.kusto.spark.datasink.KustoSinkProvider")
+      .options(Map(
+        KustoSinkOptions.KUSTO_CLUSTER -> kustoConnectionOptions.cluster,
+        KustoSinkOptions.KUSTO_TABLE -> table,
+        KustoSinkOptions.KUSTO_DATABASE -> kustoConnectionOptions.database,
+        KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
+        KustoSinkOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey,
+        KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID -> kustoConnectionOptions.authority,
+        KustoSinkOptions.KUSTO_WRITE_MODE -> WriteMode.Stream.toString))
+      .trigger(Trigger.Once)
+
+    kustoQ.start().awaitTermination()
+
+    KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, kustoConnectionOptions.database, expectedNumberOfRows, timeoutMs - sleepTimeTillTableCreate, tableCleanupPrefix = prefix)
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -142,7 +142,7 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(kustoConnectionOptions.database, generateTempTableCreateCommand(table, columnsTypesAndNames = "ColA:string, ColB:int"))
     kustoAdminClient.execute(kustoConnectionOptions.database, generateTableAlterStreamIngestionCommand(table))
-    Thread.sleep(sleepTimeTillTableCreate)
+    kustoAdminClient.execute(kustoConnectionOptions.database, generateClearStreamingIngestionCacheCommand(table))
 
     val csvDf = spark
       .readStream
@@ -166,6 +166,39 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
     kustoQ.start().awaitTermination()
 
-    KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, kustoConnectionOptions.database, expectedNumberOfRows, timeoutMs - sleepTimeTillTableCreate, tableCleanupPrefix = prefix)
+    KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, kustoConnectionOptions.database, expectedNumberOfRows, 10000, tableCleanupPrefix = prefix)
+  }
+
+  "KustoStreamingSinkStreamingIngestionWithCreate" should "ingest structured data to a Kusto cluster using stream ingestion" taggedAs KustoE2E in {
+    val prefix = "KustoStreamingSparkE2E_StreamIngest"
+    val table = s"${prefix}_${UUID.randomUUID().toString.replace("-", "_")}"
+    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
+      kustoConnectionOptions.appId, kustoConnectionOptions.appKey, kustoConnectionOptions.authority)
+    val kustoAdminClient = ClientFactory.createClient(engineKcsb)
+
+    val csvDf = spark
+      .readStream
+      .schema(customSchema)
+      .csv(csvPath)
+
+    spark.conf.set("spark.sql.streaming.checkpointLocation", "target/temp/checkpoint")
+
+    val kustoQ = csvDf
+      .writeStream
+      .format("com.microsoft.kusto.spark.datasink.KustoSinkProvider")
+      .options(Map(
+        KustoSinkOptions.KUSTO_CLUSTER -> kustoConnectionOptions.cluster,
+        KustoSinkOptions.KUSTO_TABLE -> table,
+        KustoSinkOptions.KUSTO_DATABASE -> kustoConnectionOptions.database,
+        KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
+        KustoSinkOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey,
+        KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID -> kustoConnectionOptions.authority,
+        KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS -> SinkTableCreationMode.CreateIfNotExist.toString,
+        KustoSinkOptions.KUSTO_WRITE_MODE -> WriteMode.Stream.toString))
+      .trigger(Trigger.Once)
+
+    kustoQ.start().awaitTermination()
+
+    KustoTestUtils.validateResultsAndCleanup(kustoAdminClient, table, kustoConnectionOptions.database, expectedNumberOfRows, 10000, tableCleanupPrefix = prefix)
   }
 }

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -77,7 +77,7 @@ All the options that can be used in the Kusto Sink can be found in KustoSinkOpti
   to load data into Kusto. Streaming ingestion is useful for loading data when you need low latency between ingestion and query.
   *Note - Stream ingestion must be enabled on the destination table or cluster (see [here](https://learn.microsoft.com/en-us/azure/data-explorer/ingest-data-streaming?tabs=azure-portal%2Cjava) for details).
   Stream ingestion has a [data size limit](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/streamingingestionpolicy) of 4 MB. 
-  If a micro-batch exceeds this size, the connector will fall back to the `Queued` write mode.
+  If a request exceeds this size, it will be broken into multiple appropriately sized chunks.
 
 * **KUSTO_POLLING_ON_DRIVER**:
   'pollingOnDriver' - If set to false (default) Kusto Spark will create a new job for the final two ingestion steps done after processing the data, so that the write operation doesn't seem to 'hang' on the Spark UI.

--- a/docs/KustoSink.md
+++ b/docs/KustoSink.md
@@ -72,7 +72,12 @@ All the options that can be used in the Kusto Sink can be found in KustoSinkOpti
   available up until the service finishes loading it, failures on the service side will not propagate to Spark but can still be seen.
   'Queued' mode scales better than the Transactional mode as it doesn't need to do track each individual ingestion created by the workers.
   This can also solve many problems faced when using Transactional mode intermediate table and better work with Materialized views.
-  *Note - Both modes are using Kusto native queued ingestion as described [here](https://learn.microsoft.com/azure/data-explorer/kusto/api/netfx/about-kusto-ingest#queued-ingestion).
+  *Note - Both modes are using Kusto native queued ingestion as described [here](https://learn.microsoft.com/azure/data-explorer/kusto/api/netfx/about-kusto-ingest#queued-ingestion).  
+  'Stream' mode - uses [stream ingestion](https://learn.microsoft.com/en-us/azure/data-explorer/ingest-data-streaming?tabs=azure-portal%2Cjava) 
+  to load data into Kusto. Streaming ingestion is useful for loading data when you need low latency between ingestion and query.
+  *Note - Stream ingestion must be enabled on the destination table or cluster (see [here](https://learn.microsoft.com/en-us/azure/data-explorer/ingest-data-streaming?tabs=azure-portal%2Cjava) for details).
+  Stream ingestion has a [data size limit](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/streamingingestionpolicy) of 4 MB. 
+  If a micro-batch exceeds this size, the connector will fall back to the `Queued` write mode.
 
 * **KUSTO_POLLING_ON_DRIVER**:
   'pollingOnDriver' - If set to false (default) Kusto Spark will create a new job for the final two ingestion steps done after processing the data, so that the write operation doesn't seem to 'hang' on the Spark UI.


### PR DESCRIPTION
#### Pull Request Description

This pull request contains code (& tests) to introduce [kusto streaming ingestion](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/streamingingestionpolicy) support in the Spark Kusto Connector. 
Stream ingestion is enabled by setting the [KUSTO_WRITE_MODE](https://github.com/Azure/azure-kusto-spark/blob/master/docs/KustoSink.md#supported-options) option to `Stream`. 

Notes
-  Stream ingestion must be enabled on the destination Table and/or Cluster (see [here](https://learn.microsoft.com/en-us/azure/data-explorer/ingest-data-streaming?tabs=azure-portal%2Cjava) for details).
- Stream ingestion has a [data size limit](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/streamingingestionpolicy) of 4 MB. If a partition exceeds this size, the connector will send multiple appropriately sized requests.

---

**Breaking Changes:**
- None

**Features:**
- https://github.com/Azure/azure-kusto-spark/issues/222

**Fixes:**
- None
