### PR TITLE
Feature/add binary type support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
         run: |
-          echo $access_token
+          echo "Here is token: $access_token
           mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.APP_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,29 @@
-name: Build
+name: Go
 on:
   push:
-    branches: [ '**' ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ "**" ]
+
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
-    name: Setup Java 8, build and run tests
+    environment: build
     permissions:
       checks: write
       pull-requests: write
+      id-token: write
+      contents: read      
     steps:
-      - uses: actions/checkout@v2
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Check out code into the Spark module directory
+        uses: actions/checkout@v2
       - name: Setup java
         uses: actions/setup-java@v3
         with:
@@ -22,12 +33,10 @@ jobs:
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}
-          kustoAadAppSecret: ${{ secrets.APP_SECRET }}
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
-          SecretPath: ${{ secrets.SECRET_PATH }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoAadAppSecret=${{ secrets.APP_SECRET }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DSecretPath=${{ secrets.SECRET_PATH }}
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
               access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
               echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
-  
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}
@@ -47,7 +46,7 @@ jobs:
           kustoAadAppId: ${{secrets.APP_ID}}
           accessToken: ${{env.ACCESS_TOKEN}}
         run: |
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
+          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,20 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: "Run az commands"
+        run: |
+              access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=https://kusto.kusto.windows.net/.default --query accessToken -o tsv)
+              echo "Access Token: $access_token" | xxd -ps
+  
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
+          accessToken: $access_token
         run: |
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: "Run az commands"
         run: |
-              access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=https://kusto.kusto.windows.net/.default --query accessToken -o tsv)
-              echo "Access Token: $access_token" | xxd -ps
+              access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+              echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
   
       - name: Run the Maven verify phase
         env:
@@ -45,9 +45,9 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-          accessToken: $access_token
+          accessToken: ${{env.ACCESS_TOKEN}}
         run: |
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Go
+name: AzureKustoSpark
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,6 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Azure CLI script
-        uses: azure/CLI@v1
-        id: azcliscript
-        with:
-          azcliversion: latest
-          inlineScript: |
-            echo "ACCESS_TOKEN=$(az account get-access-token --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)" >> "$GITHUB_OUTPUT"
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java
@@ -43,10 +36,8 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-          accessToken: ${{steps.azcliscript.outputs.ACCESS_TOKEN}}
         run: |
-          echo "Here is token: $accessToken"
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{steps.azcliscript.outputs.ACCESS_TOKEN}}
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,11 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Azure CLI script
         uses: azure/CLI@v1
+        id: azcliscript
         with:
           azcliversion: latest
           inlineScript: |
-            access_token=$(az account get-access-token --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+            echo "ACCESS_TOKEN=$(az account get-access-token --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)" >> "$GITHUB_OUTPUT"
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java
@@ -42,9 +43,10 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
+          accessToken: ${{steps.azcliscript.outputs.ACCESS_TOKEN}}
         run: |
-          echo "Here is token: $access_token
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
+          echo "Here is token: $accessToken"
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$accessToken
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           accessToken: ${{steps.azcliscript.outputs.ACCESS_TOKEN}}
         run: |
           echo "Here is token: $accessToken"
-          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$accessToken
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{steps.azcliscript.outputs.ACCESS_TOKEN}}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Azure CLI script
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az account show      
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Azure CLI script
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az account show          
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}   
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v4
       - name: Setup java
@@ -34,6 +28,12 @@ jobs:
             pom.xml
             connector/pom.xml
             samples/pom.xml
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DlogLevel=OFF
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,9 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
+        run: |
+          echo $access_token
+          mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DlogLevel=OFF
+        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az account show      
+            access_token=$(az account get-access-token --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java
@@ -42,7 +42,7 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
+        run: mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=$access_token
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,22 +14,26 @@ jobs:
       checks: write
       pull-requests: write
       id-token: write
-      contents: read      
+      contents: read
     steps:
       - name: Azure login
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}   
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Check out code into the Spark module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: 8
           cache: 'maven'
