### PR TITLE
Retry for ingestion Resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
           java-version: 8
           cache: 'maven'
       - name: Run the Maven verify phase
-#        env:
-#          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
-#          kustoAadAppSecret: ${{secrets.APP_SECRET}}
-#          kustoDatabase: ${{secrets.DATABASE}}
-#          kustoCluster: ${{secrets.CLUSTER}}
-#          SecretPath: ${{secrets.SECRET_PATH}}
-#          kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{secrets.APP_ID}} -DkustoAadAuthorityID=${{secrets.TENANT_ID}} -DkustoAadAppSecret=${{secrets.APP_SECRET}} -DkustoDatabase=${{secrets.DATABASE}} -DkustoCluster=${{secrets.CLUSTER}} -DSecretPath=${{secrets.SECRET_PATH}}
+        env:
+          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
+          kustoAadAppSecret: ${{secrets.APP_SECRET}}
+          kustoDatabase: ${{secrets.DATABASE}}
+          kustoCluster: ${{secrets.CLUSTER}}
+          SecretPath: ${{secrets.SECRET_PATH}}
+          kustoAadAppId: ${{secrets.APP_ID}}
+        run: mvn clean verify
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,16 @@ jobs:
           java-version: 8
           cache: 'maven'
       - name: Run the Maven verify phase
+        env:
+          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
+          kustoAadAppSecret: ${{secrets.APP_SECRET}}
+          kustoDatabase: ${{secrets.DATABASE}}
+          kustoCluster: ${{secrets.CLUSTER}}
+          SecretPath: ${{secrets.SECRET_PATH}}
+          kustoAadAppId: ${{secrets.APP_ID}}
         run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DSecretPath=${{secrets.SECRET_PATH}}
+      - name: debug Print env
+        run: echo "------>>> ENV- $kustoCluster"
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           kustoCluster: ${{secrets.CLUSTER}}
           SecretPath: ${{secrets.SECRET_PATH}}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify
