### PR TITLE
Handle spark's `BinaryType`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 
+# VS Code and extensions
+.vscode/
+.bloop/
+.metals/

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/RowCSVWriterUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/RowCSVWriterUtils.scala
@@ -4,6 +4,7 @@ import java.io.CharArrayWriter
 import java.math.BigInteger
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, LocalDateTime, ZoneId}
+import java.util.Base64
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
@@ -61,6 +62,7 @@ object RowCSVWriterUtils {
       nested: Boolean): Unit = {
     dataType match {
       case StringType => writeStringFromUTF8(row.getUTF8String(fieldIndexInRow), writer)
+      case BinaryType => writeStringFromBinary(row.getBinary(fieldIndexInRow), writer)
       case DateType =>
         writer.writeStringField(DateTimeUtils.toJavaDate(row.getInt(fieldIndexInRow)).toString)
       case TimestampType =>
@@ -246,5 +248,9 @@ object RowCSVWriterUtils {
 
   private def writeStringFromUTF8(str: UTF8String, writer: Writer): Unit = {
     writer.writeStringField(str.toString)
+  }
+
+  private def writeStringFromBinary(bytes: Array[Byte], writer: Writer): Unit = {
+    writer.writeStringField(Base64.getEncoder.encodeToString(bytes))
   }
 }

--- a/docs/Spark-Kusto DataTypes mapping.md
+++ b/docs/Spark-Kusto DataTypes mapping.md
@@ -8,6 +8,7 @@ When writing to or reading from a Kusto table, the connector converts types from
 | Spark data type | Kusto data type |
 |-----------------|-----------------|
 | StringType      | string          |
+| BinaryType      | string          |
 | IntegerType     | int             |
 | LongType        | long            |
 | BooleanType     | bool            |
@@ -46,6 +47,8 @@ When writing to or reading from a Kusto table, the connector converts types from
 Kusto **datetime** data type is always read in '%Y-%m-%d %H:%M:%s' format , while **timespan** format is '%H:%M:%s'. On the other
 hand spark **DateType** is of format '%Y-%m-%d' and **TimestampType** is of format '%Y-%m-%d %H:%M:%s'. This is why Kusto 'timespan' 
 type is translated into a string by the connector and **we recommend using only datetime and TimestampType**. 
+
+Spark **BinaryType** is convereted to a base 64 encoded string.
 
 Kusto **decimal** type 
 - Kusto as a source : The precision and scale supported with Kusto as a source is (38,18) respectively.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>5.0.6</revision>
+        <revision>5.0.7</revision>
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>
         <scalafmt.plugin.version>1.1.1640084764.9f463a9</scalafmt.plugin.version>


### PR DESCRIPTION
#### Pull Request Description

Today `BinaryType` columns get written as a string by just using `.toString` on a byte array resulting in a value similar to `[B@7fdcec67`. This PR updates the handling of this column type to write a base64 encoded string instead.

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- BinaryType data ingestion
