### PR TITLE
fix: add --overwrite to blob upload in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,5 +104,6 @@ jobs:
             --account-name ${{ secrets.AZURE_RELEASE_STORAGE_ACCOUNT }} \
             --destination ${{ secrets.AZURE_STORAGE_CONTAINER }}/kusto/spark/${{ steps.get_version.outputs.SPARK_VERSION }}_${{ steps.get_version.outputs.VERSION }} \
             --source staging \
-            --auth-mode login
+            --auth-mode login \
+            --overwrite
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_azure == 'true') }}


### PR DESCRIPTION
Add `--overwrite` flag to `az storage blob upload-batch` in release.yml to prevent failures when re-releasing a version whose blobs already exist in storage.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>