+        run: mvn clean verify -DkustoAadAppId=${{secrets.APP_ID}} -DkustoAadAuthorityID=${{secrets.TENANT_ID}} -DkustoAadAppSecret=${{secrets.APP_SECRET}} -DkustoDatabase=${{secrets.DATABASE}} -DkustoCluster=${{secrets.CLUSTER}} -DSecretPath=${{secrets.SECRET_PATH}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: 8
           cache: 'maven'
       - name: Run the Maven verify phase
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} 
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DSecretPath=${{secrets.SECRET_PATH}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build Java
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Setup Java 8, build and run tests
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 8
+          cache: 'maven'
+      - name: Run the Maven verify phase
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} 
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            data/target/surefire-reports/*.xml
+            ingest/target/surefire-reports/*.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,14 @@ jobs:
           java-version: 8
           cache: 'maven'
       - name: Run the Maven verify phase
-        env:
-          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
-          kustoAadAppSecret: ${{secrets.APP_SECRET}}
-          kustoDatabase: ${{secrets.DATABASE}}
-          kustoCluster: ${{secrets.CLUSTER}}
-          SecretPath: ${{secrets.SECRET_PATH}}
-          kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DSecretPath=${{secrets.SECRET_PATH}}
-      - name: debug Print env
-        run: echo "------>>> ENV- $kustoCluster"
+#        env:
+#          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
+#          kustoAadAppSecret: ${{secrets.APP_SECRET}}
+#          kustoDatabase: ${{secrets.DATABASE}}
+#          kustoCluster: ${{secrets.CLUSTER}}
+#          SecretPath: ${{secrets.SECRET_PATH}}
+#          kustoAadAppId: ${{secrets.APP_ID}}
+        run: mvn clean verify -DkustoAadAppId=${{secrets.APP_ID}} -DkustoAadAuthorityID=${{secrets.TENANT_ID}} -DkustoAadAppSecret=${{secrets.APP_SECRET}} -DkustoDatabase=${{secrets.DATABASE}} -DkustoCluster=${{secrets.CLUSTER}} -DSecretPath=${{secrets.SECRET_PATH}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
           cache: 'maven'
       - name: Run the Maven verify phase
         env:
-          kustoAadAuthorityID: ${{secrets.TENANT_ID}}
-          kustoAadAppSecret: ${{secrets.APP_SECRET}}
-          kustoDatabase: ${{secrets.DATABASE}}
-          kustoCluster: ${{secrets.CLUSTER}}
-          SecretPath: ${{secrets.SECRET_PATH}}
+          kustoAadAuthorityID: ${{ secrets.TENANT_ID }}
+          kustoAadAppSecret: ${{ secrets.APP_SECRET }}
+          kustoDatabase: ${{ secrets.DATABASE }}
+          kustoCluster: ${{ secrets.CLUSTER }}
+          SecretPath: ${{ secrets.SECRET_PATH }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{secrets.APP_ID}} -DkustoAadAuthorityID=${{secrets.TENANT_ID}} -DkustoAadAppSecret=${{secrets.APP_SECRET}} -DkustoDatabase=${{secrets.DATABASE}} -DkustoCluster=${{secrets.CLUSTER}} -DSecretPath=${{secrets.SECRET_PATH}}
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DSecretPath=${{ secrets.SECRET_PATH }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -309,7 +309,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/exceptions/NoStorageContainersException.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/exceptions/NoStorageContainersException.scala
@@ -1,0 +1,5 @@
+package com.microsoft.kusto.spark.exceptions
+
+case class NoStorageContainersException(msg: String) extends scala.Exception(msg)  {
+
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/ExtendedKustoClientTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/ExtendedKustoClientTests.scala
@@ -7,7 +7,7 @@ import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.{SparkIngestionProperties, WriteOptions}
 import com.microsoft.kusto.spark.utils.ExtendedKustoClient
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, times, verify}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -40,7 +40,7 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
     sc.stop()
   }
-  private val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
 
   val csvPath: String = System.getProperty("path", "connector/src/test/resources/TestData/csv")
   val customSchema: StructType = new StructType().add("colA", StringType, nullable = true).add("colB", IntegerType, nullable = true)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -107,7 +107,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     // Create a new table.
     KDSU.logInfo("e2e","running KustoConnector")
     val crp = new ClientRequestProperties
-    crp.setTimeoutInMilliSec(2000)
+    crp.setTimeoutInMilliSec(60000)
     val ingestByTags = new java.util.ArrayList[String]
     val tag = "dammyTag"
     ingestByTags.add(tag)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -2,20 +2,15 @@ package com.microsoft.kusto.spark.utils
 
 import com.azure.storage.blob.BlobContainerClient
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
-import com.microsoft.azure.kusto.data.exceptions.DataServiceException
-import com.microsoft.azure.kusto.data.{Client, ClientRequestProperties, KustoOperationResult}
+import com.microsoft.azure.kusto.data.{Client, KustoOperationResult}
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
 import com.microsoft.azure.kusto.ingest.resources.ContainerWithSas
 import com.microsoft.azure.kusto.ingest.{IngestionResourceManager, QueuedIngestClient}
-import org.apache.http.HttpHost
-import org.apache.http.conn.HttpHostConnectException
 import org.mockito.Mockito
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.io.IOException
-import java.net.{ConnectException, InetAddress}
 import java.util.Collections
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.io.Source
@@ -43,7 +38,7 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
       }
     }
     // noMoreThanTwice()
-    mockIngestClient.getResourceManager _ expects() returning mockIngestionResourceManager
+    mockIngestClient.getResourceManager _ expects() atLeastOnce() returning mockIngestionResourceManager
     // Unfortunately we cannot Mock this class as there is a member variable that is a val and cannot be mocked
     new ExtendedKustoClient(new ConnectionStringBuilder("https://somecluster.eastus.kusto.windows.net/"),
       new ConnectionStringBuilder("https://ingest-somecluster.eastus.kusto.windows.net"), "somecluster") {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -1,41 +1,84 @@
 package com.microsoft.kusto.spark.utils
 
-import com.microsoft.azure.kusto.data.KustoOperationResult
+import com.azure.storage.blob.BlobContainerClient
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException
-import org.apache.commons.lang3.exception.ExceptionUtils
+import com.microsoft.azure.kusto.data.{Client, ClientRequestProperties, KustoOperationResult}
+import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
+import com.microsoft.azure.kusto.ingest.resources.ContainerWithSas
+import com.microsoft.azure.kusto.ingest.{IngestionResourceManager, QueuedIngestClient}
 import org.apache.http.HttpHost
 import org.apache.http.conn.HttpHostConnectException
+import org.mockito.Mockito
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.Ignore
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.net.{ConnectException, InetAddress}
-import scala.io.Source
 import java.io.IOException
+import java.net.{ConnectException, InetAddress}
+import java.util.Collections
+import scala.collection.JavaConverters.seqAsJavaListConverter
+import scala.io.Source
 
-@Ignore
+
 class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
   val CACHE_EXPIRY_SEC = 2
   val SLEEP_TIME_SEC = 10
+
+  private def createExtendedKustoMockClient(hasEmptyResults: Boolean = false, mockDmClient: Client,
+                                            mayBeExceptionThrown: Option[Throwable] = None): ExtendedKustoClient = {
+    val mockIngestClient: QueuedIngestClient = mock[QueuedIngestClient]
+    val mockIngestionResourceManager: IngestionResourceManager = Mockito.mock[IngestionResourceManager](classOf[IngestionResourceManager])
+
+    mayBeExceptionThrown match {
+      case Some(exception) => Mockito.when(mockIngestionResourceManager.getShuffledContainers)
+        .thenThrow(exception).thenThrow(exception).
+        thenAnswer(_ => List(getMockContainerWithSas(1), getMockContainerWithSas(2)).asJava)
+      case None => if (hasEmptyResults) {
+        Mockito.when(mockIngestionResourceManager.getShuffledContainers).
+          thenAnswer(_ => Collections.EMPTY_LIST)
+      } else {
+        Mockito.when(mockIngestionResourceManager.getShuffledContainers).
+          thenAnswer(_ => List(getMockContainerWithSas(1), getMockContainerWithSas(2)).asJava)
+      }
+    }
+    // noMoreThanTwice()
+    mockIngestClient.getResourceManager _ expects() returning mockIngestionResourceManager
+    // Unfortunately we cannot Mock this class as there is a member variable that is a val and cannot be mocked
+    new ExtendedKustoClient(new ConnectionStringBuilder("https://somecluster.eastus.kusto.windows.net/"),
+      new ConnectionStringBuilder("https://ingest-somecluster.eastus.kusto.windows.net"), "somecluster") {
+      override lazy val ingestClient: QueuedIngestClient = mockIngestClient
+      override lazy val dmClient: Client = mockDmClient
+    }
+  }
+
+  private def getMockContainerWithSas(index: Int): ContainerWithSas = {
+    val mockResultsOne: ContainerWithSas = Mockito.mock[ContainerWithSas](classOf[ContainerWithSas])
+    val blobResultsOne: BlobContainerClient = Mockito.mock[BlobContainerClient](classOf[BlobContainerClient])
+    Mockito.when(blobResultsOne.getBlobContainerUrl).thenAnswer(_ => s"https://sacc$index.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0")
+    Mockito.when(mockResultsOne.getSas).thenAnswer(_ => "?sv=2018-03-28&sr=c&sp=rw")
+    Mockito.when(mockResultsOne.getContainer).thenAnswer(_ => blobResultsOne)
+    mockResultsOne
+  }
   // happy path
   "ContainerProvider" should "return a container" in {
-    val extendedMockClient = mock[ExtendedKustoClient]
-    val extendedMockClientEmptyFail = mock[ExtendedKustoClient]
     val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result.json"), "v1")
+    val mockDmClient = mock[Client]
+    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *).
+      noMoreThanOnce().returning(kustoOperationResult)
+
     val clusterAlias = "ingest-cluster"
     val command = ".create tempstorage"
-    val ingestProviderEntryCreator = (c: ContainerAndSas) => c
     /*
       Invoke and test
      */