+          cache-dependency-path: |
+            pom.xml
+            connector/pom.xml
+            samples/pom.xml
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.APP_ID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-        run: mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
+        run: mvn clean test verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Azure CLI script
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az account show          
       - name: Check out code into the Spark module directory
         uses: actions/checkout@v2
       - name: Setup java

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 
+# VS Code and extensions
+.vscode/
+.bloop/
+.metals/

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -83,12 +83,22 @@
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-identity</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
             <version>${msal4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>${az.identity.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
@@ -134,6 +144,10 @@
                 <exclusion>
                     <groupId>com.azure</groupId>
                     <artifactId>azure-storage-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-identity</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -493,4 +507,11 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>maven_central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+    </repositories>
 </project>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -64,10 +64,6 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.microsoft.azure</groupId>
-                    <artifactId>msal4j</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>commons-codec</artifactId>
                     <groupId>commons-codec</groupId>
                 </exclusion>
@@ -83,22 +79,7 @@
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-identity</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>msal4j</artifactId>
-            <version>${msal4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-identity</artifactId>
-            <version>${az.identity.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
@@ -144,10 +125,6 @@
                 <exclusion>
                     <groupId>com.azure</groupId>
                     <artifactId>azure-storage-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-identity</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/RowCSVWriterUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/RowCSVWriterUtils.scala
@@ -4,6 +4,7 @@ import java.io.CharArrayWriter
 import java.math.BigInteger
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, LocalDateTime, ZoneId}
+import java.util.Base64
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
@@ -61,6 +62,7 @@ object RowCSVWriterUtils {
       nested: Boolean): Unit = {
     dataType match {
       case StringType => writeStringFromUTF8(row.getUTF8String(fieldIndexInRow), writer)
+      case BinaryType => writeStringFromBinary(row.getBinary(fieldIndexInRow), writer)
       case DateType =>
         writer.writeStringField(DateTimeUtils.toJavaDate(row.getInt(fieldIndexInRow)).toString)
       case TimestampType =>
@@ -246,5 +248,9 @@ object RowCSVWriterUtils {
 
   private def writeStringFromUTF8(str: UTF8String, writer: Writer): Unit = {
     writer.writeStringField(str.toString)
+  }
+
+  private def writeStringFromBinary(bytes: Array[Byte], writer: Writer): Unit = {
+    writer.writeStringField(Base64.getEncoder.encodeToString(bytes))
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoAuthenticationTestE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoAuthenticationTestE2E.scala
@@ -1,7 +1,23 @@
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.ClientFactory
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.KustoTestUtils.KustoConnectionOptions
 import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode}
 import com.microsoft.kusto.spark.sql.extension.SparkExtension._
 import com.microsoft.kusto.spark.utils.KustoQueryUtils
@@ -17,14 +33,7 @@ class KustoAuthenticationTestE2E extends AnyFlatSpec {
     .appName("KustoSink")
     .master(f"local[2]")
     .getOrCreate()
-
-  val cluster: String = System.getProperty(KustoSinkOptions.KUSTO_CLUSTER)
-  val database: String = System.getProperty(KustoSinkOptions.KUSTO_DATABASE)
-
-  val appId: String = System.getProperty(KustoSinkOptions.KUSTO_AAD_APP_ID)
-  val appKey: String = System.getProperty(KustoSinkOptions.KUSTO_AAD_APP_SECRET)
-  val authority: String =
-    System.getProperty(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
 
   val keyVaultAppId: String = System.getProperty(KustoSinkOptions.KEY_VAULT_APP_ID)
   val keyVaultAppKey: String = System.getProperty(KustoSinkOptions.KEY_VAULT_APP_KEY)
@@ -39,24 +48,20 @@ class KustoAuthenticationTestE2E extends AnyFlatSpec {
       (1 to expectedNumberOfRows).map(v => (s"row-$v", v))
     val prefix = "keyVaultAuthentication"
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoConnectionOptions.cluster,kustoConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
 
     val df = rows.toDF("name", "value")
     val conf: Map[String, String] = Map(
       KustoSinkOptions.KEY_VAULT_URI -> keyVaultUri,
-      KustoSinkOptions.KEY_VAULT_APP_ID -> (if (keyVaultAppId == null) appId else keyVaultAppId),
-      KustoSinkOptions.KEY_VAULT_APP_KEY -> (if (keyVaultAppKey == null) appKey
-                                             else keyVaultAppKey),
+      KustoSinkOptions.KEY_VAULT_APP_ID -> (if (keyVaultAppId == null) "" else keyVaultAppId),
+      KustoSinkOptions.KEY_VAULT_APP_KEY -> (if (keyVaultAppKey == null) {""} else {keyVaultAppKey}),
       KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS -> SinkTableCreationMode.CreateIfNotExist.toString)
 
-    df.write.kusto(cluster, database, table, conf)
+    df.write.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
 
-    val dfResult = spark.read.kusto(cluster, database, table, conf)
+    val dfResult = spark.read.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
     val result = dfResult.select("name", "value").rdd.collect().sortBy(x => x.getInt(1))
     val orig = df.select("name", "value").rdd.collect().sortBy(x => x.getInt(1))
 
@@ -72,16 +77,16 @@ class KustoAuthenticationTestE2E extends AnyFlatSpec {
     val prefix = "managedIdentityAuth"
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
     val engineKcsb =
-      ConnectionStringBuilder.createWithAadManagedIdentity(s"https://$cluster.kusto.windows.net")
+      ConnectionStringBuilder.createWithAadManagedIdentity(kustoConnectionOptions.cluster)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
 
     val df = rows.toDF("name", "value")
     val conf: Map[String, String] =
       Map(KustoSinkOptions.KUSTO_MANAGED_IDENTITY_AUTH -> true.toString)
 
-    df.write.kusto(cluster, database, table, conf)
+    df.write.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
 
-    val dfResult = spark.read.kusto(cluster, database, table, conf)
+    val dfResult = spark.read.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
     val result = dfResult.select("name", "value").rdd.collect().sortBy(x => x.getInt(1))
     val orig = df.select("name", "value").rdd.collect().sortBy(x => x.getInt(1))
 
@@ -99,26 +104,21 @@ class KustoAuthenticationTestE2E extends AnyFlatSpec {
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
 
     val deviceAuth = new com.microsoft.kusto.spark.authentication.DeviceAuthentication(
-      s"https://${cluster}.kusto.windows.net",
-      authority)
-
+      kustoConnectionOptions.cluster,
+      kustoConnectionOptions.tenantId)
     val token = deviceAuth.acquireToken()
-
     val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
-      s"https://$cluster.kusto.windows.net",
+      kustoConnectionOptions.cluster,
       token)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
-
     val df = rows.toDF("name", "value")
     val conf: Map[String, String] = Map(
       KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS -> SinkTableCreationMode.CreateIfNotExist.toString)
-
-    df.write.kusto(cluster, database, table, conf)
-
+    df.write.kusto(kustoConnectionOptions.cluster, kustoConnectionOptions.database, table, conf)
     KustoTestUtils.validateResultsAndCleanup(
       kustoAdminClient,
       table,
-      database,
+      kustoConnectionOptions.database,
       expectedNumberOfRows,
       timeoutMs,
       tableCleanupPrefix = prefix)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoBlobAccessE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoBlobAccessE2E.scala
@@ -67,7 +67,7 @@ class KustoBlobAccessE2E extends AnyFlatSpec with BeforeAndAfterAll {
     sc.stop()
   }
 
-  private val kustoTestConnectionOptions = getSystemTestOptions
+  private lazy val kustoTestConnectionOptions = getSystemTestOptions
 
   private val table: String = System.getProperty(KustoSinkOptions.KUSTO_TABLE, "")
   private val storageAccount: String =

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoPruneAndFilterE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoPruneAndFilterE2E.scala
@@ -1,7 +1,23 @@
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.ClientFactory
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.KustoTestUtils.getSystemTestOptions
 import com.microsoft.kusto.spark.common.KustoDebugOptions
 import com.microsoft.kusto.spark.datasink.KustoSinkOptions
 import com.microsoft.kusto.spark.datasource.{
@@ -23,6 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable
 
 class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
+  private val kustoTestConnectionOptions = getSystemTestOptions
+
   private val nofExecutors = 4
   private val spark: SparkSession = SparkSession
     .builder()
@@ -46,13 +64,6 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     sc.stop()
   }
 
-  val appId: String = System.getProperty(KustoSourceOptions.KUSTO_AAD_APP_ID)
-  val appKey: String = System.getProperty(KustoSourceOptions.KUSTO_AAD_APP_SECRET)
-  val authority: String =
-    System.getProperty(KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
-  val cluster: String = System.getProperty(KustoSourceOptions.KUSTO_CLUSTER)
-  val database: String = System.getProperty(KustoSourceOptions.KUSTO_DATABASE)
-
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
   if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
 
@@ -63,11 +74,12 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
       s"$table | where (toint(ColB) % 1000 == 0) ")
 
     val conf = Map(
-      KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-      KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
       KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceSingleMode.toString)
 
-    val df = spark.read.kusto(cluster, database, query, conf).select("ColA")
+    val df = spark.read
+      .kusto(kustoTestConnectionOptions.cluster, kustoTestConnectionOptions.database, query, conf)
+      .select("ColA")
     df.show()
   }
 
@@ -85,21 +97,23 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
         Array(new TransientStorageCredentials(storageAccount, blobKey, container)))
 
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString)
     } else {
       val storage =
         new TransientStorageParameters(Array(new TransientStorageCredentials(blobSas))) //          ,
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString
         // KustoDebugOptions.KUSTO_DBG_BLOB_FORCE_KEEP -> "true"
       )
     }
 
-    val df = spark.read.kusto(cluster, database, query, conf)
+    val df = spark.read.kusto(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.database,
+      query,
+      conf)
 
     df.show(20)
   }
@@ -123,24 +137,20 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val blobSas: String = System.getProperty("blobSas")
 
     // Create a new table.
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(
-      database,
+      kustoTestConnectionOptions.database,
       generateTempTableCreateCommand(query, columnsTypesAndNames = "ColA:string, ColB:int"))
 
     dfOrig.write
       .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, query)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
       .mode(SaveMode.Append)
       .save()
 
@@ -148,8 +158,7 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
       val storage = new TransientStorageParameters(
         Array(new TransientStorageCredentials(storageAccount, blobKey, container)))
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString,
         KustoDebugOptions.KUSTO_DBG_BLOB_COMPRESS_ON_EXPORT -> "false"
       ) // Just to test this option
@@ -158,14 +167,17 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
         new TransientStorageParameters(Array(new TransientStorageCredentials(blobSas))) //          ,
 
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString,
         KustoDebugOptions.KUSTO_DBG_BLOB_COMPRESS_ON_EXPORT -> "false"
       ) // Just to test this option
     }
 
-    val dfResult = spark.read.kusto(cluster, database, query, conf)
+    val dfResult = spark.read.kusto(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.database,
+      query,
+      conf)
 
     val orig = dfOrig
       .select("name", "value")
@@ -184,7 +196,7 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     assert(orig.deep == result.deep)
 
     val dfResultPruned = spark.read
-      .kusto(cluster, database, query, conf)
+      .kusto(kustoTestConnectionOptions.cluster, kustoTestConnectionOptions.database, query, conf)
       .select("ColA")
       .sort("ColA")
       .collect()
@@ -199,7 +211,7 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     // Cleanup
     KustoTestUtils.tryDropAllTablesByPrefix(
       kustoAdminClient,
-      database,
+      kustoTestConnectionOptions.database,
       "KustoSparkReadWriteWithFiltersTest")
   }
 
