### PR TITLE
Fixes blob clientBatchLimit implementation

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -34,11 +34,6 @@
             <version>${commons.lang3.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>${commons.text.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
             <version>${kusto.sdk.version}</version>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -32,7 +32,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
@@ -167,6 +172,11 @@
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
         </dependency>
     </dependencies>
     <!-- Build properties -->

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -12,32 +12,17 @@ import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
 import com.microsoft.azure.kusto.ingest.resources.ContainerWithSas
 import com.microsoft.azure.kusto.ingest.result.IngestionResult
 import com.microsoft.azure.kusto.ingest.source.{BlobSourceInfo, StreamSourceInfo}
-import com.microsoft.azure.kusto.ingest.{
-  IngestClient,
-  IngestionProperties,
-  ManagedStreamingIngestClient
-}
+import com.microsoft.azure.kusto.ingest.{IngestClient, IngestionProperties, ManagedStreamingIngestClient}
 import com.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlockBlob}
 import com.microsoft.kusto.spark.authentication.KustoAuthentication
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.FinalizeHelper.finalizeIngestionWhenWorkersSucceeded
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator.generateTableGetSchemaAsRowsCommand
-import com.microsoft.kusto.spark.utils.KustoConstants.{
-  IngestSkippedTrace,
-  MaxIngestRetryAttempts,
-  WarnStreamingBytes
-}
-import com.microsoft.kusto.spark.utils.{
-  ByteArrayOutputStreamWithOffset,
-  ExtendedKustoClient,
-  KustoClientCache,
-  KustoIngestionUtils,
-  KustoQueryUtils,
-  KustoConstants => KCONST,
-  KustoDataSourceUtils => KDSU
-}
+import com.microsoft.kusto.spark.utils.KustoConstants.{IngestSkippedTrace, MaxIngestRetryAttempts, WarnStreamingBytes}
+import com.microsoft.kusto.spark.utils.{ByteArrayOutputStreamWithOffset, ExtendedKustoClient, KustoClientCache, KustoIngestionUtils, KustoQueryUtils, KustoConstants => KCONST, KustoDataSourceUtils => KDSU}
 import io.github.resilience4j.retry.RetryConfig
 import org.apache.commons.io.IOUtils
+import org.apache.commons.io.output.CountingOutputStream
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
@@ -538,11 +523,9 @@ object KustoWriter {
     val currentSas = containerAndSas.sas
     val options = new BlobRequestOptions()
     options.setConcurrentRequestCount(4) // Should be configured from outside
-    val gzip: GZIPOutputStream = new GZIPOutputStream(
-      currentBlob.openOutputStream(null, options, null))
-
+    val countingOutputStream = new CountingOutputStream(currentBlob.openOutputStream(null, options, null))
+    val gzip: GZIPOutputStream = new GZIPOutputStream(countingOutputStream)
     val writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)
-
     val buffer: BufferedWriter = new BufferedWriter(writer, GzipBufferSize)
     val csvWriter = CountingWriter(buffer)
     BlobWriteResource(buffer, gzip, csvWriter, currentBlob, currentSas)
@@ -703,12 +686,7 @@ object KustoWriter {
   }
 }
 