-    val containerProvider = new ContainerProvider(extendedMockClient, clusterAlias, command,CACHE_EXPIRY_SEC)
-    extendedMockClient.executeDM _ expects(command, None, *) noMoreThanOnce() returning kustoOperationResult
-    containerProvider.getContainer.containerUrl should(not be "")
+    val extendedMockClient = createExtendedKustoMockClient(mockDmClient = mockDmClient)
+    val containerProvider = new ContainerProvider(extendedMockClient, clusterAlias, command, CACHE_EXPIRY_SEC)
+    containerProvider.getContainer.containerUrl should (not be "")
     Some(containerProvider.getContainer.containerUrl) should contain oneOf
       ("https://sacc1.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0",
         "https://sacc2.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0")
-    containerProvider.getContainer.sas should(not be "")
+    containerProvider.getContainer.sas should (not be "")
 
     /* Second test that returns from cache. The test will fail if the client is invoked again as expectation is to call once */
     containerProvider.getContainer.containerUrl should (not be "")
@@ -43,90 +86,57 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
       ("https://sacc1.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0",
         "https://sacc2.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0")
     containerProvider.getContainer.sas should (not be "")
-
-
     /* Third test where the cache expires and the invocation throws an exception */
     Thread.sleep(SLEEP_TIME_SEC * 1000) // Milliseconds
