### PR TITLE
fix: commons-io shading fix for v7.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.0.7] - 2026-05-28
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- Add commons-io as explicit compile-scope dependency to fix shading (resolves NoClassDefFoundError for `kusto_connector_shaded/org/apache/commons/io/IOUtils` on Fabric)
+
 ## [7.0.6] - 2026-05-11
 
 ### Changed

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -526,8 +526,8 @@
                                     <shadedPattern>${kusto.shade.prefix}.org.apache.http</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.common</pattern>
-                                    <shadedPattern>${kusto.shade.prefix}.org.apache.common</shadedPattern>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${kusto.shade.prefix}.org.apache.commons</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.checkerframework</pattern>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -91,6 +91,11 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-retry</artifactId>
             <version>${resilience4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.6</revision>
+        <revision>7.0.7-SNAPSHOT</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.3.6</azure.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.7-SNAPSHOT</revision>
+        <revision>7.0.7</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.3.6</azure.bom.version>


### PR DESCRIPTION
<!-- PR Title Format (Conventional Commits): -->
<!-- type: short description                  -->
<!--                                          -->
<!-- Types: feat, fix, chore, docs, refactor, ci, test -->
<!-- Examples:                                -->
<!--   feat: add storage protocol option      -->
<!--   fix: resolve CloudInfo cache issue     -->
<!--   chore: bump version to 7.0.6           -->
<!--   docs: update troubleshooting guide     -->
<!--   ci: fix release pipeline               -->

#### Pull Request Description
This pull request introduces a new dependency and updates the project version. The most significant changes are:

Dependency management:

* Added the `commons-io` library (version 2.18.0) as a dependency in `connector/pom.xml` to provide utility IO functionality.

Versioning:

* Updated the main project version from `7.0.6` to `7.0.7` in `pom.xml` to reflect ongoing development.
