### PR TITLE
fix(connector): bundle commons-io and correct shade relocation (fixes #479)

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -197,6 +197,20 @@
             <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
+        <!--
+            commons-io is used at runtime by KustoWriter (IOUtils.close). It was previously
+            assumed to be provided transitively by Hadoop/Spark, but the <artifactSet> below
+            excludes org.apache.hadoop:* and org.apache.spark:*, so the class is never bundled
+            into the shaded uber jar. The relocation rule (further below) then rewrites the
+            bytecode reference to a shaded prefix that does not exist at runtime, causing
+            NoClassDefFoundError: kusto_connector_shaded/org/apache/commons/io/IOUtils when
+            KustoStreaming writes are executed (see issue #479).
+        -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.20.0</version>
+        </dependency>
     </dependencies>
     <!-- Build properties -->
     <build>
@@ -520,9 +534,21 @@
                                     <pattern>org.apache.http</pattern>
                                     <shadedPattern>${kusto.shade.prefix}.org.apache.http</shadedPattern>
                                 </relocation>
+                                <!--
+                                    NOTE: this pattern intentionally matches the full
+                                    "org.apache.commons" prefix (including the trailing 's').
+                                    Prior to issue #479 the pattern was the typo'd
+                                    "org.apache.common" (singular). Maven Shade Plugin's
+                                    SimpleRelocator matches by String.startsWith on the
+                                    package path, so the typo accidentally rewrote
+                                    org/apache/commons/io/IOUtils bytecode references in
+                                    KustoWriter to a shaded prefix - but because commons-io
+                                    was not a declared dependency, the class was never
+                                    bundled, producing NoClassDefFoundError at runtime.
+                                -->
                                 <relocation>
-                                    <pattern>org.apache.common</pattern>
-                                    <shadedPattern>${kusto.shade.prefix}.org.apache.common</shadedPattern>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${kusto.shade.prefix}.org.apache.commons</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.checkerframework</pattern>


### PR DESCRIPTION
## Summary

Fixes #479.

`KustoStreaming` writes fail at runtime in **every released artifact since `v3.0_5.2.4` up to and including the current `7.0.6`** (both `_3.0_2.12` and `_4.0_2.13` lines on Maven Central) with:

```
NoClassDefFoundError: kusto_connector_shaded/org/apache/commons/io/IOUtils
```

This is a two-bug compound failure in `connector/pom.xml`. Either bug alone would be harmless; together they corrupt the shaded uber jar in a way that only blows up when `KustoStreaming` mode is actually exercised at runtime — which is why it slipped through CI and every release.

## Root cause

### Bug 1 — `commons-io` is not a declared dependency

`KustoWriter.scala:40` imports `org.apache.commons.io.IOUtils` and calls `IOUtils.close(writer, byteArrayOutputStream)` at line 432 (in the `KustoStreaming` write path). `commons-io` was implicitly relied on through the Hadoop/Spark transitive dependency graph.

But the shade plugin's `<artifactSet>` excludes `org.apache.hadoop:*` and `org.apache.spark:*`, so `commons-io` is **never bundled** into the uber jar.

```bash
$ unzip -l kusto-spark_3.0_2.12-7.0.6.jar | grep -c 'commons/io/IOUtils.class'
0
```

### Bug 2 — typo'd shade relocation pattern (`org.apache.common` instead of `org.apache.commons`)

The current pom has (line 524):

```xml
<relocation>
    <pattern>org.apache.common</pattern>    <!-- ← missing the trailing 's' -->
    <shadedPattern>${kusto.shade.prefix}.org.apache.common</shadedPattern>
</relocation>
```

Maven Shade Plugin's `SimpleRelocator` matches by `String.startsWith(pathPattern)` on the JAR-entry path — **not** dot/slash-boundary matching. So the path `org/apache/commons/io/IOUtils` starts with `org/apache/common`, the rule fires, and the bytecode reference in `KustoWriter$.class` is silently rewritten to `kusto_connector_shaded/org/apache/commons/io/IOUtils`:

```bash
$ javap -p -c -v 'com/microsoft/kusto/spark/datasink/KustoWriter$.class' \
    | grep -o 'kusto_connector_shaded[^"]*IOUtils[^"]*'
kusto_connector_shaded/org/apache/commons/io/IOUtils.close
```

…but as established by Bug 1, no such class exists in the uber jar.

## Why this slipped through

- `KustoQueuedIngestionWrite` does not call `IOUtils.close`, so queued-mode customers never see this.
- The only call site is on the `KustoStreaming` happy path during `close()`, where the executor crashes and the failure shows up as a confusing task-level error rather than a build-time test failure.
- Both bugs are needed: drop the typo and the bytecode is unchanged (and resolves correctly to an unshaded `commons-io` if present); declare `commons-io` and the typo still rewrites bytecode but at least the class is bundled.

## Fix

1. **Declare `commons-io` as a direct compile-scope dependency** so the class is actually bundled into the shaded uber jar.
2. **Correct the typo** `org.apache.common` → `org.apache.commons` so the relocation rule is precise and intentional rather than accidentally firing.

A regression check that any future release should pass:

```bash
unzip -p target/kusto-spark_*.jar \
  'kusto_connector_shaded/org/apache/commons/io/IOUtils.class' \
  | wc -c   # must be > 0
```

## Customer impact

This bug currently blocks **every Microsoft Fabric Spark notebook customer** using `KustoStreaming` writes. Fabric Runtime 1.2 (Spark 3.4) and 1.3 (Spark 3.5) both ship the broken `kusto-spark_3.0_2.12-7.0.4.jar` on the JVM system classpath, where it wins against user-supplied jars due to parent-first delegation. The only workaround we've been able to ship to customers in production is a renamed-package rebuild of the connector under a different FQN — which obviously isn't a tenable long-term answer.

Once this PR is merged and released, Fabric (and any other distro that bundles `kusto-spark`) can refresh and customers will be unblocked using the standard `format("com.microsoft.kusto.spark.datasink.KustoSinkProvider")` path.