-final case class BlobWriteResource(
-    writer: BufferedWriter,
-    gzip: GZIPOutputStream,
-    csvWriter: CountingWriter,
-    blob: CloudBlockBlob,
-    sas: String)
+final case class BlobWriteResource(writer: BufferedWriter, gzip: OutputStream, csvWriter: CountingWriter, blob: CloudBlockBlob, sas: String)
 final case class KustoWriteResource(
     authentication: KustoAuthentication,
     coordinates: KustoCoordinates,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -645,21 +645,14 @@ object KustoWriter {
     // Serialize rows to ingest and send to blob storage.
     val lastBlobWriter = rows.zipWithIndex.foldLeft[BlobWriteResource](initialBlobWriter) {
       case (blobWriter, row) =>
-        println(
-          "--------------->>>>>> blob size before : " + blobWriter.csvWriter.getCounter + " : blobuuid: " + curBlobUUID);
         RowCSVWriterUtils.writeRowAsCSV(row._1, parameters.schema, timeZone, blobWriter.csvWriter)
 
         val count =
           blobWriter.countingOutputStream.getByteCount // blobWriter.csvWriter.getCounter
-        println(
-          "--------------->>>>>> blob size AFTER : " + blobWriter.csvWriter.getCounter + " : blobuuid: " + curBlobUUID + " : Maxsize; " + maxBlobSize);
         val shouldNotCommitBlockBlob = count < maxBlobSize
         if (shouldNotCommitBlockBlob) {
-          println("----------->>> Not committing blob yet, size: " + count);
           blobWriter
         } else {
-          println(
-            "--------------->>>>>> blob size: maxedout " + count + " : blobuuid: " + curBlobUUID);
           KDSU.logInfo(
             className,
             s"ELSEEEEE  blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
@@ -672,8 +665,6 @@ object KustoWriter {
               s"Sealing blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
                 s"blob number ${row._2}, with size $count blob: $curBlobUUID")
             finalizeBlobWrite(blobWriter)
-            println(
-              "--------------->>>>>> blob size: maxedout : ingest size: " + blobWriter.countingOutputStream.getByteCount);
             ingest(
               blobWriter,
               blobWriter.csvWriter.getCounter,
@@ -696,8 +687,6 @@ object KustoWriter {
       if (parameters.writeOptions.ensureNoDupBlobs) {
         taskMap.put(curBlobUUID, lastBlobWriter)
       } else {
-        println(
-          "------------->>>>>> ingesting the data ensure nodupes : " + lastBlobWriter.csvWriter.getCounter);
         ingest(
           lastBlobWriter,
           lastBlobWriter.csvWriter.getCounter,
@@ -711,8 +700,6 @@ object KustoWriter {
       taskMap.forEach((uuid, bw) => {
         ingest(bw, bw.csvWriter.getCounter, bw.sas, flushImmediately = false, uuid, kustoClient)
       })
-      println(
-        "------------->>>>>> finishing the ingestrows: " + lastBlobWriter.csvWriter.getCounter);
     }
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -12,14 +12,30 @@ import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
 import com.microsoft.azure.kusto.ingest.resources.ContainerWithSas
 import com.microsoft.azure.kusto.ingest.result.IngestionResult
 import com.microsoft.azure.kusto.ingest.source.{BlobSourceInfo, StreamSourceInfo}
-import com.microsoft.azure.kusto.ingest.{IngestClient, IngestionProperties, ManagedStreamingIngestClient}
+import com.microsoft.azure.kusto.ingest.{
+  IngestClient,
+  IngestionProperties,
+  ManagedStreamingIngestClient
+}
 import com.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlockBlob}
 import com.microsoft.kusto.spark.authentication.KustoAuthentication
 import com.microsoft.kusto.spark.common.KustoCoordinates
 import com.microsoft.kusto.spark.datasink.FinalizeHelper.finalizeIngestionWhenWorkersSucceeded
 import com.microsoft.kusto.spark.utils.CslCommandsGenerator.generateTableGetSchemaAsRowsCommand
-import com.microsoft.kusto.spark.utils.KustoConstants.{IngestSkippedTrace, MaxIngestRetryAttempts, WarnStreamingBytes}
-import com.microsoft.kusto.spark.utils.{ByteArrayOutputStreamWithOffset, ExtendedKustoClient, KustoClientCache, KustoIngestionUtils, KustoQueryUtils, KustoConstants => KCONST, KustoDataSourceUtils => KDSU}
+import com.microsoft.kusto.spark.utils.KustoConstants.{
+  IngestSkippedTrace,
+  MaxIngestRetryAttempts,
+  WarnStreamingBytes
+}
+import com.microsoft.kusto.spark.utils.{
+  ByteArrayOutputStreamWithOffset,
+  ExtendedKustoClient,
+  KustoClientCache,
+  KustoIngestionUtils,
+  KustoQueryUtils,
+  KustoConstants => KCONST,
+  KustoDataSourceUtils => KDSU
+}
 import io.github.resilience4j.retry.RetryConfig
 import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.CountingOutputStream
@@ -344,18 +360,19 @@ object KustoWriter {
     //    val byteArrayPool = Array[ByteArrayOutputStream](new ByteArrayOutputStream(), null)// Init the 2nd lazy.
     //    val byteArrayOutputStream = byteArrayPool[]
     var byteArrayOutputStream = new ByteArrayOutputStreamWithOffset()
-    var streamWriter = new OutputStreamWriter(byteArrayOutputStream)
+    var countingOutputStream = new CountingOutputStream(byteArrayOutputStream)
+    var streamWriter = new OutputStreamWriter(countingOutputStream)
     var writer = new BufferedWriter(streamWriter)
-    var csvWriter = CountingWriter(writer)
+    var csvWriter = new CountingWriter(writer)
     var totalSize = 0L
     var lastIndex = 0
     for ((row, index) <- rows.zipWithIndex) {
       RowCSVWriterUtils.writeRowAsCSV(row, parameters.schema, timeZone, csvWriter)
-      if (csvWriter.getCounter >= parameters.writeOptions.streamIngestUncompressedMaxSize) {
+      if (countingOutputStream.getByteCount >= parameters.writeOptions.streamIngestUncompressedMaxSize) {
         KDSU.logWarn(
           className,
           s"Batch $batchIdForTracing exceeds the max streaming size ${parameters.writeOptions.streamIngestUncompressedMaxSize} " +
-            s"MB compressed!.Streaming ${csvWriter.getCounter} bytes from batch $batchIdForTracing." +
+            s"MB compressed!.Streaming ${countingOutputStream.getByteCount} bytes from batch $batchIdForTracing." +
             s"Index of the batch ($index).")
         writer.flush()
         streamWriter.flush()
@@ -377,8 +394,9 @@ object KustoWriter {
           lastIndex = bb2.size()
           // TODO Is it really better > (other option is to copy the data from the stream to a new stream - which i try to avoid)?
           streamWriter = new OutputStreamWriter(byteArrayOutputStream)
+          countingOutputStream = new CountingOutputStream(byteArrayOutputStream)
           writer = new BufferedWriter(streamWriter)
-          csvWriter = CountingWriter(writer, bb2.size())
+          csvWriter = new CountingWriter(writer, bb2.size())
         } else {
           KDSU.logInfo(
             className,
@@ -391,8 +409,9 @@ object KustoWriter {
             streamingClient,
             byteArrayOutputStream.size())
           byteArrayOutputStream.reset()
-          totalSize += csvWriter.getCounter
+          totalSize += countingOutputStream.getByteCount
           csvWriter.resetCounter()
+          countingOutputStream.resetByteCount()
         }
       } else {
         // flush before counting output size
@@ -523,12 +542,13 @@ object KustoWriter {
     val currentSas = containerAndSas.sas
     val options = new BlobRequestOptions()
     options.setConcurrentRequestCount(4) // Should be configured from outside
-    val countingOutputStream = new CountingOutputStream(currentBlob.openOutputStream(null, options, null))
+    val countingOutputStream = new CountingOutputStream(
+      currentBlob.openOutputStream(null, options, null))
     val gzip: GZIPOutputStream = new GZIPOutputStream(countingOutputStream)
     val writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)
     val buffer: BufferedWriter = new BufferedWriter(writer, GzipBufferSize)
-    val csvWriter = CountingWriter(buffer)
-    BlobWriteResource(buffer, gzip, csvWriter, currentBlob, currentSas)
+    val csvWriter = new CountingWriter(buffer)
+    BlobWriteResource(buffer, gzip, csvWriter, currentBlob, currentSas, countingOutputStream)
   }
 
   @throws[IOException]
@@ -593,7 +613,7 @@ object KustoWriter {
                 className,
                 e,
                 s"Queueing blob for ingestion, retry number '$i', in partition " +
-                  s"$partitionIdString for requestId: '${parameters.writeOptions.requestId}")
+                  s"$partitionIdString for requestId: '${parameters.writeOptions.requestId} blob: $blobUUID")
               val blobUrlWithSas =
                 s"${blobResource.blob.getStorageUri.getPrimaryUri.toString}${blobResource.sas}"
               val containerWithSas = new ContainerWithSas(blobUrlWithSas, null)
@@ -625,21 +645,35 @@ object KustoWriter {
     // Serialize rows to ingest and send to blob storage.
     val lastBlobWriter = rows.zipWithIndex.foldLeft[BlobWriteResource](initialBlobWriter) {
       case (blobWriter, row) =>
+        println(
+          "--------------->>>>>> blob size before : " + blobWriter.csvWriter.getCounter + " : blobuuid: " + curBlobUUID);
         RowCSVWriterUtils.writeRowAsCSV(row._1, parameters.schema, timeZone, blobWriter.csvWriter)
 
-        val count = blobWriter.csvWriter.getCounter
+        val count =
+          blobWriter.countingOutputStream.getByteCount // blobWriter.csvWriter.getCounter
+        println(
+          "--------------->>>>>> blob size AFTER : " + blobWriter.csvWriter.getCounter + " : blobuuid: " + curBlobUUID + " : Maxsize; " + maxBlobSize);
         val shouldNotCommitBlockBlob = count < maxBlobSize
         if (shouldNotCommitBlockBlob) {
+          println("----------->>> Not committing blob yet, size: " + count);
           blobWriter
         } else {
+          println(
+            "--------------->>>>>> blob size: maxedout " + count + " : blobuuid: " + curBlobUUID);
+          KDSU.logInfo(
+            className,
+            s"ELSEEEEE  blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
+              s"blob number ${row._2}, with size $count blob: $curBlobUUID ${blobWriter.countingOutputStream.getByteCount}")
           if (parameters.writeOptions.ensureNoDupBlobs) {
             taskMap.put(curBlobUUID, blobWriter)
           } else {
             KDSU.logInfo(
               className,
               s"Sealing blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
-                s"blob number ${row._2}, with size $count")
+                s"blob number ${row._2}, with size $count blob: $curBlobUUID")
             finalizeBlobWrite(blobWriter)
+            println(
+              "--------------->>>>>> blob size: maxedout : ingest size: " + blobWriter.countingOutputStream.getByteCount);
             ingest(
               blobWriter,
               blobWriter.csvWriter.getCounter,
@@ -662,6 +696,8 @@ object KustoWriter {
       if (parameters.writeOptions.ensureNoDupBlobs) {
         taskMap.put(curBlobUUID, lastBlobWriter)
       } else {
+        println(
+          "------------->>>>>> ingesting the data ensure nodupes : " + lastBlobWriter.csvWriter.getCounter);
         ingest(
           lastBlobWriter,
           lastBlobWriter.csvWriter.getCounter,
@@ -675,6 +711,8 @@ object KustoWriter {
       taskMap.forEach((uuid, bw) => {
         ingest(bw, bw.csvWriter.getCounter, bw.sas, flushImmediately = false, uuid, kustoClient)
       })
+      println(
+        "------------->>>>>> finishing the ingestrows: " + lastBlobWriter.csvWriter.getCounter);
     }
   }
 
@@ -686,7 +724,13 @@ object KustoWriter {
   }
 }
 
-final case class BlobWriteResource(writer: BufferedWriter, gzip: OutputStream, csvWriter: CountingWriter, blob: CloudBlockBlob, sas: String)
+final case class BlobWriteResource(
+    writer: BufferedWriter,
+    gzip: OutputStream,
+    csvWriter: CountingWriter,
+    blob: CloudBlockBlob,
+    sas: String,
+    countingOutputStream: CountingOutputStream)
 final case class KustoWriteResource(
     authentication: KustoAuthentication,
     coordinates: KustoCoordinates,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/Writers.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/Writers.scala
@@ -44,8 +44,7 @@ class CountingWriter(outwriter: java.io.Writer, var bytesCounter: Long = 0L) ext
 
   override def writeStringField(str: String): Unit = {
     if (str.nonEmpty) {
-      StringEscapeUtils.escapeJava(str)
-      /*outwriter.write('"')
+      outwriter.write('"')
       bytesCounter += 2
       for (c <- str) {
         if (c == '"') {
@@ -56,7 +55,7 @@ class CountingWriter(outwriter: java.io.Writer, var bytesCounter: Long = 0L) ext
         }
       }
       outwriter.write('"')
-      bytesCounter += str.length*/
+      bytesCounter += str.length
     }
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/Writers.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/Writers.scala
@@ -68,7 +68,7 @@ class CountingWriter(outwriter: java.io.Writer, var bytesCounter: Long = 0L) ext
   override val out: io.Writer = outwriter
 }
 
-case class EscapedWriter(out: java.io.Writer) extends Writer { // stringEscapUtils
+case class EscapedWriter(out: java.io.Writer) extends Writer {
   override def write(c: Char): Unit = {
     out.write(c)
   }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -62,7 +62,7 @@ class WriterTests extends AnyFlatSpec with Matchers {
     val byteArrayOutputStream = new ByteArrayOutputStream()
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
-    val csvWriter = CountingWriter(writer)
+    val csvWriter = new CountingWriter(writer)
     RowCSVWriterUtils.writeRowAsCSV(
       dfRow,
       df.schema,
@@ -83,7 +83,7 @@ class WriterTests extends AnyFlatSpec with Matchers {
     val byteArrayOutputStream = new ByteArrayOutputStream()
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
-    var csvWriter = CountingWriter(writer)
+    var csvWriter = new CountingWriter(writer)
     RowCSVWriterUtils.writeRowAsCSV(
       dfRow,
       df.schema,
@@ -102,7 +102,7 @@ class WriterTests extends AnyFlatSpec with Matchers {
     val byteArrayOutputStream = new ByteArrayOutputStream()
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
-    val csvWriter = CountingWriter(writer)
+    val csvWriter = new CountingWriter(writer)
 
     RowCSVWriterUtils.writeRowAsCSV(
       dfRow,
@@ -117,9 +117,9 @@ class WriterTests extends AnyFlatSpec with Matchers {
   "finalizeFileWrite" should "should flush and close buffers" in {
     val gzip = mock(classOf[GZIPOutputStream])
     val buffer = mock(classOf[BufferedWriter])
-    val csvWriter = CountingWriter(buffer)
+    val csvWriter = new CountingWriter(buffer)
 
-    val fileWriteResource = BlobWriteResource(buffer, gzip, csvWriter, null, null)
+    val fileWriteResource = BlobWriteResource(buffer, gzip, csvWriter, null, null, null)
     KustoWriter.finalizeBlobWrite(fileWriteResource)
 
     verify(gzip, times(1)).flush()
@@ -251,7 +251,7 @@ class WriterTests extends AnyFlatSpec with Matchers {
     val byteArrayOutputStream = new ByteArrayOutputStream()
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
-    val csvWriter = CountingWriter(writer)
+    val csvWriter = new CountingWriter(writer)
 
     RowCSVWriterUtils.writeRowAsCSV(dfRow, df.schema, tz.getZone, csvWriter)
 
@@ -307,14 +307,13 @@ class WriterTests extends AnyFlatSpec with Matchers {
     val byteArrayOutputStream = new ByteArrayOutputStream()
     val streamWriter = new OutputStreamWriter(byteArrayOutputStream)
     val writer = new BufferedWriter(streamWriter)
-    val csvWriter = CountingWriter(writer)
+    val csvWriter = new CountingWriter(writer)
 
     val someData =
       List(
         "Test string for spark binary".getBytes(),
         "A second test string for spark binary".getBytes(),
-        null
-      )
+        null)
 
     val someSchema = List(StructField("binaryString", BinaryType, nullable = true))
 
@@ -324,9 +323,21 @@ class WriterTests extends AnyFlatSpec with Matchers {
 
     val dfRows: Array[InternalRow] = df.queryExecution.toRdd.collect()
 
-    RowCSVWriterUtils.writeRowAsCSV(dfRows(0), df.schema, TimeZone.getTimeZone("UTC").toZoneId, csvWriter)
-    RowCSVWriterUtils.writeRowAsCSV(dfRows(1), df.schema, TimeZone.getTimeZone("UTC").toZoneId, csvWriter)
-    RowCSVWriterUtils.writeRowAsCSV(dfRows(2), df.schema, TimeZone.getTimeZone("UTC").toZoneId, csvWriter)
+    RowCSVWriterUtils.writeRowAsCSV(
+      dfRows(0),
+      df.schema,
+      TimeZone.getTimeZone("UTC").toZoneId,
+      csvWriter)
+    RowCSVWriterUtils.writeRowAsCSV(
+      dfRows(1),
+      df.schema,
+      TimeZone.getTimeZone("UTC").toZoneId,
+      csvWriter)
+    RowCSVWriterUtils.writeRowAsCSV(
+      dfRows(2),
+      df.schema,
+      TimeZone.getTimeZone("UTC").toZoneId,
+      csvWriter)
 
     writer.flush()
     val res1 = byteArrayOutputStream.toString

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <jsonsmart.version>2.4.10</jsonsmart.version>
         <junit4.version>4.13.2</junit4.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
+        <commons.text.version>1.13.0</commons.text.version>
+        <commons.io.version>2.18.0</commons.io.version>
         <hadoop.version>3.3.6</hadoop.version>
         <kusto.sdk.version>5.1.1</kusto.sdk.version>
         <java.source.version>1.8</java.source.version>


### PR DESCRIPTION
#### Pull Request Description

Using CountingOutputStream to calculate the size of the stream before writing to the blob storage. This fixes that was resulting multiple blobs of smaller sizes.

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