@@ -222,24 +234,21 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val blobSas: String = System.getProperty("blobSas")
 
     // Create a new table.
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(
-      database,
+      kustoTestConnectionOptions.database,
       generateTempTableCreateCommand(query, columnsTypesAndNames = "ColA:string, ColB:int"))
 
     dfOrig.write
       .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, query)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
+      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, kustoTestConnectionOptions.tenantId)
       .mode(SaveMode.Append)
       .save()
 
@@ -247,8 +256,7 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
       val storage = new TransientStorageParameters(
         Array(new TransientStorageCredentials(storageAccount, blobKey, container)))
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString)
 
     } else {
@@ -256,12 +264,15 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
         new TransientStorageParameters(Array(new TransientStorageCredentials(blobSas))) //          ,
 
       Map(
-        KustoSourceOptions.KUSTO_AAD_APP_ID -> appId,
-        KustoSourceOptions.KUSTO_AAD_APP_SECRET -> appKey,
+        KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
         KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toString)
     }
 
-    val dfResult = spark.read.kusto(cluster, database, query, conf)
+    val dfResult = spark.read.kusto(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.database,
+      query,
+      conf)
     val dfFiltered = dfResult
       .where(dfResult.col("ColA']").startsWith("row-2"))
       .filter("ColB > 12")
@@ -275,7 +286,7 @@ class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
     // Cleanup
     KustoTestUtils.tryDropAllTablesByPrefix(
       kustoAdminClient,
-      database,
+      kustoTestConnectionOptions.database,
       "KustoSparkReadWriteWithFiltersTest")
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoPruneAndFilterE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoPruneAndFilterE2E.scala
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable
 
 class KustoPruneAndFilterE2E extends AnyFlatSpec with BeforeAndAfterAll {
-  private val kustoTestConnectionOptions = getSystemTestOptions
+  private lazy val kustoTestConnectionOptions = getSystemTestOptions
 
   private val nofExecutors = 4
   private val spark: SparkSession = SparkSession

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -76,7 +76,7 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     .master(f"local[$nofExecutors]")
     .getOrCreate()
 
-  private val kustoTestConnectionOptions = getSystemTestOptions
+  private lazy val kustoTestConnectionOptions = getSystemTestOptions
   private var sc: SparkContext = _
   private var sqlContext: SQLContext = _
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -1,11 +1,27 @@
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.ClientFactory
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.KustoTestUtils.getSystemTestOptions
 import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode}
 import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode}
-import com.microsoft.kusto.spark.sql.extension.SparkExtension._
-import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
+import com.microsoft.kusto.spark.sql.extension.SparkExtension.DataFrameReaderExtension
+import com.microsoft.kusto.spark.utils.CslCommandsGenerator.generateTempTableCreateCommand
 import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils => KDSU}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql._
@@ -21,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable
 
 class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
-  private val myName = this.getClass.getSimpleName
+  private val className = this.getClass.getSimpleName
   private val rowId = new AtomicInteger(1)
   private val rowId2 = new AtomicInteger(1)
 
@@ -60,6 +76,7 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     .master(f"local[$nofExecutors]")
     .getOrCreate()
 
+  private val kustoTestConnectionOptions = getSystemTestOptions
   private var sc: SparkContext = _
   private var sqlContext: SQLContext = _
 
@@ -72,16 +89,9 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     super.afterAll()
-
     sc.stop()
   }
 
