### PR TITLE
Bugfix/sparkversion change2.4

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -281,6 +281,7 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
+                            <addScalacArgs>-target:jvm-1.8</addScalacArgs>
                             <args>
                                 <arg>-dependencyfile</arg>
                                 <arg>${project.build.directory}/.scala_dependencies</arg>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -281,7 +281,6 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <addScalacArgs>-target:jvm-1.8</addScalacArgs>
                             <args>
                                 <arg>-dependencyfile</arg>
                                 <arg>${project.build.directory}/.scala_dependencies</arg>

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCacheTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCacheTest.scala
@@ -36,7 +36,7 @@ class KustoAzureFsSetupCacheTest extends AnyFunSuite {
       // The cache is expired, so it will be re-set.The checkIfRefreshNeeded will return false, but the state is already true.
       (Instant.now(Clock.systemUTC()).minus(3 * KustoConstants.SparkSettingsRefreshMinutes, ChronoUnit.MINUTES), true),
       // This will be within the cache interval and also the flag is set to true
-      (Instant.now(Clock.systemUTC()).minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES) , true),
+      (Instant.now(Clock.systemUTC()).minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES) , true)
     )
 
     forAll(dataToTest) { (now: Instant, expectedResult: Boolean) =>
@@ -51,7 +51,7 @@ class KustoAzureFsSetupCacheTest extends AnyFunSuite {
       // The cache is expired, so it will be re-set.The checkIfRefreshNeeded will return false, but the state is already true.
       (Instant.now(Clock.systemUTC()).minus(3 * KustoConstants.SparkSettingsRefreshMinutes, ChronoUnit.MINUTES), true),
       // This will be within the cache interval and also the flag is set to true
-      (Instant.now(Clock.systemUTC()).minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES), false),
+      (Instant.now(Clock.systemUTC()).minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES), false)
     )
 
     forAll(dataToTest) { (now: Instant, expectedResult: Boolean) =>
@@ -75,7 +75,7 @@ class KustoAzureFsSetupCacheTest extends AnyFunSuite {
       // Container name changes. This should get set
       ("container2","account1", "secret2", Instant.now(Clock.systemUTC()), false),
       // Since the key exists, this should return true
-      ("container2","account1", "secret2", Instant.now(), true),
+      ("container2","account1", "secret2", Instant.now(), true)
     )
 
     forAll(dataToTest) { (container:String, account: String, secret: String, now: Instant, expectedResult: Boolean) =>

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
     <properties>
         <revision>4.0.0</revision>
         <!-- Spark dependencies -->
-        <scala.version.major>2.12</scala.version.major>
-        <scala.version.minor>17</scala.version.minor>
-        <spark.version.major>3.0</spark.version.major>
-        <spark.version.minor>1</spark.version.minor>
+        <scala.version.major>2.11</scala.version.major>
+        <scala.version.minor>12</scala.version.minor>
+        <spark.version.major>2.4</spark.version.major>
+        <spark.version.minor>0</spark.version.minor>
 
         <!-- other dependencies -->
         <azure.bom.version>1.2.4</azure.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <revision>4.0.0</revision>
         <!-- Spark dependencies -->
-        <scala.version.major>2.11</scala.version.major>
+        <scala.version.major>2.12</scala.version.major>
         <scala.version.minor>12</scala.version.minor>
         <spark.version.major>2.4</spark.version.major>
         <spark.version.minor>0</spark.version.minor>


### PR DESCRIPTION
#### Pull Request Description

For the JDK 11 compat to work with scala 2.4. We will need to use scala 2.12. 

