### PR TITLE
Fixed readMode check for StorageProtocol

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -87,6 +87,21 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-core</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>${io.vavr.version}</version>
+        </dependency>
         <!--might need 3.2.0 here for local run query-->
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -49,7 +49,6 @@ import java.io.InputStream
 import java.net.URI
 import java.security.InvalidParameterException
 import java.util
-import java.util.Locale
 import java.util.concurrent.{Callable, CountDownLatch, TimeUnit}
 import java.util.{
   NoSuchElementException,
@@ -144,13 +143,6 @@ object KustoDataSourceUtils {
           val errorMessage =
             s"Invalid value for ${KustoSourceOptions.STORAGE_PROTOCOL}: '$protocol'. " +
               s"Must be either '${KCONST.storageProtocolWasbs}', '${KCONST.storageProtocolAbfs}', or '${KCONST.storageProtocolAbfss}'."
-          logError(className, errorMessage)
-          throw new IllegalArgumentException(errorMessage)
-        }
-        // Validate that storageProtocol is only used with ForceDistributedMode
-        if (readMode.isDefined && readMode.get != ReadMode.ForceDistributedMode) {
-          val errorMessage = s"${KustoSourceOptions.STORAGE_PROTOCOL} can only be used with " +
-            s"${KustoSourceOptions.KUSTO_READ_MODE}='ForceDistributedMode'"
           logError(className, errorMessage)
           throw new IllegalArgumentException(errorMessage)
         }

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
         <java.source.version>21</java.source.version>
         <kusto.sdk.version>7.0.3</kusto.sdk.version>
+        <resilience4j.version>1.7.1</resilience4j.version>
+        <io.vavr.version>0.10.4</io.vavr.version>
         <slf4j.version>2.0.17</slf4j.version>
 
         <!-- Provided-scoped dependency versions (provided by runtime/Spark/Hadoop) -->


### PR DESCRIPTION
#### Pull Request Description

This pull request introduces new dependencies to support resilience and functional programming features, and makes a small change to validation logic in the Kusto data source utility. The most important changes are summarized below:

**Dependency additions:**

* Added `resilience4j-retry` and `resilience4j-core` dependencies to `connector/pom.xml` to enable retry and resilience patterns in the connector.
* Added `vavr` dependency to `connector/pom.xml` to support functional programming constructs.
* Defined new version properties for `resilience4j` and `vavr` in the root `pom.xml`.

**Validation logic update:**

* Removed the restriction that required `storageProtocol` to only be used with `ForceDistributedMode` in `KustoDataSourceUtils.scala`, allowing more flexible configuration.

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