-  val appId: String = System.getProperty(KustoSinkOptions.KUSTO_AAD_APP_ID)
-  val appKey: String = System.getProperty(KustoSinkOptions.KUSTO_AAD_APP_SECRET)
-  val authority: String =
-    System.getProperty(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
-  val cluster: String = System.getProperty(KustoSinkOptions.KUSTO_CLUSTER)
-  val database: String = System.getProperty(KustoSinkOptions.KUSTO_DATABASE)
   val expectedNumberOfRows: Int = 1 * 1000
   val rows: immutable.IndexedSeq[(String, Int)] =
     (1 to expectedNumberOfRows).map(v => (newRow(), v))
@@ -90,10 +100,10 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
   if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
 
   "KustoConnectorLogger" should "log to console according to the level set" taggedAs KustoE2E in {
-    KDSU.logInfo(myName, "******** info ********")
-    KDSU.logError(myName, "******** error ********")
+    KDSU.logInfo(className, "******** info ********")
+    KDSU.logError(className, "******** error ********")
     KDSU.logFatal(
-      myName,
+      className,
       "******** fatal  ********. Use a 'logLevel' system variable to change the logging level.")
   }
 
@@ -132,12 +142,10 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     dfOrig.write
       .format("com.microsoft.kusto.spark.datasource")
       .partitionBy("value")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
       .option(DateTimeUtils.TIMEZONE_OPTION, "GMT+4")
       .option(
         KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS,
@@ -146,17 +154,23 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
       .save()
 
     val conf: Map[String, String] = Map(
-      KustoSinkOptions.KUSTO_AAD_APP_ID -> appId,
-      KustoSinkOptions.KUSTO_AAD_APP_SECRET -> appKey,
+      KustoSinkOptions.KUSTO_ACCESS_TOKEN -> kustoTestConnectionOptions.accessToken,
       KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceDistributedMode.toString)
 
     val conf2: Map[String, String] = Map(
-      KustoSinkOptions.KUSTO_AAD_APP_ID -> appId,
-      KustoSinkOptions.KUSTO_AAD_APP_SECRET -> appKey,
+      KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoTestConnectionOptions.accessToken,
       KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceSingleMode.toString)
 
-    val dfResultDist: DataFrame = spark.read.kusto(cluster, database, table, conf)
-    val dfResultSingle: DataFrame = spark.read.kusto(cluster, database, table, conf2)
+    val dfResultDist: DataFrame = spark.read.kusto(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.database,
+      table,
+      conf)
+    val dfResultSingle: DataFrame = spark.read.kusto(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.database,
+      table,
+      conf2)
 
     def getRowOriginal(x: Row): (
         String,
@@ -317,16 +331,17 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
     assert(isEqual)
     KDSU.logInfo(
-      myName,
+      className,
       s"KustoBatchSinkDataTypesTest: Ingestion results validated for table '$table'")
 
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
     val engineClient = ClientFactory.createClient(engineKcsb)
-    KustoTestUtils.tryDropAllTablesByPrefix(engineClient, database, prefix)
+    KustoTestUtils.tryDropAllTablesByPrefix(
+      engineClient,
+      kustoTestConnectionOptions.database,
+      prefix)
   }
 
   "KustoBatchSinkSync" should "also ingest simple data to a Kusto cluster" taggedAs KustoE2E in {
@@ -334,25 +349,21 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2E_Ingest"
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(
-      database,
+      kustoTestConnectionOptions.database,
       generateTempTableCreateCommand(table, columnsTypesAndNames = "ColA:string, ColB:int"))
 
     df.write
       .format("com.microsoft.kusto.spark.datasource")
       .partitionBy("value")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
       .option(KustoSinkOptions.KUSTO_TIMEOUT_LIMIT, (8 * 60).toString)
       .mode(SaveMode.Append)
       .save()
@@ -362,7 +373,7 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     KustoTestUtils.validateResultsAndCleanup(
       kustoAdminClient,
       table,
-      database,
+      kustoTestConnectionOptions.database,
       expectedNumberOfRows,
       timeoutMs,
       tableCleanupPrefix = prefix)
@@ -373,24 +384,20 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2EIngestAsync"
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://$cluster.kusto.windows.net",
-      appId,
-      appKey,
-      authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(
-      database,
+      kustoTestConnectionOptions.database,
       generateTempTableCreateCommand(table, columnsTypesAndNames = "ColA:string, ColB:int"))
 
     df.write
       .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
       .option(KustoSinkOptions.KUSTO_WRITE_ENABLE_ASYNC, "true")
       .mode(SaveMode.Append)
       .save()
@@ -400,7 +407,7 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     KustoTestUtils.validateResultsAndCleanup(
       kustoAdminClient,
       table,
-      database,
+      kustoTestConnectionOptions.database,
       expectedNumberOfRows,
       timeoutMs,
       tableCleanupPrefix = prefix)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
@@ -15,13 +15,7 @@
 
 package com.microsoft.kusto.spark
 
-import com.microsoft.kusto.spark.KustoTestUtils.{
-  KustoConnectionOptions,
-  cleanup,
-  createTestTable,
-  ingest,
-  validateTargetTable
-}
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, cleanup, createTestTable, getSystemTestOptions, ingest, validateTargetTable}
 import com.microsoft.kusto.spark.datasink.{SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.exceptions.SchemaMatchException
 import com.microsoft.kusto.spark.utils.KustoQueryUtils
@@ -48,7 +42,7 @@ class KustoSinkSchemaAdjustmentE2E
   private val expectedNumberOfRows = 3
   private def newRow(index: Int): String = s"row-$index"
 
-  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = getSystemTestOptions
 
   override def afterAll(): Unit = {
     cleanup(kustoConnectionOptions, testTablePrefix)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
@@ -48,7 +48,7 @@ class KustoSinkSchemaAdjustmentE2E
   private val expectedNumberOfRows = 3
   private def newRow(index: Int): String = s"row-$index"
 
-  val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
 
   override def afterAll(): Unit = {
     cleanup(kustoConnectionOptions, testTablePrefix)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkSchemaAdjustmentE2E.scala
@@ -1,6 +1,27 @@
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
-import com.microsoft.kusto.spark.KustoTestUtils.KustoConnectionOptions
+import com.microsoft.kusto.spark.KustoTestUtils.{
+  KustoConnectionOptions,
+  cleanup,
+  createTestTable,
+  ingest,
+  validateTargetTable
+}
 import com.microsoft.kusto.spark.datasink.{SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.exceptions.SchemaMatchException
 import com.microsoft.kusto.spark.utils.KustoQueryUtils
@@ -30,11 +51,8 @@ class KustoSinkSchemaAdjustmentE2E
   val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
 
   override def afterAll(): Unit = {
+    cleanup(kustoConnectionOptions, testTablePrefix)
     spark.sparkContext.stop()
-  }
-
-  override def afterEach(): Unit = {
-    // KustoTestUtils.cleanup(kustoConnectionOptions, testTablePrefix)
   }
 
   "Source DataFrame schema adjustment" should "not adjust" taggedAs KustoE2E in {
@@ -43,19 +61,14 @@ class KustoSinkSchemaAdjustmentE2E
     val df = sourceValues.toDF("WrongColA", "WrongColB")
     val targetSchema = "ColA:int, ColB:string"
     val schemaAdjustmentMode = "NoAdjustment"
-
-    val testTable =
-      KustoTestUtils.createTestTable(kustoConnectionOptions, testTablePrefix, targetSchema)
-    KustoTestUtils.ingest(kustoConnectionOptions, df, testTable, schemaAdjustmentMode)
+    val testTable = createTestTable(kustoConnectionOptions, testTablePrefix, targetSchema)
+    ingest(kustoConnectionOptions, df, testTable, schemaAdjustmentMode)
 
     val expectedData = df
       .withColumn("ColA", functions.lit(null))
       .withColumn("ColB", functions.col("WrongColB").cast(StringType))
       .select("ColA", "ColB")
-
-    assert(
-      KustoTestUtils.validateTargetTable(kustoConnectionOptions, testTable, expectedData, spark))
-
+    assert(validateTargetTable(kustoConnectionOptions, testTable, expectedData, spark))
   }
 
   "Source DataFrame schema adjustment" should "produce SchemaMatchException when column names not match" taggedAs KustoE2E in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -1,3 +1,19 @@
+
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.ClientFactory
@@ -55,11 +71,9 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
   "KustoStreamingSinkSyncWithTableCreateAndIngestIfNotExist" should "ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
     val prefix = "KustoStreamingSparkE2E_Ingest"
     val table = s"${prefix}_${UUID.randomUUID().toString.replace("-", "_")}"
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
-      kustoConnectionOptions.appId,
-      kustoConnectionOptions.appKey,
-      kustoConnectionOptions.authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoConnectionOptions.cluster,
+      kustoConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
 
     val csvDf = spark.readStream
@@ -85,9 +99,7 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
         KustoSinkOptions.KUSTO_CLUSTER -> kustoConnectionOptions.cluster,
         KustoSinkOptions.KUSTO_TABLE -> table,
         KustoSinkOptions.KUSTO_DATABASE -> kustoConnectionOptions.database,
-        KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
-        KustoSinkOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey,
-        KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID -> kustoConnectionOptions.authority,
+        KustoSinkOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken,
         KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS -> SinkTableCreationMode.CreateIfNotExist.toString,
         KustoDebugOptions.KUSTO_ENSURE_NO_DUPLICATED_BLOBS -> true.toString,
         KustoSinkOptions.KUSTO_SPARK_INGESTION_PROPERTIES_JSON -> sp.toString))
@@ -109,11 +121,9 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
   "KustoStreamingSinkAsync" should "also ingest structured data to a Kusto cluster" taggedAs KustoE2E in {
     val prefix = "KustoStreamingSparkE2EAsync_Ingest"
     val table = s"${prefix}_${UUID.randomUUID().toString.replace("-", "_")}"
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
-      kustoConnectionOptions.appId,
-      kustoConnectionOptions.appKey,
-      kustoConnectionOptions.authority)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoConnectionOptions.cluster,
+      kustoConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
 
     kustoAdminClient.execute(
@@ -138,9 +148,7 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
         KustoSinkOptions.KUSTO_CLUSTER -> kustoConnectionOptions.cluster,
         KustoSinkOptions.KUSTO_TABLE -> table,
         KustoSinkOptions.KUSTO_DATABASE -> kustoConnectionOptions.database,
-        KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
-        KustoSinkOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey,
-        KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID -> kustoConnectionOptions.authority,
+        KustoSinkOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.accessToken,
         KustoSinkOptions.KUSTO_WRITE_ENABLE_ASYNC -> "true"))
       .trigger(Trigger.Once)
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -18,13 +18,9 @@ package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.ClientFactory
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
-import com.microsoft.kusto.spark.KustoTestUtils.KustoConnectionOptions
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
 import com.microsoft.kusto.spark.common.KustoDebugOptions
-import com.microsoft.kusto.spark.datasink.{
-  KustoSinkOptions,
-  SinkTableCreationMode,
-  SparkIngestionProperties
-}
+import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.streaming.Trigger
@@ -59,7 +55,7 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
     sc.stop()
   }
   private lazy val kustoConnectionOptions: KustoConnectionOptions =
-    KustoTestUtils.getSystemTestOptions
+    getSystemTestOptions
 
   val csvPath: String = System.getProperty("path", "connector/src/test/resources/TestData/csv")
   val customSchema: StructType = new StructType()

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkStreamingE2E.scala
@@ -50,14 +50,12 @@ class KustoSinkStreamingE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
     sc = spark.sparkContext
     sqlContext = spark.sqlContext
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-
     sc.stop()
   }
   private lazy val kustoConnectionOptions: KustoConnectionOptions =

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -17,19 +17,10 @@ package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.{Client, ClientFactory, ClientRequestProperties}
-import com.microsoft.kusto.spark.KustoTestUtils.KustoConnectionOptions
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
 import com.microsoft.kusto.spark.common.KustoDebugOptions
-import com.microsoft.kusto.spark.datasink.{
-  KustoSinkOptions,
-  SinkTableCreationMode,
-  SparkIngestionProperties
-}
-import com.microsoft.kusto.spark.datasource.{
-  KustoSourceOptions,
-  ReadMode,
-  TransientStorageCredentials,
-  TransientStorageParameters
-}
+import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties}
+import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode, TransientStorageCredentials, TransientStorageParameters}
 import com.microsoft.kusto.spark.sql.extension.SparkExtension._
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
 import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils => KDSU}
