### PR TITLE
chore: bump kusto SDK to 8.0.1 and azure-bom to 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ## [Unreleased]
 
 ### Changed
-- None
+- Bump kusto-data and kusto-ingest SDK from 7.0.5 to 8.0.1
+- Bump azure-sdk-bom from 1.3.2 to 1.3.6
 
 ### Added
 - None
 
 ### Fixed
-- None
+- Fix HTTP client timeout being 30s longer than expected (via SDK 8.0.1 fix)
 
 ## [7.0.5] - 2026-03-09
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,14 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.5</revision>
+        <revision>7.0.6</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
-        <azure.bom.version>1.3.2</azure.bom.version>
+        <azure.bom.version>1.3.6</azure.bom.version>
         <azure.storage.version>8.6.6</azure.storage.version>
         <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
         <java.source.version>21</java.source.version>
-        <kusto.sdk.version>7.0.5</kusto.sdk.version>
+        <kusto.sdk.version>8.0.1</kusto.sdk.version>
         <resilience4j.version>1.7.1</resilience4j.version>
         <io.vavr.version>0.10.4</io.vavr.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -114,7 +114,7 @@
                         <scala>
                             <scalafmt>
                                 <version>3.5.9</version>
-                                <file>.scalafmt.conf</file>
+                                <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
                             </scalafmt>
                         </scala>
                     </configuration>


### PR DESCRIPTION
#### Pull Request Description

Upgrade kusto-data and kusto-ingest from 7.0.5 to 8.0.1. Bump azure-sdk-bom from 1.3.2 to 1.3.6 to align transitive dependencies (azure-core 1.57.1, azure-storage-blob 12.33.3). Bump connector revision to 7.0.6.

**Key fix in SDK 8.0.1**: Corrects HTTP timeout double-buffering — effective HTTP-client timeout was `serverTimeout + 60s`; now restored to `serverTimeout + 30s` as intended.

---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Fix HTTP client timeout being 30s longer than expected (via SDK 8.0.1 fix)