### PR TITLE
Remove unused dependencies

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -12,11 +12,6 @@
     </parent>
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
             <version>${kusto.sdk.version}</version>
@@ -86,6 +81,12 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
             <version>${azure.storage.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-lang3</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -119,8 +120,8 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>commons-lang</artifactId>
-                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                    <groupId>org.apache.commons</groupId>
                 </exclusion>
                 <exclusion>
                     <artifactId>jsr305</artifactId>


### PR DESCRIPTION
This pull request updates the Maven dependencies in the `connector/pom.xml` file to clean up and better manage the usage of the `commons-lang3` library. The main focus is on removing direct and transitive dependencies on `commons-lang3` where they are not needed.

Dependency management improvements:

* Removed the direct dependency on `commons-lang3` from the `connector/pom.xml` file, reducing unnecessary dependencies.
* Excluded `commons-lang3` as a transitive dependency from the `azure-storage` dependency to prevent it from being included indirectly.
* Updated the exclusions for the `azure-storage` dependency under the `<scope>provided</scope>` section to exclude `commons-lang3` from `org.apache.commons` instead of the older `commons-lang` from `commons-lang`.