### PR TITLE
fix: commons-io shading fix for v7.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.0.7] - 2026-05-28
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- Fix commons-io not being shaded into connector JAR, causing `NoClassDefFoundError: kusto_connector_shaded/org/apache/commons/io/IOUtils` on Fabric
+- Fix shading relocation pattern typo (`org.apache.common` → `org.apache.commons`)
+
 ## [7.0.6] - 2026-05-07
 
 ### Changed

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -92,6 +92,11 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-retry</artifactId>
             <version>${resilience4j.version}</version>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -522,8 +522,8 @@
                                     <shadedPattern>${kusto.shade.prefix}.org.apache.http</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.common</pattern>
-                                    <shadedPattern>${kusto.shade.prefix}.org.apache.common</shadedPattern>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${kusto.shade.prefix}.org.apache.commons</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.checkerframework</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.6</revision>
+        <revision>7.0.7-SNAPSHOT</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.7-SNAPSHOT</revision>
+        <revision>7.0.7</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>


### PR DESCRIPTION
## Summary

Fix `NoClassDefFoundError: kusto_connector_shaded/org/apache/commons/io/IOUtils` on Fabric platform.

## Root Cause

1. **Shading pattern typo**: `org.apache.common` instead of `org.apache.commons` — while functionally equivalent due to prefix matching, it was misleading
2. **Missing compile dependency**: `commons-io` was only available as a transitive `provided` dependency (from hadoop-common), so it was never packaged into the JAR and therefore never shaded

## Fix

- Added `commons-io:2.18.0` as explicit compile-scope dependency in `connector/pom.xml`
- Corrected shading relocation pattern to `org.apache.commons`
- Bumped version to `7.0.7`
- Updated CHANGELOG.md

## Changes

- `connector/pom.xml`: Added commons-io dependency + fixed relocation pattern
- `pom.xml`: Version bump 7.0.7-SNAPSHOT → 7.0.7
- `CHANGELOG.md`: Added 7.0.7 release entry

## Verification

After build, the JAR should contain:
```
kusto_connector_shaded/org/apache/commons/io/IOUtils.class
```

Verify with:
```bash
jar tf connector/target/kusto-spark_3.0_2.12-7.0.7.jar | grep "kusto_connector_shaded/org/apache/commons/io/IOUtils"
```