@@ -56,7 +47,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private var sc: SparkContext = _
   private var sqlContext: SQLContext = _
 
-  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = getSystemTestOptions
   private val table =
     KustoQueryUtils.simplifyName(s"KustoSparkReadWriteTest_${UUID.randomUUID()}")
   private val className = this.getClass.getSimpleName

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -27,7 +27,7 @@ import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils =>
 import org.apache.hadoop.util.ComparableVersion
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.time.temporal.ChronoUnit
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable
 import scala.util.{Failure, Random, Success, Try}
 
+@Ignore
 class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private lazy val kustoConnectionOptions: KustoConnectionOptions =
     getSystemTestOptions

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable
 import scala.util.{Failure, Random, Success, Try}
 
-@Ignore
 class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private lazy val kustoConnectionOptions: KustoConnectionOptions =
     getSystemTestOptions

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -67,10 +67,6 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     sqlContext = spark.sqlContext
     val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(kustoConnectionOptions.cluster,
       kustoConnectionOptions.accessToken)
-
-    KDSU.logWarn(className, message = s"******************************* Masked ACCESS TOKEN HERE ${
-      kustoConnectionOptions.accessToken.slice(0,kustoConnectionOptions.accessToken.length-2)}");
-
     maybeKustoAdminClient = Some(ClientFactory.createClient(engineKcsb))
     val ingestUrl =
       new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(kustoConnectionOptions.cluster))
@@ -111,6 +107,10 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
         }
       case None => KDSU.logWarn(className, s"Admin client is null, could not drop table $table ")
     }
+    KDSU.logWarn(className, s"******************************* Masked ACCESS TOKEN HERE ${
+      kustoConnectionOptions.accessToken.slice(0, kustoConnectionOptions.accessToken.length - 2)
+    }");
+
     sc.stop()
   }
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -56,7 +56,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private var sc: SparkContext = _
   private var sqlContext: SQLContext = _
 
-  private val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = KustoTestUtils.getSystemTestOptions
   private val table =
     KustoQueryUtils.simplifyName(s"KustoSparkReadWriteTest_${UUID.randomUUID()}")
   private val className = this.getClass.getSimpleName

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -47,7 +47,6 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private var sc: SparkContext = _
   private var sqlContext: SQLContext = _
 
-  private var kustoConnectionOptions: KustoConnectionOptions = _
   private val table =
     KustoQueryUtils.simplifyName(s"KustoSparkReadWriteTest_${UUID.randomUUID()}")
   private val className = this.getClass.getSimpleName
@@ -63,25 +62,24 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   override def beforeAll(): Unit = {
     super.beforeAll()
     sc = spark.sparkContext
-    kustoConnectionOptions = getSystemTestOptions
     sqlContext = spark.sqlContext
-    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(kustoConnectionOptions.cluster,
-      kustoConnectionOptions.accessToken)
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(getSystemTestOptions.cluster,
+      getSystemTestOptions.accessToken)
     maybeKustoAdminClient = Some(ClientFactory.createClient(engineKcsb))
     val ingestUrl =
-      new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(kustoConnectionOptions.cluster))
+      new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(getSystemTestOptions.cluster))
         .insert(8, "ingest-")
         .toString
     val ingestKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
       ingestUrl,
-      kustoConnectionOptions.accessToken)
+      getSystemTestOptions.accessToken)
     maybeKustoDmClient = Some(ClientFactory.createClient(ingestKcsb))
     Try(
       maybeKustoAdminClient.get.execute(
-        kustoConnectionOptions.database,
+        getSystemTestOptions.database,
         generateAlterIngestionBatchingPolicyCommand(
           "database",
-          kustoConnectionOptions.database,
+          getSystemTestOptions.database,
           "{\"\"MaximumBatchingTimeSpan\"\":\"\"00:00:10\"\", \"\"MaximumNumberOfItems\"\": 500, \"\"MaximumRawDataSizeMB\"\": 1024}"))) match {
       case Success(_) => KDSU.logDebug(className, "Ingestion policy applied")
       case Failure(exception: Throwable) =>
@@ -98,7 +96,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     Try(
       // Remove table if stopping gracefully
       maybeKustoAdminClient.get
-        .execute(kustoConnectionOptions.database, generateTableDropCommand(table))) match {
+        .execute(getSystemTestOptions.database, generateTableDropCommand(table))) match {
       case Success(_) => KDSU.logDebug(className, "Ingestion policy applied")
       case Failure(e: Throwable) =>
         KDSU.reportExceptionAndThrow(className, e, "Dropping test table", shouldNotThrow = true)
@@ -150,10 +148,10 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
     dfOrig.write
       .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoConnectionOptions.cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, kustoConnectionOptions.database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, getSystemTestOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, getSystemTestOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoConnectionOptions.accessToken)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, getSystemTestOptions.accessToken)
       .option(KustoSinkOptions.KUSTO_CLIENT_REQUEST_PROPERTIES_JSON, crp.toString)
       .option(
         KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS,
@@ -166,19 +164,19 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
     val instant = Instant.now.plus(1, ChronoUnit.HOURS)
     maybeKustoAdminClient.get.execute(
-      kustoConnectionOptions.database,
+      getSystemTestOptions.database,
       generateTableAlterAutoDeletePolicy(table, instant))
 
     val conf: Map[String, String] =
-      Map(KustoSinkOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken)
+      Map(KustoSinkOptions.KUSTO_ACCESS_TOKEN -> getSystemTestOptions.accessToken)
     validateRead(conf)
   }
 
   val minimalParquetWriterVersion: String = "3.3.0"
   private def validateRead(conf: Map[String, String]) = {
     val dfResult = spark.read.kusto(
-      kustoConnectionOptions.cluster,
-      kustoConnectionOptions.database,
+      getSystemTestOptions.cluster,
+      getSystemTestOptions.database,
       table,
       conf)
     val orig = dfOrig
@@ -199,7 +197,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   "KustoSource" should "execute a read query on Kusto cluster in single mode" in {
     val conf: Map[String, String] = Map(
       KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceSingleMode.toString,
-      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken)
+      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> getSystemTestOptions.accessToken)
     validateRead(conf)
   }
 
@@ -207,7 +205,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     maybeKustoDmClient match {
       case Some(kustoIngestClient) =>
         val storageWithKey = kustoIngestClient
-          .execute(kustoConnectionOptions.database, generateGetExportContainersCommand())
+          .execute(getSystemTestOptions.database, generateGetExportContainersCommand())
           .getPrimaryResults
           .getData
           .get(0)
@@ -221,15 +219,15 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
         val conf: Map[String, String] = Map(
           KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceDistributedMode.toString,
           KustoSourceOptions.KUSTO_TRANSIENT_STORAGE -> storage.toInsecureString,
-          KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken)
+          KustoSourceOptions.KUSTO_ACCESS_TOKEN -> getSystemTestOptions.accessToken)
         val supportNewParquetWriter = new ComparableVersion(spark.version)
           .compareTo(new ComparableVersion(minimalParquetWriterVersion)) > 0
         if (supportNewParquetWriter) {
           validateRead(conf)
         } else {
           val dfResult = spark.read.kusto(
-            kustoConnectionOptions.cluster,
-            kustoConnectionOptions.database,
+            getSystemTestOptions.cluster,
+            getSystemTestOptions.database,
             table,
             conf)
           assert(dfResult.count() == expectedNumberOfRows)
@@ -248,15 +246,15 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     val conf: Map[String, String] = Map(
       KustoSourceOptions.KUSTO_READ_MODE -> ReadMode.ForceDistributedMode.toString,
       KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE -> true.toString,
-      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken)
+      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> getSystemTestOptions.accessToken)
 
     // write
     dfOrig.write
       .format("com.microsoft.kusto.spark.datasource")