-    extendedMockClient.executeDM _ expects(command, None, *) throws new DataServiceException(clusterAlias,"Cannot create temp storage",false)
     containerProvider.getContainer.containerUrl should (not be "")
     Some(containerProvider.getContainer.containerUrl) should contain oneOf
       ("https://sacc1.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0",
         "https://sacc2.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0")
     containerProvider.getContainer.sas should (not be "")
-    // The case where storageUris.nonEmpty is false. This will throw the exception as there is nothing to give from the cache
-    Thread.sleep(SLEEP_TIME_SEC * 1000) // Milliseconds
 
-    extendedMockClientEmptyFail.executeDM _ expects(command, None, *) throws new DataServiceException(clusterAlias, "Cannot create temp storage", false)
-    val emptyStorageContainerProvider = new ContainerProvider(extendedMockClientEmptyFail, clusterAlias, command,CACHE_EXPIRY_SEC)
+    // The case where storageUris.nonEmpty is false. This will throw the exception as there is nothing to give from the cache
+    Thread.sleep((SLEEP_TIME_SEC * 2) * 1000) // Milliseconds
+
+    val mockDmFailClient = mock[Client]
+    val extendedMockClientEmptyFail = createExtendedKustoMockClient(hasEmptyResults = true, mockDmClient = mockDmFailClient)
+    val emptyStorageContainerProvider = new ContainerProvider(extendedMockClientEmptyFail, clusterAlias, command, CACHE_EXPIRY_SEC)
     val caught =
-      intercept[DataServiceException] { // Result type: Assertion
+      intercept[RuntimeException] { // Result type: Assertion
         emptyStorageContainerProvider.getContainer
-    }
-    assert(caught.getMessage.indexOf("Cannot create temp storage") != -1)
+      }
+    assert(caught.getMessage.indexOf("Failed to allocate temporary storage") != -1)
   }
 
   "ContainerProvider" should "fail in the case when call succeeds but returns no storage" in {
-    val extendedMockClient = mock[ExtendedKustoClient]
-    val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result-empty.json"), "v1")
     val clusterAlias = "ingest-cluster"
     val command = ".create tempstorage"
-    val ingestProviderEntryCreator = (c: ContainerAndSas) => c
+
+    val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result-empty.json"), "v1")
+    val mockDmClient = mock[Client]
+    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *).
+      noMoreThanOnce() returning (kustoOperationResult)
+    /*
+      Invoke and test
+     */
+    val extendedMockClient = createExtendedKustoMockClient(hasEmptyResults = true, mockDmClient = mockDmClient)
     /*
       Invoke and test. In this case the call succeeds but returns no storage. This will hit the empty storage block
      */
     val containerProvider = new ContainerProvider(extendedMockClient, clusterAlias, command, CACHE_EXPIRY_SEC)
