### PR TITLE
[fix]: Github release pipeline fixing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          name: "kusto-spark ${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}"
+          name: ${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.VERSION }}"
           generate_release_notes: true
           files: |
             staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     environment: build
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 on:
   push:
     tags:
-      - "v(2.4|3.0|4.0)_[0-9]+.[0-9]+.[0-9]+"
+      - 'v[34].0_[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:
@@ -20,14 +20,15 @@ on:
       upload_to_azure:
         description: 'Upload to Azure storage'
         required: false
-        default: false
+        default: 'false'
       github_release:
         description: 'Create Github release'
         required: false
-        default: false
+        default: 'false'
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     environment: build
     strategy:
@@ -67,9 +68,9 @@ jobs:
       - name: Get versions
         id: get_version
         run: |
-          echo ::set-output name=VERSION::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo ::set-output name=SCALA_VERSION::$(mvn help:evaluate -Dexpression=scala.version.major -q -DforceStdout)
-          echo ::set-output name=SPARK_VERSION::$(mvn help:evaluate -Dexpression=spark.version.major -q -DforceStdout)
+          echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+          echo "SCALA_VERSION=$(mvn help:evaluate -Dexpression=scala.version.major -q -DforceStdout)" >> $GITHUB_OUTPUT
+          echo "SPARK_VERSION=$(mvn help:evaluate -Dexpression=spark.version.major -q -DforceStdout)" >> $GITHUB_OUTPUT
       - name: Move artifacts to staging
         run: |
           version=${{ steps.get_version.outputs.VERSION }}
@@ -80,14 +81,17 @@ jobs:
           cp connector/target/*.jar staging
           cp connector/.flattened-pom.xml staging/kusto-spark_${{steps.get_version.outputs.SPARK_VERSION}}_${{steps.get_version.outputs.SCALA_VERSION}}-$version.pom
       - name: Github Release
-        uses: docker://antonyurchenko/git-release:v6
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: "kusto-spark ${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}"
+          generate_release_notes: true
+          files: |
+            staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}.jar
+            staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}-sources.jar
+            staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}.pom
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: |
-            staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}-jar-with-dependencies.jar
-            staging/kusto-spark_${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.SCALA_VERSION }}-${{ steps.get_version.outputs.VERSION }}-sources.jar
-        continue-on-error: true
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.github_release == 'true') }}
       - name: Azure login for azuresdkpartnerdrops SA
         uses: azure/login@v2


### PR DESCRIPTION
#### Pull Request Description
This pull request updates the release workflow in `.github/workflows/release.yml` to improve reliability and compatibility with GitHub Actions. The key changes include updating tag matching patterns, correcting input defaults, modernizing output setting syntax, and switching to a new GitHub release action.

Release workflow improvements:

* Updated the tag matching pattern in the `push` trigger to support both v3.0 and v4.0 releases and simplify the regex.
* Changed the default values for workflow inputs (`upload_to_azure`, `github_release`) to string `'false'` for better compatibility with GitHub Actions input parsing.
* Added a conditional to the `release` job to prevent running on branch names containing hyphens, except for manual dispatches.

GitHub Actions modernization:

* Replaced deprecated `::set-output` syntax with the new `$GITHUB_OUTPUT` format for setting output variables in shell steps.
* Switched the GitHub Release step from a Docker-based action (`antonyurchenko/git-release`) to the official `softprops/action-gh-release`, added automatic release notes, and improved file attachment handling.
_[Add a description of your pull request here]_

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