-      .option(KustoSinkOptions.KUSTO_CLUSTER, kustoConnectionOptions.cluster)
-      .option(KustoSinkOptions.KUSTO_DATABASE, kustoConnectionOptions.database)
+      .option(KustoSinkOptions.KUSTO_CLUSTER, getSystemTestOptions.cluster)
+      .option(KustoSinkOptions.KUSTO_DATABASE, getSystemTestOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoConnectionOptions.accessToken)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, getSystemTestOptions.accessToken)
       .option(
         KustoSinkOptions.KUSTO_TABLE_CREATE_OPTIONS,
         SinkTableCreationMode.CreateIfNotExist.toString)
@@ -264,8 +262,8 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
       .save()
 
     val df = spark.read.kusto(
-      kustoConnectionOptions.cluster,
-      kustoConnectionOptions.database,
+      getSystemTestOptions.cluster,
+      getSystemTestOptions.database,
       table,
       conf)
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -95,13 +95,17 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     super.afterAll()
-    Try(
       // Remove table if stopping gracefully
-      maybeKustoAdminClient.get
-        .execute(kustoConnectionOptions.database, generateTableDropCommand(table))) match {
-      case Success(_) => KDSU.logDebug(className, "Ingestion policy applied")
-      case Failure(e: Throwable) =>
-        KDSU.reportExceptionAndThrow(className, e, "Dropping test table", shouldNotThrow = true)
+    maybeKustoAdminClient match {
+      case Some(kustoAdminClient) =>
+        Try(
+          kustoAdminClient
+            .execute(kustoConnectionOptions.database, generateTableDropCommand(table))) match {
+          case Success(_) => KDSU.logDebug(className, "Ingestion policy applied")
+          case Failure(e: Throwable) =>
+            KDSU.reportExceptionAndThrow(className, e, "Dropping test table", shouldNotThrow = true)
+        }
+      case None => KDSU.logWarn(className, s"Admin client is null, could not drop table $table ")
     }
     sc.stop()
   }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -17,7 +17,7 @@ package com.microsoft.kusto.spark
 
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.{Client, ClientFactory, ClientRequestProperties}
-import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions, kustoConnectionOptions}
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
 import com.microsoft.kusto.spark.common.KustoDebugOptions
 import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode, TransientStorageCredentials, TransientStorageParameters}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -63,7 +63,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private val className = this.getClass.getSimpleName
   private lazy val ingestUrl =
     new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(kustoConnectionOptions.cluster))