-    extendedMockClient.executeDM _ expects(command, None, *) noMoreThanOnce() returning kustoOperationResult
     the[RuntimeException] thrownBy containerProvider.getContainer should have message "Failed to allocate temporary storage"
   }
 
   "ContainerProvider" should "retry and return a container in case of a temporary HTTPException" in {
-    val extendedMockClient = mock[ExtendedKustoClient]
-    val extendedMockNoRootExceptionFail = mock[ExtendedKustoClient]
-    val extendedMockClientIOExceptionFail = mock[ExtendedKustoClient]
-    val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result.json"), "v1")
     val clusterAlias = "ingest-cluster"
     val command = ".get ingestion resources"
     /*
       Invoke and test
      */
+    val mockDmClient = mock[Client]
+    val extendedMockClient = createExtendedKustoMockClient(mockDmClient = mockDmClient,
+      mayBeExceptionThrown = Some(new IngestionServiceException("IOError when trying to retrieve CloudInfo")))
     val containerProvider = new ContainerProvider(extendedMockClient, clusterAlias, command, CACHE_EXPIRY_SEC)
-
-    // HttpHostConnectException -> IOException -> ConnectException This is the only hierarchy available
-    extendedMockClient.executeDM _ expects(command, None, *) throws new DataServiceException(clusterAlias,
-      "IOError when trying to retrieve CloudInfo",new HttpHostConnectException(
-      new IOException(new ConnectException("Connection timed out")),
-      HttpHost.create("kustocluster.centralus.kusto.windows.net"),
-      InetAddress.getLoopbackAddress),true) once() returning kustoOperationResult
-    // The first call will fail with a HttpHostConnectException. The second call will succeed
-    containerProvider.getContainer.containerUrl should (not be "")
-    Some(containerProvider.getContainer.containerUrl) should contain oneOf
-      ("https://sacc1.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0",
-        "https://sacc2.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0")
-    containerProvider.getContainer.sas should (not be "")
-
-    // Test where the root exception below it is empty, It will fail
-    extendedMockNoRootExceptionFail.executeDM _ expects(command, None, *) throws new DataServiceException(clusterAlias,
-      "No root exception", false)
-    val noRootExceptionContainerProvider = new ContainerProvider(extendedMockNoRootExceptionFail, clusterAlias, command,
-      CACHE_EXPIRY_SEC)
-    val caught =
-      intercept[DataServiceException] { // Result type: Assertion
-        noRootExceptionContainerProvider.getContainer
-      }
-    assert(caught.getMessage.indexOf("No root exception") != -1)
-
-
-    // Test where the root exception below it is not a HttpHostConnectException. It will fail
-    extendedMockClientIOExceptionFail.executeDM _ expects(command, None, *) throws new DataServiceException(clusterAlias,
-      "No root exception", new IOException(new ConnectException("IOError when trying to retrieve CloudInfo")), true)
-    val ioExceptionContainerProvider = new ContainerProvider(extendedMockClientIOExceptionFail, clusterAlias, command,
-      CACHE_EXPIRY_SEC)
-    val ioErrorCaught =
-      intercept[DataServiceException] { // Result type: Assertion
-        ioExceptionContainerProvider.getContainer
-      }
-    assert(ioErrorCaught.getMessage.indexOf("No root exception") != -1)
-    assert(ExceptionUtils.getRootCause(ioErrorCaught).getMessage.indexOf("IOError when trying to retrieve CloudInfo") != -1)
+    the[IngestionServiceException] thrownBy containerProvider.getContainer should have message "IOError when trying to retrieve CloudInfo"
   }
 
   private def readTestSource(fileName: String): String = {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -26,11 +26,11 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
   val SLEEP_TIME_SEC = 10
 
   private def createExtendedKustoMockClient(hasEmptyResults: Boolean = false, mockDmClient: Client,
-                                            mayBeExceptionThrown: Option[Throwable] = None): ExtendedKustoClient = {
+                                            maybeExceptionThrown: Option[Throwable] = None): ExtendedKustoClient = {
     val mockIngestClient: QueuedIngestClient = mock[QueuedIngestClient]
     val mockIngestionResourceManager: IngestionResourceManager = Mockito.mock[IngestionResourceManager](classOf[IngestionResourceManager])
 
-    mayBeExceptionThrown match {
+    maybeExceptionThrown match {
       case Some(exception) => Mockito.when(mockIngestionResourceManager.getShuffledContainers)
         .thenThrow(exception).thenThrow(exception).
         thenAnswer(_ => List(getMockContainerWithSas(1), getMockContainerWithSas(2)).asJava)
@@ -134,7 +134,7 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
      */
     val mockDmClient = mock[Client]
     val extendedMockClient = createExtendedKustoMockClient(mockDmClient = mockDmClient,
-      mayBeExceptionThrown = Some(new IngestionServiceException("IOError when trying to retrieve CloudInfo")))
+      maybeExceptionThrown = Some(new IngestionServiceException("IOError when trying to retrieve CloudInfo")))
     val containerProvider = new ContainerProvider(extendedMockClient, clusterAlias, command, CACHE_EXPIRY_SEC)
     the[IngestionServiceException] thrownBy containerProvider.getContainer should have message "IOError when trying to retrieve CloudInfo"
   }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -61,11 +61,10 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
     mockResultsOne
   }
   // happy path
-  "ContainerProvider" should "return a container" in {
+  "ContainerProvider returns a container" should "from RM" in {
     val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result.json"), "v1")
     val mockDmClient = mock[Client]
-    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *).
-      noMoreThanOnce().returning(kustoOperationResult)
+    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *) returning(kustoOperationResult)
 
     val clusterAlias = "ingest-cluster"
     val command = ".create tempstorage"

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -37,8 +37,8 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
           thenAnswer(_ => List(getMockContainerWithSas(1), getMockContainerWithSas(2)).asJava)
       }
     }
