### PR TITLE
Remove V3 engine check

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -98,10 +98,6 @@ private[kusto] object CslCommandsGenerator {
     s""".show materialized-views | where SourceTable == '$destinationTableName' | count"""
   }
 
-  def generateIsTableEngineV3(tableName: String): String = {
-    s""".show table ${tableName} details | project todynamic(ShardingPolicy).UseShardEngine"""
-  }
-
   def generateTableMoveExtentsCommand(
       sourceTableName: String,
       destinationTableName: String,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
@@ -44,7 +44,7 @@ import org.apache.log4j.Level
 import org.apache.spark.sql.types.StructType
 
 import java.time.{Instant, OffsetDateTime}
-import java.util.{StringJoiner, UUID}
+import java.util.{Objects, StringJoiner, UUID}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
@@ -527,18 +527,13 @@ class ExtendedKustoClient(
         generateIsTableMaterializedViewSourceCommand(targetTable),
         "isTableMV",
         crp).getPrimaryResults
-    isDestinationTableMaterializedViewSourceResult.next()
-    val isDestinationTableMaterializedViewSource: Boolean =
-      isDestinationTableMaterializedViewSourceResult.getLong(0) > 0
-    if (isDestinationTableMaterializedViewSource) {
-      val res =
-        executeEngine(
-          database,
-          generateIsTableEngineV3(targetTable),
-          "isTableV3",
-          crp).getPrimaryResults
-      res.next()
-      res.getBoolean(0)
+    // Added a check just to be sure that
+    if (!Objects.isNull(isDestinationTableMaterializedViewSourceResult) &&
+      isDestinationTableMaterializedViewSourceResult.hasNext) {
+      isDestinationTableMaterializedViewSourceResult.next()
+      val isDestinationTableMaterializedViewSource: Boolean =
+        isDestinationTableMaterializedViewSourceResult.getLong(0) > 0
+      isDestinationTableMaterializedViewSource
     } else {
       false
     }


### PR DESCRIPTION
This pull request primarily refactors how the system checks if a table is a materialized view source and removes an unused method for determining if a table uses Engine V3. The logic for checking if a table is a materialized view source is simplified, and unnecessary code is eliminated.

Key changes include:

### Refactoring and Code Simplification

* Removed the `generateIsTableEngineV3` method from `CslCommandsGenerator` as it is no longer used.
* Simplified the logic in `ExtendedKustoClient` for checking if a table is a materialized view source by eliminating the Engine V3 check and directly returning the result.
