### PR TITLE
Spark ingestion properties clone

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -127,6 +127,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage</artifactId>
+            <version>${azure-storage.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-security-keyvault-secrets</artifactId>
             <exclusions>

--- a/connector/src/main/resources/log4j.properties
+++ b/connector/src/main/resources/log4j.properties
@@ -1,0 +1,12 @@
+# Set everything to be logged to the console
+log4j.rootLogger=INFO, KustoConnector
+log4j.appender.KustoConnector=org.apache.log4j.ConsoleAppender
+log4j.appender.KustoConnector.target=System.out
+log4j.appender.KustoConnector.layout=org.apache.log4j.PatternLayout
+log4j.appender.KustoConnector.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -111,7 +111,7 @@ object KustoWriter {
       val partitionsResults = rdd.sparkContext.collectionAccumulator[PartitionResult]
       val parameters = KustoWriteResource(authentication = authentication, coordinates = tableCoordinates,
         schema = data.schema, writeOptions = rebuiltOptions, tmpTableName = tmpTableName)
-      val sinkStartTime = getCreationTime(stagingTableIngestionProperties, tableCoordinates)
+      val sinkStartTime = getCreationTime(stagingTableIngestionProperties)
       if (writeOptions.isAsync) {
         val asyncWork = rdd.foreachPartitionAsync { rows => ingestRowsIntoTempTbl(rows, batchIdIfExists,
           partitionsResults,parameters) }
@@ -157,12 +157,9 @@ object KustoWriter {
     }
   }
 
-  private def getCreationTime(ingestionProperties: SparkIngestionProperties, tableCoordinates: KustoCoordinates): Instant = {
-    val startTime = Option(ingestionProperties.toIngestionProperties(tableCoordinates.database,
-      tableCoordinates.table.get).getAdditionalProperties.get("startTime"))
-
-    startTime match {
-      case Some(creationTimeVal) => Instant.parse(creationTimeVal)
+  private def getCreationTime(ingestionProperties: SparkIngestionProperties): Instant = {
+    Option(ingestionProperties.creationTime) match {
+      case Some(creationTimeVal) => creationTimeVal
       case None => Instant.now(Clock.systemUTC())
     }
   }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/SparkIngestionProperties.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/SparkIngestionProperties.scala
@@ -85,6 +85,8 @@ object SparkIngestionProperties {
     cloned.setIngestIfNotExists(ingestionProperties.getIngestIfNotExists)
     cloned.setDataFormat(ingestionProperties.getDataFormat)
     cloned.setIngestionMapping(ingestionProperties.getIngestionMapping)
+    cloned.setAdditionalProperties(ingestionProperties.getAdditionalProperties)
+    cloned.setFlushImmediately(ingestionProperties.getFlushImmediately)
     cloned
   }
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -56,7 +56,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     Try(kustoAdminClient.get.execute(kustoConnectionOptions.database, generateAlterIngestionBatchingPolicyCommand(
       "database",
       kustoConnectionOptions.database,
-      "{\"MaximumBatchingTimeSpan\":\"00:00:10\", \"MaximumNumberOfItems\": 500, \"MaximumRawDataSizeMB\": 1024}"))) match {
+      "{\"\"MaximumBatchingTimeSpan\"\":\"\"00:00:10\"\", \"\"MaximumNumberOfItems\"\": 500, \"\"MaximumRawDataSizeMB\"\": 1024}"))) match {
       case Success(_) => KDSU.logDebug(myName,"Ingestion policy applied")
       case Failure(exception:Throwable) => KDSU.reportExceptionAndThrow(myName, exception,"Updating database batching policy", shouldNotThrow = true)
     }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/SparkIngestionPropertiesTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/SparkIngestionPropertiesTest.scala
@@ -1,0 +1,42 @@
+package com.microsoft.kusto.spark.utils
+
+
+import com.microsoft.kusto.spark.datasink.SparkIngestionProperties
+import org.apache.commons.lang3.builder.EqualsBuilder
+
+import java.time.{Clock, Instant}
+import org.scalatest.flatspec.AnyFlatSpec
+
+
+class SparkIngestionPropertiesTest extends AnyFlatSpec {
+
+  "props" should "be same after clone" in {
+    val ingestByTags = new java.util.ArrayList[String]
+    val tag = "dammyTag"
+    ingestByTags.add(tag)
+
+    val sp = new SparkIngestionProperties(
+      flushImmediately = true,
+      csvMappingNameReference = "mapy",
+      ingestByTags = ingestByTags,
+      creationTime = Instant.now(Clock.systemUTC()),
+      ingestIfNotExists = ingestByTags,
+      additionalTags = ingestByTags,
+      csvMapping = "[{\"Column\": \"a\", \"Properties\": {\"Ordinal\": \"0\"}}]"
+    )
+    val stringProps = sp.toString
+    val spFromString = SparkIngestionProperties.fromString(stringProps)
+
+    assert(EqualsBuilder.reflectionEquals(spFromString, sp))
+    val ingestByTags2 = new java.util.ArrayList[String]
+    val tag2 = "dammyTag2"
+    ingestByTags.add(tag2)
+    sp.ingestByTags = ingestByTags2
+    assert(!EqualsBuilder.reflectionEquals(spFromString, sp))
+
+    val ingestionProperties = spFromString
+      .toIngestionProperties("database", "tableName")
+    val cloned = SparkIngestionProperties.cloneIngestionProperties(ingestionProperties)
+    assert(EqualsBuilder.reflectionEquals(ingestionProperties, cloned))
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <spark.version.minor>1</spark.version.minor>
         <!-- other dependencies -->
         <azure.bom.version>1.2.4</azure.bom.version>
+        <!-- Deprecate only after full migration to azure storage 12-->
+        <azure-storage.version>8.6.6</azure-storage.version>
         <commons.lang3.version>3.9</commons.lang3.version>
         <fasterxml.jackson.version>[2.11.0,2.13.0)</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.13.4.2</fasterxml.jackson.databind.version>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -54,6 +54,16 @@
 
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
**Fixes:**
- Spark ingestion properties clone was bad, impacted only users that use flashImmediately
- Missing dependency on old azure storage