-    // noMoreThanTwice()
-    mockIngestClient.getResourceManager _ expects() atLeastOnce() returning mockIngestionResourceManager
+    // Expecting getResourceManager to be called maxCommandsRetryAttempts i.e. 8 times.
+    mockIngestClient.getResourceManager _ expects() repeated 8 times() returning mockIngestionResourceManager
     // Unfortunately we cannot Mock this class as there is a member variable that is a val and cannot be mocked
     new ExtendedKustoClient(new ConnectionStringBuilder("https://somecluster.eastus.kusto.windows.net/"),
       new ConnectionStringBuilder("https://ingest-somecluster.eastus.kusto.windows.net"), "somecluster") {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -22,7 +22,7 @@ import scala.io.Source
 
 
 class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
-  val CACHE_EXPIRY_SEC = 2
+  val CACHE_EXPIRY_SEC = 30
   val SLEEP_TIME_SEC = 10
 
   private def createExtendedKustoMockClient(hasEmptyResults: Boolean = false, mockDmClient: Client,
@@ -64,7 +64,7 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
   "ContainerProvider returns a container" should "from RM" in {
     val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result.json"), "v1")
     val mockDmClient = mock[Client]
-    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *) returning(kustoOperationResult)
+//    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *) returning(kustoOperationResult)
 
     val clusterAlias = "ingest-cluster"
     val command = ".create tempstorage"
@@ -112,8 +112,8 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
 
     val kustoOperationResult = new KustoOperationResult(readTestSource("storage-result-empty.json"), "v1")
     val mockDmClient = mock[Client]
-    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *).
-      noMoreThanOnce() returning (kustoOperationResult)
+//    (mockDmClient.execute(_: String, _: String, _: ClientRequestProperties)).expects(*, *, *).
+//      returning (kustoOperationResult)
     /*
       Invoke and test
      */

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCacheTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoAzureFsSetupCacheTest.scala
@@ -29,19 +29,23 @@ class KustoAzureFsSetupCacheTest extends AnyFunSuite {
   }
 
   test("testUpdateAndGetPrevNativeAzureFs") {
+    val now = Instant.now(Clock.systemUTC())
     val dataToTest = Table(
-      ("now", "expectedResult"),
+      ("now", "checkIfRefreshNeeded", "Scenario"),
       // Initial set is false for the flag, but refresh
-      (Instant.now(Clock.systemUTC()), true),
+      (now, true, "Initial set is false, refresh is needed"),
       // The cache is expired, so it will be re-set.The checkIfRefreshNeeded will return false, but the state is already true.
-      (Instant.now(Clock.systemUTC()).minus(3 * KustoConstants.SparkSettingsRefreshMinutes, ChronoUnit.MINUTES), true),
+      (now.minus(3 * KustoConstants.SparkSettingsRefreshMinutes, ChronoUnit.MINUTES), true,
+        "The cache is expired, so it will be re-set.The checkIfRefreshNeeded will return false, but the state is already true."),
       // This will be within the cache interval and also the flag is set to true
-      (Instant.now(Clock.systemUTC()).minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES) , true),
+      (now.minus(KustoConstants.SparkSettingsRefreshMinutes / 2, ChronoUnit.MINUTES) , true,
+        "This will be within the cache interval and also the flag is set to true"),
     )
 
-    forAll(dataToTest) { (now: Instant, expectedResult: Boolean) =>
+    forAll(dataToTest) { (now: Instant, checkIfRefreshNeeded: Boolean, scenario:String) =>
       val actualResult = KustoAzureFsSetupCache.updateAndGetPrevNativeAzureFs(now)
-      actualResult shouldEqual expectedResult
+      assert(actualResult == checkIfRefreshNeeded, scenario)
+      actualResult shouldEqual checkIfRefreshNeeded
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>3.0.0</maven.surefire.plugin.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>4.11.0</mockito.version>
         <netty.version>4.1.94.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <reactor.netty.version>1.0.39</reactor.netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <junit4.version>4.13.2</junit4.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <hadoop.version>3.3.6</hadoop.version>
-        <kusto.sdk.version>5.0.3</kusto.sdk.version>
+        <kusto.sdk.version>5.0.4</kusto.sdk.version>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
         <!-- test dependencies -->


### PR DESCRIPTION
#### Pull Request Description

Added retry mechanism for the cases when no storage is returned. 

errortrace:

```
ERROR: Query termination received for [id=96300c8c-6de5-46bc-816e-ce9e78bd2e53, runId=722c6239-67b9-4182-b3b4-3c33c1e37f69], with exception: py4j.Py4JException: An exception was raised by the Python Proxy. Return Message: Traceback (most recent call last):
  File "/databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/clientserver.py", line 617, in _call_proxy
    return_value = getattr(self.pool[obj_id], method)(*params)
  File "/databricks/spark/python/pyspark/sql/utils.py", line 117, in call
    raise e
  File "/databricks/spark/python/pyspark/sql/utils.py", line 114, in call
    self.func(DataFrame(jdf, wrapped_session_jdf), batch_id)
  File "/Workspace/Repos/aisfenix/adx-ingest/src/euvdb/jobs_uc.py", line 388, in adx_batch_write_gtr
    fut.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Workspace/Repos/aisfenix/adx-ingest/src/euvdb/jobs_uc.py", line 430, in write_batch_date_gtr
    self.adx.write(adx_table_name, adx_df, adx_props, write_mode)
  File "/Workspace/Repos/aisfenix/adx-ingest/src/euvdb/clients_uc.py", line 268, in write
    .save()
  File "/databricks/spark/python/pyspark/instrumentation_utils.py", line 48, in wrapper
    res = func(*args, **kwargs)
  File "/databricks/spark/python/pyspark/sql/readwriter.py", line 1461, in save
    self._jwrite.save()
  File "/databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1322, in __call__
    return_value = get_return_value(
  File "/databricks/spark/python/pyspark/errors/exceptions/captured.py", line 188, in deco
    return f(*a, **kw)
  File "/databricks/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py", line 326, in get_return_value
    raise Py4JJavaError(
py4j.protocol.Py4JJavaError: An error occurred while calling o1732.save.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 251.0 failed 1 times, most recent failure: Lost task 0.0 in stage 251.0 (TID 13845) (10.231.232.29 executor driver): java.lang.RuntimeException: Failed to allocate temporary storage
	at com.microsoft.kusto.spark.utils.ContainerProvider.processContainerResults(ContainerProvider.scala:94)
	at com.microsoft.kusto.spark.utils.ContainerProvider.refresh(ContainerProvider.scala:83)
	at com.microsoft.kusto.spark.utils.ContainerProvider.getContainer(ContainerProvider.scala:47)
	at com.microsoft.kusto.spark.utils.ExtendedKustoClient.getTempBlobForIngestion(ExtendedKustoClient.scala:114)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.createBlobWriter(KustoWriter.scala:249)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRows(KustoWriter.scala:331)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRowsIntoKusto(KustoWriter.scala:190)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestToTemporaryTableByWorkers(KustoWriter.scala:236)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRowsIntoTempTbl(KustoWriter.scala:171)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.$anonfun$write$7(KustoWriter.scala:137)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.$anonfun$write$7$adapted(KustoWriter.scala:137)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2(RDD.scala:1086)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2$adapted(RDD.scala:1086)
	at org.apache.spark.SparkContext.$anonfun$runJob$2(SparkContext.scala:2999)
	at org.apache.spark.scheduler.ResultTask.$anonfun$runTask$3(ResultTask.scala:82)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.ResultTask.$anonfun$runTask$1(ResultTask.scala:82)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:62)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:196)
	at org.apache.spark.scheduler.Task.doRunTask(Task.scala:181)
	at org.apache.spark.scheduler.Task.$anonfun$run$5(Task.scala:146)
	at com.databricks.unity.UCSEphemeralState$Handle.runWith(UCSEphemeralState.scala:41)
	at com.databricks.unity.HandleImpl.runWith(UCSHandle.scala:99)
	at com.databricks.unity.HandleImpl.$anonfun$runWithAndClose$1(UCSHandle.scala:104)
	at scala.util.Using$.resource(Using.scala:269)
	at com.databricks.unity.HandleImpl.runWithAndClose(UCSHandle.scala:103)
	at org.apache.spark.scheduler.Task.$anonfun$run$1(Task.scala:146)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$8(Executor.scala:897)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1709)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:900)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:795)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

Driver stacktrace:
	at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:3588)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:3519)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:3506)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:3506)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1516)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1516)
	at scala.Option.foreach(Option.scala:407)
	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1516)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3835)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:3747)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:3735)
	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:51)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$runJob$1(DAGScheduler.scala:1240)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.databricks.spark.util.FrameProfiler$.record(FrameProfiler.scala:94)
	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:1228)
	at org.apache.spark.SparkContext.runJobInternal(SparkContext.scala:2959)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2942)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2980)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2999)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:3024)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$1(RDD.scala:1086)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:165)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:125)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
	at org.apache.spark.rdd.RDD.withScope(RDD.scala:448)
	at org.apache.spark.rdd.RDD.foreachPartition(RDD.scala:1084)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.write(KustoWriter.scala:137)
	at com.microsoft.kusto.spark.datasource.DefaultSource.createRelation(DefaultSource.scala:49)
	at org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand.run(SaveIntoDataSourceCommand.scala:49)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.$anonfun$sideEffectResult$1(commands.scala:82)
	at com.databricks.spark.util.FrameProfiler$.record(FrameProfiler.scala:94)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:80)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:79)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:91)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$$nestedInanonfun$eagerlyExecuteCommands$1$1.$anonfun$applyOrElse$3(QueryExecution.scala:272)
	at org.apache.spark.sql.catalyst.QueryPlanningTracker$.withTracker(QueryPlanningTracker.scala:166)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$$nestedInanonfun$eagerlyExecuteCommands$1$1.$anonfun$applyOrElse$2(QueryExecution.scala:272)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withCustomExecutionEnv$8(SQLExecution.scala:274)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:498)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withCustomExecutionEnv$1(SQLExecution.scala:201)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:1113)
	at org.apache.spark.sql.execution.SQLExecution$.withCustomExecutionEnv(SQLExecution.scala:151)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:447)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$$nestedInanonfun$eagerlyExecuteCommands$1$1.$anonfun$applyOrElse$1(QueryExecution.scala:271)
	at org.apache.spark.sql.execution.QueryExecution.org$apache$spark$sql$execution$QueryExecution$$withMVTagsIfNecessary(QueryExecution.scala:245)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$$nestedInanonfun$eagerlyExecuteCommands$1$1.applyOrElse(QueryExecution.scala:266)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$$nestedInanonfun$eagerlyExecuteCommands$1$1.applyOrElse(QueryExecution.scala:251)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:465)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:69)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:465)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:39)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:316)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:312)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:39)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:39)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:441)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$eagerlyExecuteCommands$1(QueryExecution.scala:251)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:372)
	at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:251)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:203)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:200)
	at org.apache.spark.sql.execution.QueryExecution.assertCommandExecuted(QueryExecution.scala:336)
	at org.apache.spark.sql.DataFrameWriter.runCommand(DataFrameWriter.scala:956)
	at org.apache.spark.sql.DataFrameWriter.saveToV1Source(DataFrameWriter.scala:424)
	at org.apache.spark.sql.DataFrameWriter.saveInternal(DataFrameWriter.scala:391)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:258)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:397)
	at py4j.Gateway.invoke(Gateway.java:306)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:195)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:115)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: Failed to allocate temporary storage
	at com.microsoft.kusto.spark.utils.ContainerProvider.processContainerResults(ContainerProvider.scala:94)
	at com.microsoft.kusto.spark.utils.ContainerProvider.refresh(ContainerProvider.scala:83)
	at com.microsoft.kusto.spark.utils.ContainerProvider.getContainer(ContainerProvider.scala:47)
	at com.microsoft.kusto.spark.utils.ExtendedKustoClient.getTempBlobForIngestion(ExtendedKustoClient.scala:114)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.createBlobWriter(KustoWriter.scala:249)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRows(KustoWriter.scala:331)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRowsIntoKusto(KustoWriter.scala:190)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestToTemporaryTableByWorkers(KustoWriter.scala:236)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.ingestRowsIntoTempTbl(KustoWriter.scala:171)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.$anonfun$write$7(KustoWriter.scala:137)
	at com.microsoft.kusto.spark.datasink.KustoWriter$.$anonfun$write$7$adapted(KustoWriter.scala:137)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2(RDD.scala:1086)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2$adapted(RDD.scala:1086)
	at org.apache.spark.SparkContext.$anonfun$runJob$2(SparkContext.scala:2999)
	at org.apache.spark.scheduler.ResultTask.$anonfun$runTask$3(ResultTask.scala:82)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.ResultTask.$anonfun$runTask$1(ResultTask.scala:82)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:62)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:196)
	at org.apache.spark.scheduler.Task.doRunTask(Task.scala:181)
	at org.apache.spark.scheduler.Task.$anonfun$run$5(Task.scala:146)
	at com.databricks.unity.UCSEphemeralState$Handle.runWith(UCSEphemeralState.scala:41)
	at com.databricks.unity.HandleImpl.runWith(UCSHandle.scala:99)
	at com.databricks.unity.HandleImpl.$anonfun$runWithAndClose$1(UCSHandle.scala:104)
	at scala.util.Using$.resource(Using.scala:269)
	at com.databricks.unity.HandleImpl.runWithAndClose(UCSHandle.scala:103)
	at org.apache.spark.scheduler.Task.$anonfun$run$1(Task.scala:146)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$8(Executor.scala:897)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1709)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:900)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:795)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	... 1 more

---

```
#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