-      .insert(8, "ingest-")
+      .replace("https://", "https://ingest-")
       .toString
 
   private lazy val maybeKustoAdminClient: Option[Client] = Some(

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -27,7 +27,7 @@ import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils =>
 import org.apache.hadoop.util.ComparableVersion
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
-import org.scalatest.{BeforeAndAfterAll, Ignore}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.time.temporal.ChronoUnit
@@ -67,6 +67,10 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
     sqlContext = spark.sqlContext
     val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(kustoConnectionOptions.cluster,
       kustoConnectionOptions.accessToken)
+
+    KDSU.logWarn(className, message = s"******************************* Masked ACCESS TOKEN HERE ${
+      kustoConnectionOptions.accessToken.slice(0,kustoConnectionOptions.accessToken.length-2)}");
+
     maybeKustoAdminClient = Some(ClientFactory.createClient(engineKcsb))
     val ingestUrl =
       new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(kustoConnectionOptions.cluster))

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -80,7 +80,7 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   loggingLevel match {
     case Some(level) => KDSU.setLoggingLevel(level)
     // default to warn for tests
-    case None => KDSU.setLoggingLevel("WARN")
+    case None => KDSU.setLoggingLevel("DEBUG")
   }
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSourceE2E.scala
@@ -63,8 +63,8 @@ class KustoSourceE2E extends AnyFlatSpec with BeforeAndAfterAll {
   private val className = this.getClass.getSimpleName
   private lazy val ingestUrl =
     new StringBuffer(KDSU.getEngineUrlFromAliasIfNeeded(kustoConnectionOptions.cluster))
-      .replace("https://", "https://ingest-")
       .toString
+      .replace("https://", "https://ingest-")
 
   private lazy val maybeKustoAdminClient: Option[Client] = Some(
     ClientFactory.createClient(

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -219,8 +219,7 @@ private[kusto] object KustoTestUtils {
       val clusterScope = s"https://kusto.kusto.windows.net/.default"
       KDSU.logWarn(className, s"Using scope $clusterScope and authority $authority")
       val tokenRequestContext = new TokenRequestContext()
-        .setScopes(Collections.singletonList(clusterScope))
-//        .setTenantId(authority)
+        .setScopes(Collections.singletonList(clusterScope)).setTenantId(authority)
 
       val accessToken = maybeAccessTokenEnv match {
         case Some(at) =>

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -229,6 +229,9 @@ private[kusto] object KustoTestUtils {
               KDSU.reportExceptionAndThrow(
                 s"Failed to get access token for cluster $cluster, database $database & table $table at scope $clusterScope",
                 exception)
+                throw new RuntimeException(
+                  s"Failed to get access token for cluster $cluster, database $database & table $table at scope $clusterScope",
+                  exception)
           }
       }
       val kco = KustoConnectionOptions(cluster, database, accessToken, authority)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -220,7 +220,7 @@ private[kusto] object KustoTestUtils {
       KDSU.logInfo(className, s"Using scope $clusterScope and authority $authority")
       val tokenRequestContext = new TokenRequestContext()
         .setScopes(Collections.singletonList(clusterScope))
-        .setTenantId(authority)
+//        .setTenantId(authority)
 
       val accessToken = maybeAccessTokenEnv match {
         case Some(at) =>

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -202,6 +202,11 @@ private[kusto] object KustoTestUtils {
     val cluster: String = clusterToKustoFQDN(
       KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_CLUSTER))
     val database: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_DATABASE)
+    val table: String = Option(KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_TABLE))
+      .getOrElse("SparkTestTable")
+    KDSU.logInfo(
+      className,
+      s"Getting AZCli token for cluster $cluster , database $database & table $table")
     val key = s"$cluster-$database"
     if (cachedToken.contains(key)) {
       cachedToken(key)
@@ -209,6 +214,7 @@ private[kusto] object KustoTestUtils {
       val authority: String =
         System.getProperty(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
       val clusterScope = s"$cluster/.default"
+      KDSU.logInfo(className, s"Using scope $clusterScope and authority $authority")
       val tokenRequestContext = new TokenRequestContext()
         .setScopes(Collections.singletonList(clusterScope))
         .setTenantId(authority)
@@ -218,11 +224,6 @@ private[kusto] object KustoTestUtils {
         className,
         s"Created an access token for the " +
           s"test that will expire at : ${accessToken.getExpiresAt}. Scope : $clusterScope")
-
-      var table: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_TABLE)
-      if (table == null) {
-        table = "SparkTestTable"
-      }
       val kco = KustoConnectionOptions(cluster, database, accessToken.getToken, authority)
       cachedToken.put(key, kco)
       kco

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -16,22 +16,14 @@
 package com.microsoft.kusto.spark
 
 import com.azure.core.credential.TokenRequestContext
-import com.azure.identity.{AzureCliCredential, AzureCliCredentialBuilder}
+import com.azure.identity.AzureCliCredentialBuilder
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.{Client, ClientFactory}
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
-import com.microsoft.kusto.spark.datasink.{
-  KustoSinkOptions,
-  SinkTableCreationMode,
-  SparkIngestionProperties
-}
+import com.microsoft.kusto.spark.datasink.{KustoSinkOptions, SinkTableCreationMode, SparkIngestionProperties}
 import com.microsoft.kusto.spark.datasource.KustoSourceOptions
 import com.microsoft.kusto.spark.sql.extension.SparkExtension.DataFrameReaderExtension
-import com.microsoft.kusto.spark.utils.CslCommandsGenerator.{
-  generateDropTablesCommand,
-  generateFindCurrentTempTablesCommand,
-  generateTempTableCreateCommand
-}
+import com.microsoft.kusto.spark.utils.CslCommandsGenerator.{generateDropTablesCommand, generateFindCurrentTempTablesCommand, generateTempTableCreateCommand}
 import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils => KDSU}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
@@ -229,6 +221,8 @@ private[kusto] object KustoTestUtils {
         case None =>
           azureCliCredential.getTokenSync(tokenRequestContext).getToken
       }
+      val secureAt = accessToken.slice(0, accessToken.length-3)
+      KDSU.logWarn(className, message = s"************* ACCESS TOKEN HERE ${secureAt}")
       val kco = KustoConnectionOptions(cluster, database, accessToken, authority)
       cachedToken.put(key, kco)
       kco

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -216,7 +216,7 @@ private[kusto] object KustoTestUtils {
       val maybeAccessTokenEnv = Option(System.getProperty(KustoSinkOptions.KUSTO_ACCESS_TOKEN))
       val authority: String =
         System.getProperty(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
-      val clusterScope = s"$cluster/.default"
+      val clusterScope = s"https://kusto.kusto.windows.net/.default"
       KDSU.logInfo(className, s"Using scope $clusterScope and authority $authority")
       val tokenRequestContext = new TokenRequestContext()
         .setScopes(Collections.singletonList(clusterScope))

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -221,8 +221,6 @@ private[kusto] object KustoTestUtils {
         case None =>
           azureCliCredential.getTokenSync(tokenRequestContext).getToken
       }
-      val secureAt = accessToken.slice(0, accessToken.length-3)
-      KDSU.logWarn(className, message = s"************* ACCESS TOKEN HERE ${secureAt}")
       val kco = KustoConnectionOptions(cluster, database, accessToken, authority)
       cachedToken.put(key, kco)
       kco

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -218,8 +218,9 @@ private[kusto] object KustoTestUtils {
       val tokenRequestContext = new TokenRequestContext()
         .setScopes(Collections.singletonList(clusterScope))
         .setTenantId(authority)
+      val azureCliCredential = new AzureCliCredentialBuilder().build()
       val accessToken =
-        new AzureCliCredentialBuilder().build().getTokenSync(tokenRequestContext)
+        azureCliCredential.getToken(tokenRequestContext).block()
       KDSU.logInfo(
         className,
         s"Created an access token for the " +

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -1,5 +1,22 @@
+// Copyright (c) 2017 Microsoft Corporation
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.microsoft.kusto.spark
 
+import com.azure.core.credential.TokenRequestContext
+import com.azure.identity.{AzureCliCredential, AzureCliCredentialBuilder}
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
 import com.microsoft.azure.kusto.data.{Client, ClientFactory}
 import com.microsoft.kusto.spark.datasink.SinkTableCreationMode.SinkTableCreationMode
@@ -10,21 +27,27 @@ import com.microsoft.kusto.spark.datasink.{
 }
 import com.microsoft.kusto.spark.datasource.KustoSourceOptions
 import com.microsoft.kusto.spark.sql.extension.SparkExtension.DataFrameReaderExtension
-import com.microsoft.kusto.spark.utils.CslCommandsGenerator._
+import com.microsoft.kusto.spark.utils.CslCommandsGenerator.{
+  generateDropTablesCommand,
+  generateFindCurrentTempTablesCommand,
+  generateTempTableCreateCommand
+}
 import com.microsoft.kusto.spark.utils.{KustoQueryUtils, KustoDataSourceUtils => KDSU}
-import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
-import java.nio.file.{Files, Paths}
 import java.security.InvalidParameterException
-import java.util.UUID
-import scala.collection.JavaConverters._
+import java.util.{Collections, UUID}
+import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.concurrent.TimeoutException
 
 private[kusto] object KustoTestUtils {
-  private val myName = this.getClass.getSimpleName
+  private val className = this.getClass.getSimpleName
   private val loggingLevel: Option[String] = Option(System.getProperty("logLevel"))
-  if (loggingLevel.isDefined) KDSU.setLoggingLevel(loggingLevel.get)
+  loggingLevel match {
+    case Some(level) => KDSU.setLoggingLevel(level)
+    // default to warn for tests
+    case None => KDSU.setLoggingLevel("WARN")
+  }
 
   def validateResultsAndCleanup(
       kustoAdminClient: Client,
@@ -50,9 +73,10 @@ private[kusto] object KustoTestUtils {
     }
 
     if (cleanupAllTables) {
-      if (tableCleanupPrefix.isEmpty)
+      if (tableCleanupPrefix.isEmpty) {
         throw new InvalidParameterException(
           "Tables cleanup prefix must be set if 'cleanupAllTables' is 'true'")
+      }
       tryDropAllTablesByPrefix(kustoAdminClient, database, tableCleanupPrefix)
     } else {
       kustoAdminClient.execute(database, generateDropTablesCommand(table))
@@ -61,11 +85,13 @@ private[kusto] object KustoTestUtils {
     if (expectedNumberOfRows >= 0) {
       if (rowCount == expectedNumberOfRows) {
         KDSU.logInfo(
-          myName,
+          className,
           s"KustoSinkStreamingE2E: Ingestion results validated for table '$table'")
       } else {
         throw new TimeoutException(
-          s"KustoSinkStreamingE2E: Timed out waiting for ingest. $rowCount rows found in database '$database' table '$table', expected: $expectedNumberOfRows. Elapsed time:$timeElapsedMs")
+          s"KustoSinkStreamingE2E: Timed out waiting for ingest. $rowCount rows " +
+            s"found in database '$database' table '$table', expected: " +
+            s"$expectedNumberOfRows. Elapsed time:$timeElapsedMs")
       }
     }
   }
@@ -88,7 +114,7 @@ private[kusto] object KustoTestUtils {
     } catch {
       case exception: Exception =>
         KDSU.logWarn(
-          myName,
+          className,
           s"Failed to delete temporary tables with exception: ${exception.getMessage}")
     }
   }
@@ -99,16 +125,14 @@ private[kusto] object KustoTestUtils {
       targetSchema: String): String = {
 
     val table = KustoQueryUtils.simplifyName(s"${prefix}_${UUID.randomUUID()}")
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
       s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
-      kustoConnectionOptions.appId,
-      kustoConnectionOptions.appKey,
-      kustoConnectionOptions.authority)
+      kustoConnectionOptions.accessToken)
+
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
     kustoAdminClient.execute(
       kustoConnectionOptions.database,
       generateTempTableCreateCommand(table, targetSchema))
-
     table
   }
 
@@ -126,9 +150,7 @@ private[kusto] object KustoTestUtils {
       .option(KustoSinkOptions.KUSTO_CLUSTER, kustoConnectionOptions.cluster)
       .option(KustoSinkOptions.KUSTO_DATABASE, kustoConnectionOptions.database)
       .option(KustoSinkOptions.KUSTO_TABLE, table)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_ID, kustoConnectionOptions.appId)
-      .option(KustoSinkOptions.KUSTO_AAD_APP_SECRET, kustoConnectionOptions.appKey)
-      .option(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, kustoConnectionOptions.authority)
+      .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoConnectionOptions.accessToken)
       .option(KustoSinkOptions.KUSTO_ADJUST_SCHEMA, schemaAdjustmentMode)
       .option(KustoSinkOptions.KUSTO_TIMEOUT_LIMIT, (8 * 60).toString)
       .option(
@@ -143,19 +165,14 @@ private[kusto] object KustoTestUtils {
   }
 
   def cleanup(kustoConnectionOptions: KustoConnectionOptions, tablePrefix: String): Unit = {
-
-    if (tablePrefix.isEmpty)
+    if (tablePrefix.isEmpty) {
       throw new InvalidParameterException("Tables cleanup prefix must be set")
-
-    val engineKcsb = ConnectionStringBuilder.createWithAadApplicationCredentials(
-      s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
-      kustoConnectionOptions.appId,
-      kustoConnectionOptions.appKey,
-      kustoConnectionOptions.authority)
+    }
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      clusterToKustoFQDN(kustoConnectionOptions.cluster),
+      kustoConnectionOptions.accessToken)
     val kustoAdminClient = ClientFactory.createClient(engineKcsb)
-
     tryDropAllTablesByPrefix(kustoAdminClient, kustoConnectionOptions.database, tablePrefix)
-
   }
 
   def validateTargetTable(
@@ -165,19 +182,35 @@ private[kusto] object KustoTestUtils {
       spark: SparkSession): Boolean = {
 
     val conf = Map[String, String](
-      KustoSourceOptions.KUSTO_AAD_APP_ID -> kustoConnectionOptions.appId,
-      KustoSourceOptions.KUSTO_AAD_APP_SECRET -> kustoConnectionOptions.appKey,
-      KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID -> kustoConnectionOptions.authority)
+      KustoSourceOptions.KUSTO_ACCESS_TOKEN -> kustoConnectionOptions.accessToken)
 
     val tableRows = spark.read
       .kusto(
-        s"https://${kustoConnectionOptions.cluster}.kusto.windows.net",
+        clusterToKustoFQDN(kustoConnectionOptions.cluster),
         kustoConnectionOptions.database,
         tableName,
         conf)
 
     tableRows.count() == tableRows.intersectAll(expectedRows).count()
 
+  }
+
+  def getSystemTestOptions: KustoConnectionOptions = {
+    val cluster: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_CLUSTER)
+    val authority: String =
+      System.getProperty(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID, "microsoft.com")
+    val clusterScope = clusterToKustoFQDN(cluster)
+    val tokenRequestContext = new TokenRequestContext()
+      .setScopes(Collections.singletonList(clusterScope))
+      .setTenantId(authority)
+    val accessToken: String =
+      new AzureCliCredentialBuilder().build().getTokenSync(tokenRequestContext).getToken
+    val database: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_DATABASE)
+    var table: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_TABLE)
+    if (table == null) {
+      table = "SparkTestTable"
+    }
+    KustoConnectionOptions(cluster, database, accessToken)
   }
 
   private def getSystemVariable(key: String) = {
@@ -188,32 +221,17 @@ private[kusto] object KustoTestUtils {
     value
   }
 
-  def getSystemTestOptions: KustoConnectionOptions = {
-    val appId: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_AAD_APP_ID)
-    var appKey: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_AAD_APP_SECRET)
-    var authority: String =
-      KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_AAD_AUTHORITY_ID)
-    if (StringUtils.isBlank(authority)) authority = "microsoft.com"
-    val cluster: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_CLUSTER)
-    val database: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_DATABASE)
-    var table: String = KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_TABLE)
-    if (table == null) {
-      table = "SparkTestTable"
+  private def clusterToKustoFQDN(cluster: String): String = {
+    if (cluster.startsWith("https://")) {
+      cluster
+    } else {
+      s"https://$cluster.kusto.windows.net"
     }
-    if (appKey == null) {
-      val secretPath = KustoTestUtils.getSystemVariable("SecretPath")
-      if (secretPath == null) throw new IllegalArgumentException("SecretPath is not set")
-      appKey = Files.readAllLines(Paths.get(secretPath)).get(0)
-    }
-
-    KustoConnectionOptions(cluster, database, appId, appKey, authority)
   }
 
-  case class KustoConnectionOptions(
+  final case class KustoConnectionOptions(
       cluster: String,
       database: String,
-      appId: String,
-      appKey: String,
-      authority: String,
+      accessToken: String,
       createTableIfNotExists: SinkTableCreationMode = SinkTableCreationMode.CreateIfNotExist)
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoTestUtils.scala
@@ -199,7 +199,7 @@ private[kusto] object KustoTestUtils {
     KDSU.logInfo(
       className,
       s"Getting AZCli token for cluster $cluster , database $database & table $table")
-    val key = s"$cluster-$database"
+    val key = s"$cluster"
     if (cachedToken.contains(key)) {
       cachedToken(key)
     } else {
@@ -211,7 +211,7 @@ private[kusto] object KustoTestUtils {
       val tokenRequestContext = new TokenRequestContext()
         .setScopes(Collections.singletonList(clusterScope))
         .setTenantId(authority)
-      val azureCliCredential = new AzureCliCredentialBuilder().build()
+
       val accessToken = maybeAccessTokenEnv match {
         case Some(at) =>
           KDSU.logInfo(
@@ -219,6 +219,7 @@ private[kusto] object KustoTestUtils {
             s"Using access token from environment variable ${KustoSinkOptions.KUSTO_ACCESS_TOKEN}")
           at
         case None =>
+          val azureCliCredential = new AzureCliCredentialBuilder().build()
           azureCliCredential.getTokenSync(tokenRequestContext).getToken
       }
       val kco = KustoConnectionOptions(cluster, database, accessToken, authority)

--- a/docs/Spark-Kusto DataTypes mapping.md
+++ b/docs/Spark-Kusto DataTypes mapping.md
@@ -8,6 +8,7 @@ When writing to or reading from a Kusto table, the connector converts types from
 | Spark data type | Kusto data type |
 |-----------------|-----------------|
 | StringType      | string          |
+| BinaryType      | string          |
 | IntegerType     | int             |
 | LongType        | long            |
 | BooleanType     | bool            |
@@ -46,6 +47,8 @@ When writing to or reading from a Kusto table, the connector converts types from
 Kusto **datetime** data type is always read in '%Y-%m-%d %H:%M:%s' format , while **timespan** format is '%H:%M:%s'. On the other
 hand spark **DateType** is of format '%Y-%m-%d' and **TimestampType** is of format '%Y-%m-%d %H:%M:%s'. This is why Kusto 'timespan' 
 type is translated into a string by the connector and **we recommend using only datetime and TimestampType**. 
+
+Spark **BinaryType** is convereted to a base 64 encoded string.
 
 Kusto **decimal** type 
 - Kusto as a source : The precision and scale supported with Kusto as a source is (38,18) respectively.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>5.0.6</revision>
+        <revision>5.0.7</revision>
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>
         <scalafmt.plugin.version>1.1.1640084764.9f463a9</scalafmt.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,8 @@
         <shadingPrefix>azure_kusto_spark</shadingPrefix>
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <specs2.version>3.6.5</specs2.version>
-        <msal4j.version>1.13.9</msal4j.version>
+        <msal4j.version>1.15.0</msal4j.version>
+        <az.identity.version>1.12.0</az.identity.version>
     </properties>
 
     <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
Pull Request Description
Today BinaryType columns get written as a string by just using .toString on a byte array resulting in a value similar to [B@7fdcec67. This PR updates the handling of this column type to write a base64 encoded string instead.

Original PR: https://github.com/Azure/azure-kusto-spark/pull/370 , just cherrypicked the commits