### PR TITLE
*Update to the right scala version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <revision>5.0.0</revision>
         <!-- Spark dependencies -->
-        <scala.version.major>2.12</scala.version.major>
+        <scala.version.major>2.11</scala.version.major>
         <scala.version.minor>12</scala.version.minor>
         <spark.version.major>2.4</spark.version.major>
         <spark.version.minor>0</spark.version.minor>


### PR DESCRIPTION
#### Pull Request Description

Spark 2.4 has to be compiled against scala 2.11. Make that fix. This was changed when JDK11 was adopted. Reversing this change

