### PR TITLE
fix: commons-io shading fix for v5.3.5

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -34,6 +34,11 @@
             <version>${commons.lang3.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
             <version>${kusto.sdk.version}</version>
@@ -494,8 +499,8 @@
                                     <shadedPattern>${kusto.shade.prefix}.org.apache.http</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.common</pattern>
-                                    <shadedPattern>${kusto.shade.prefix}.org.apache.common</shadedPattern>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${kusto.shade.prefix}.org.apache.commons</shadedPattern>
                                 </relocation>
                                 <!-- IO -->
                                 <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>5.3.4</revision>
+        <revision>5.3.5</revision>
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>
         <scalafmt.plugin.version>1.1.1640084764.9f463a9</scalafmt.plugin.version>


### PR DESCRIPTION
## Problem
Customer on Fabric platform hitting:
```
NoClassDefFoundError: kusto_connector_shaded/org/apache/commons/io/IOUtils
```

## Root Cause
- `commons-io` is a transitive dependency from `hadoop-common` with `provided` scope
- `provided` scope means it's never included in the uber JAR → never shaded
- The shade plugin relocates references to `kusto_connector_shaded.org.apache.commons.io.*` but the actual classes don't exist in the JAR

## Fix
1. Added `commons-io:2.8.0` as an explicit compile-scope dependency so it gets included and shaded
2. Corrected shading pattern from `org.apache.common` to `org.apache.commons` (cosmetic; prefix matching makes them equivalent)
3. Bumped version to 5.3.5

## Verification
- Built JAR confirmed to contain `kusto_connector_shaded/org/apache/commons/io/IOUtils.class` (21 classes total)
- `mvn package` succeeds cleanly