### PR TITLE
chore: bump kusto SDK to 7.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Version numbers follow the `{major}.{minor}.{patch}` scheme (e.g., `7.0.5`).
 Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Spark 3 / release/spark3).
 
+## [Unreleased]
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- None
+
 ## [7.0.6] - 2026-05-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Version numbers follow the `{major}.{minor}.{patch}` scheme (e.g., `7.0.5`).
 Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Spark 3 / release/spark3).
 
-## [Unreleased]
+## [7.0.6] - 2026-05-07
 
 ### Changed
-- None
+- Bump kusto-data and kusto-ingest SDK from 7.0.5 to 7.0.8
 
 ### Added
 - None
 
 ### Fixed
-- None
+- Fix HTTP client timeout being 30s longer than expected (via SDK 7.0.6 fix)
+- Fix `servertimeout` option being overridden when reusing ClientRequestProperties (via SDK 7.0.6 fix)
 
 ## [7.0.5] - 2026-03-09
 

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -12,6 +12,7 @@
     </parent>
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <scalafmt.config.path>${project.basedir}/../.scalafmt.conf</scalafmt.config.path>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <xml.maven.plugin.version>1.1.0</xml.maven.plugin.version>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
+        <scalafmt.config.path>${project.basedir}/.scalafmt.conf</scalafmt.config.path>
     </properties>
     <inceptionYear>2018</inceptionYear>
     <scm>
@@ -115,7 +116,7 @@
                         <scala>
                             <scalafmt>
                                 <version>3.5.9</version>
-                                <file>.scalafmt.conf</file>
+                                <file>${scalafmt.config.path}</file>
                             </scalafmt>
                         </scala>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.5</revision>
+        <revision>7.0.6</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>
         <azure.storage.version>8.6.6</azure.storage.version>
         <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
-        <kusto.sdk.version>7.0.5</kusto.sdk.version>
+        <kusto.sdk.version>7.0.8</kusto.sdk.version>
         <resilience4j.version>1.7.1</resilience4j.version>
         <io.vavr.version>0.10.4</io.vavr.version>
         <slf4j.version>2.0.17</slf4j.version>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -11,6 +11,10 @@
         <version>${revision}</version>
     </parent>
 
+    <properties>
+        <scalafmt.config.path>${project.basedir}/../.scalafmt.conf</scalafmt.config.path>
+    </properties>
+
     <dependencies>
         <!-- Compile Scope -->
         <dependency>


### PR DESCRIPTION
#### Pull Request Description

Upgrade kusto-data and kusto-ingest from 7.0.5 to 7.0.8 on the Spark 3 branch.
Bump connector revision to 7.0.6.

**Key fixes included (from SDK 7.0.6):**
- Fix HTTP client timeout double-buffering — effective timeout was `serverTimeout + 60s`, now restored to `serverTimeout + 30s`
- Fix `servertimeout` option being overridden from timespan string to numeric long when reusing `ClientRequestProperties` across queries

---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Fix HTTP client timeout being 30s longer than expected (via SDK 7.0.6)
- Fix servertimeout option being overridden when reusing ClientRequestProperties (via SDK 7.0.6)