### PR TITLE
chore: update changelog for 7.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ## [Unreleased]
 
 ### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- None
+
+## [7.0.6] - 2026-05-11
+
+### Changed
 - Bump kusto-data and kusto-ingest SDK from 7.0.5 to 8.0.1
 - Bump azure-sdk-bom from 1.3.2 to 1.3.6
 


### PR DESCRIPTION
Update CHANGELOG.md: move [Unreleased] items into [7.0.6] section for release.

Changes in 7.0.6:
- Bump kusto-data and kusto-ingest SDK from 7.0.5 to 8.0.1
- Bump azure-sdk-bom from 1.3.2 to 1.3.6
- Fix HTTP client timeout being 30s longer than expected (via SDK 8.0.1 fix)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>