### PR TITLE
feat(read): port OneLake transient storage support to Spark 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.1.0] - 2026-06-12
+
+### Changed
+- Jackson ObjectMapper in `TransientStorageParameters.fromString` now accepts case-insensitive property names
+
+### Added
+- OneLake transient storage support for distributed reads (PR #491)
+  - New `oneLakeUrl` field in `storageCredentials` JSON for Fabric OneLake URLs
+  - Kusto exports via `.export to oneLakeUrl;impersonate`; Spark reads back over abfss with ambient AAD
+  - Automatic `fs.azure.abfs.valid.endpoints` allowlisting for OneLake hosts
+  - Supports both `https://` and `abfss://` URL formats (canonicalized internally)
+- Cloud-agnostic OneLake host validation — supports internal/sovereign environments (e.g., `dfs.pbidedicated.windows-int.net`)
+- Security: reject IP-literal, localhost, and single-label hosts for OneLake URLs
+- Security: URL-decoded path traversal checks on workspace and artifact segments
+
+### Fixed
+- OneLake host validation no longer rejects valid internal/sovereign OneLake domains
+- `validate()` now attempts `parseOneLake` as fallback instead of rejecting when derived fields are unpopulated
+
 ## [7.0.7] - 2026-05-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.1.1] - 2026-06-15
+
+### Fixed
+- Removed `/Files/` subfolder restriction from OneLake path validation — allows any subfolder (e.g., `/Ingestions/`)
+
 ## [7.1.0] - 2026-06-12
 
 ### Changed

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -200,7 +200,14 @@ object KustoReader {
       directory: String,
       endpointSuffix: String,
       storageProtocol: String = KCONST.storageProtocolWasbs): Boolean = {
-    if (params.authMethod == AuthMethod.Impersonation) {
+    if (params.isOneLake) {
+      // OneLake: probe via Hadoop FileSystem over abfss using ambient AAD (Fabric Spark).
+      val base = params.oneLakeAbfssBase
+      val hadoopConf = spark.sparkContext.hadoopConfiguration
+      val fs = FileSystem.get(new URI(base), hadoopConf)
+      val path = new Path(s"$base/$directory")
+      fs.exists(path)
+    } else if (params.authMethod == AuthMethod.Impersonation) {
       val url =
         s"$storageProtocol://${params.blobContainer}@${params.storageAccountName}.blob.$endpointSuffix"
       val hadoopConf = spark.sparkContext.hadoopConfiguration
@@ -212,7 +219,7 @@ object KustoReader {
       val endpoint = s"https://${params.storageAccountName}.blob.$endpointSuffix"
       val container = params.authMethod match {
         case AuthMethod.Sas =>
-          val sas = if (params.sasKey(0) == '?') params.sasKey else s"?${params.sasKey}"
+          val sas = if (params.sasKey.startsWith("?")) params.sasKey else s"?${params.sasKey}"
           new BlobContainerClientBuilder()
             .endpoint(endpoint)
             .containerName(params.blobContainer)
@@ -244,7 +251,12 @@ object KustoReader {
       className,
       s"Starting exporting data from Kusto to blob storage in Distributed mode. requestId: ${request.requestId}")
 
-    val protocol = options.storageProtocol.getOrElse(KCONST.storageProtocolWasbs)
+    // OneLake transient storage always reads back over abfss; force the protocol when any
+    // credential is a OneLake URL so the rest of the read path uses the correct scheme.
+    val anyOneLake = storage.storageCredentials.exists(_.isOneLake)
+    val protocol =
+      if (anyOneLake) KCONST.storageProtocolAbfss
+      else options.storageProtocol.getOrElse(KCONST.storageProtocolWasbs)
     setupBlobAccess(request, storage, protocol)
     val partitions = calculatePartitions(options.partitionOptions)
     val reader = new KustoReader(kustoClient)
@@ -265,8 +277,12 @@ object KustoReader {
       .filter(params =>
         dirExist(request.sparkSession, params, directory, storage.endpointSuffix, protocol))
       .map(params =>
-        s"$protocol://${params.blobContainer}" +
-          s"@${params.storageAccountName}.blob.${storage.endpointSuffix}/$directory")
+        if (params.isOneLake) {
+          s"${params.oneLakeAbfssBase}/$directory"
+        } else {
+          s"$protocol://${params.blobContainer}" +
+            s"@${params.storageAccountName}.blob.${storage.endpointSuffix}/$directory"
+        })
     KDSU.logInfo(
       className,
       s"Finished exporting from Kusto to ${paths.mkString(",")}" +
@@ -335,6 +351,8 @@ object KustoReader {
         case AuthMethod.Sas =>
           handleSasAuth(storage, storageParameters, config, sparkConf, now, useAbfs)
         case _ =>
+        // Impersonation (including OneLake) relies on ambient AAD configured by the
+        // Spark runtime (e.g. Fabric notebooks). Nothing to install here.
       }
     }
   }
@@ -456,13 +474,25 @@ object KustoReader {
       sparkConf: RuntimeConfig): Unit = {
     val endpointKey = "fs.azure.abfs.valid.endpoints"
     val currentEndpoints = config.get(endpointKey, "")
-    val storageDomain = storageParameters.endpointSuffix
-    if (!currentEndpoints.contains(storageDomain)) {
-      val updatedEndpoints = if (currentEndpoints.isEmpty) {
-        storageDomain
-      } else {
-        s"$currentEndpoints,$storageDomain"
-      }
+    val existingSet = currentEndpoints
+      .split(',')
+      .iterator
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toSet
+    // Default storage domain (e.g. core.windows.net) plus any per-credential OneLake hosts
+    // (e.g. onelake.dfs.fabric.microsoft.com) that the Fabric/MWC abfss client must accept.
+    val oneLakeEndpoints = storageParameters.storageCredentials
+      .filter(_.isOneLake)
+      .map(_.oneLakeEndpoint)
+      .filter(_ != null)
+      .distinct
+      .toSeq
+    val candidates = Seq(storageParameters.endpointSuffix) ++ oneLakeEndpoints
+    val toAdd = candidates.filter(d => d != null && d.nonEmpty && !existingSet.contains(d.trim))
+    if (toAdd.nonEmpty) {
+      val updatedEndpoints =
+        (Seq(currentEndpoints).filter(_.nonEmpty) ++ toAdd).mkString(",")
       setHadoopConf(config, sparkConf, endpointKey, updatedEndpoints)
       KDSU.logInfo(
         className,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -13,8 +13,27 @@ object KustoSourceOptions extends KustoOptions {
   /** Optional options */
   val KUSTO_CUSTOM_DATAFRAME_COLUMN_TYPES: String = newOption("customSchema")
 
-  // Blob Storage access parameters for source connector when working in 'distributed' mode (read)
-  // These parameters are not be required as the service supply it by default
+  // Blob Storage / OneLake access parameters for source connector when working in 'distributed' mode (read)
+  // These parameters are not required as the service supplies it by default.
+  // A JSON of the form { "storageCredentials": [ ... ], "endpointSuffix": "<suffix>" } where each entry is either:
+  //   - blob SAS:        { "sasUrl": "https://<account>.blob.<suffix>/<container>?<SAS>" }
+  //   - account+key:     { "storageAccountName": "...", "storageAccountKey": "...", "blobContainer": "..." }
+  //   - blob impersonate:{ "sasUrl": "https://<account>.blob.<suffix>/<container>;impersonate" }
+  //   - OneLake (Fabric Lakehouse), with caller AAD impersonation (no SAS required):
+  //       {
+  //         "storageCredentials": [
+  //           { "oneLakeUrl": "https://onelake.dfs.fabric.microsoft.com/<workspace>/<lakehouse>.Lakehouse/Files/<subpath>" }
+  //         ]
+  //       }
+  //     The oneLakeUrl value accepts two forms:
+  //       - https:  https://onelake.dfs.fabric.microsoft.com/<workspace>/<lakehouse>.Lakehouse/Files/<subpath>
+  //       - abfss:  abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>.Lakehouse/Files/<subpath>
+  //     For OneLake the connector forces storageProtocol=abfss and uses ambient AAD configured by Spark
+  //     (Fabric notebooks). The caller must have at least Workspace Contributor / item-level Write on the
+  //     target Lakehouse Files path. Useful with DEP / OAP environments where Kusto-managed export blobs
+  //     are unreachable from executors.
+  //   The storage kind is determined solely by which field is populated: an entry with `oneLakeUrl`
+  //   is treated as OneLake, otherwise it is treated as Azure blob/ADLS2.
   val KUSTO_TRANSIENT_STORAGE: String = newOption("transientStorage")
 
   // Blob domain endpoint suffix - default: core.windows.net - needed for non-public clouds

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
@@ -236,7 +236,7 @@ final case class TransientStorageCredentials() {
         if (StringUtils.isBlank(ws) || ws.contains(":") || StringUtils.isBlank(
             host) || rawPath.length <= 1) {
           throw new InvalidParameterException(
-            s"OneLake abfss URL must be 'abfss://<workspace>@<endpoint>/<artifact>/Files/...': $url")
+            s"OneLake abfss URL must be 'abfss://<workspace>@<endpoint>/<artifact>/<subpath>/...': $url")
         }
         (host, ws, rawPath.stripPrefix("/").stripSuffix("/"))
       case "https" =>
@@ -246,7 +246,7 @@ final case class TransientStorageCredentials() {
         }
         if (StringUtils.isBlank(host) || rawPath.length <= 1) {
           throw new InvalidParameterException(
-            s"OneLake https URL must be 'https://<endpoint>/<workspace>/<artifact>/Files/...': $url")
+            s"OneLake https URL must be 'https://<endpoint>/<workspace>/<artifact>/<subpath>/...': $url")
         }
         val parts = rawPath.stripPrefix("/").stripSuffix("/").split("/", 2)
         if (parts.length < 2 || parts(0).isEmpty || parts(1).isEmpty) {
@@ -267,9 +267,7 @@ final case class TransientStorageCredentials() {
         s"OneLake URL host must not be localhost, an IP literal, or a single-label host: $url")
     }
 
-    // Enforce Lakehouse Files path shape: '<artifact>/Files/<subpath>' with non-empty
-    // segments and no consecutive slashes. This blocks accidental targeting of Tables/
-    // (which would clash with Delta semantics) and catches typos early.
+    // Ensure non-empty path segments (no consecutive slashes) and basic traversal protection.
     val artifactSegments = artifactPath.split("/", -1)
     if (artifactSegments.exists(_.isEmpty)) {
       throw new InvalidParameterException(
@@ -282,9 +280,11 @@ final case class TransientStorageCredentials() {
       }) {
       throw new InvalidParameterException(s"OneLake URL path must not contain '..' or '.': $url")
     }
-    if (artifactSegments.length < 3 || !artifactSegments(1).equalsIgnoreCase("Files")) {
+    // Require at least two path segments (artifact + subpath) to avoid targeting the
+    // artifact root directly without a subfolder.
+    if (artifactSegments.length < 2) {
       throw new InvalidParameterException(
-        s"OneLake artifact path must be '<lakehouse>(.Lakehouse)?/Files/<subpath>': $url")
+        s"OneLake artifact path must include at least '<artifact>/<subpath>': $url")
     }
 
     this.oneLakeEndpoint = endpoint

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
@@ -4,12 +4,13 @@
 package com.microsoft.kusto.spark.datasource
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
-import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.annotation.{JsonIgnore, PropertyAccessor}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.microsoft.azure.kusto.data.StringUtils
 import com.microsoft.kusto.spark.utils.KustoDataSourceUtils
 
+import java.net.URI
 import java.security.InvalidParameterException
 import scala.util.matching.Regex
 class TransientStorageParameters(
@@ -19,6 +20,32 @@ class TransientStorageParameters(
   // C'tor for serialization
   def this() {
     this(Array())
+  }
+
+  /**
+   * Validate cross-credential invariants. Currently: refuse mixing OneLake credentials with
+   * non-OneLake (Blob SAS/Key) credentials in the same array — read-back protocol coercion can
+   * only honor one storage flavor per export.
+   */
+  def validate(): Unit = {
+    if (storageCredentials != null && storageCredentials.length > 0) {
+      if (storageCredentials.exists(_ == null)) {
+        throw new InvalidParameterException(
+          "transientStorage.storageCredentials must not contain null entries")
+      }
+      // NB: do not call per-credential validate() here. parseOneLake() invokes per-cred
+      // validate() for OneLake credentials, and historically blob credentials supplied
+      // via fromString are not re-validated (they may legitimately have only sasUrl set
+      // when ;impersonate auth is used). This wrapper only enforces cross-credential
+      // invariants.
+      val anyOneLake = storageCredentials.exists(c => c.isOneLake)
+      val anyNonOneLake = storageCredentials.exists(c => !c.isOneLake)
+      if (anyOneLake && anyNonOneLake) {
+        throw new InvalidParameterException(
+          "transientStorage cannot mix OneLake and non-OneLake credentials. " +
+            "Provide either all OneLake URLs or all Azure Storage (blob) credentials.")
+      }
+    }
   }
 
   override def toString: String = {
@@ -46,6 +73,20 @@ final case class TransientStorageCredentials() {
   var sasUrl: String = _
   var domainSuffix: String = _
 
+  // OneLake transient storage support. When set, this credential targets a Fabric OneLake
+  // (Lakehouse Files) location instead of an Azure Storage account. Kusto .export accepts
+  // OneLake URIs with ;impersonate and Spark reads back over abfss using ambient AAD auth
+  // already configured by the Fabric Spark runtime.
+  //
+  // `oneLakeUrl` is the only user-supplied OneLake field; the derived fields below
+  // (oneLakeWorkspace, oneLakeEndpoint, oneLakeArtifactPath) are always recomputed from
+  // `oneLakeUrl` and are marked @JsonIgnore so untrusted JSON cannot inject inconsistent
+  // values.
+  var oneLakeUrl: String = _
+  @JsonIgnore var oneLakeWorkspace: String = _
+  @JsonIgnore var oneLakeEndpoint: String = _
+  @JsonIgnore var oneLakeArtifactPath: String = _
+
   def this(storageAccountName: String, storageAccountKey: String, blobContainer: String) {
     this()
     this.blobContainer = blobContainer
@@ -60,30 +101,83 @@ final case class TransientStorageCredentials() {
     parseSas(sas)
   }
 
+  @JsonIgnore
+  def isOneLake: Boolean =
+    StringUtils.isNotBlank(oneLakeUrl) &&
+      StringUtils.isNotBlank(oneLakeWorkspace) &&
+      StringUtils.isNotBlank(oneLakeEndpoint) &&
+      StringUtils.isNotBlank(oneLakeArtifactPath)
+
+  @JsonIgnore
   def authMethod: AuthMethod.AuthMethod = {
-    sasKey match {
-      case null => AuthMethod.Key
-      case TransientStorageParameters.ImpersonationString => AuthMethod.Impersonation
-      case _ => AuthMethod.Sas
+    if (isOneLake) {
+      AuthMethod.Impersonation
+    } else {
+      sasKey match {
+        case null => AuthMethod.Key
+        case TransientStorageParameters.ImpersonationString => AuthMethod.Impersonation
+        case _ => AuthMethod.Sas
+      }
+    }
+  }
+
+  /**
+   * Canonical abfss base URL for OneLake credentials, of the form
+   * abfss://{workspace}@{endpoint}/{artifactPath}. Returns null for non-OneLake credentials.
+   * Spark reads back parquet output via this URL.
+   */
+  @JsonIgnore
+  def oneLakeAbfssBase: String = {
+    if (!isOneLake) null
+    else if (oneLakeArtifactPath == null || oneLakeArtifactPath.isEmpty) {
+      s"abfss://$oneLakeWorkspace@$oneLakeEndpoint"
+    } else {
+      s"abfss://$oneLakeWorkspace@$oneLakeEndpoint/$oneLakeArtifactPath"
     }
   }
 
   def validate(): Unit = {
-    authMethod match {
-      case AuthMethod.Sas =>
-        if (sasUrl.isEmpty) throw new InvalidParameterException("sasUrl is null or empty")
-      case AuthMethod.Key =>
-        if (StringUtils.isBlank(storageAccountName)) {
-          throw new InvalidParameterException("storageAccount name is null or empty")
-        }
-        if (StringUtils.isBlank(storageAccountKey)) {
-          throw new InvalidParameterException("storageAccount key is null or empty")
-        }
-        if (StringUtils.isBlank(blobContainer)) {
-          throw new InvalidParameterException("blob container name is null or empty")
-        }
-      case _ =>
-    }
+    if (isOneLake) {
+      // Defense in depth: reject any blob-flavor field that would conflict with OneLake.
+      val conflictingFields = Seq(
+        ("storageAccountName", storageAccountName),
+        ("storageAccountKey", storageAccountKey),
+        ("blobContainer", blobContainer),
+        ("sasKey", sasKey)).collect {
+        case (name, value) if StringUtils.isNotBlank(value) => name
+      }
+      if (conflictingFields.nonEmpty) {
+        throw new InvalidParameterException(
+          s"OneLake credential cannot also specify blob storage fields: ${conflictingFields.mkString(", ")}")
+      }
+      // sasUrl is for blob/ADLS2 only — reject if set on a OneLake credential.
+      if (StringUtils.isNotBlank(sasUrl)) {
+        throw new InvalidParameterException(
+          "OneLake credential must not specify a sasUrl (use oneLakeUrl instead)")
+      }
+    } else if (StringUtils.isNotBlank(oneLakeUrl)) {
+      // oneLakeUrl was set but parsing failed to produce derived fields.
+      // Attempt parsing now rather than rejecting — supports any valid OneLake-like host.
+      parseOneLake(oneLakeUrl)
+    } else
+      authMethod match {
+        case AuthMethod.Sas =>
+          if (StringUtils.isBlank(sasUrl))
+            throw new InvalidParameterException("sasUrl is null or empty")
+          if (StringUtils.isBlank(sasKey))
+            throw new InvalidParameterException("sasKey is null or empty")
+        case AuthMethod.Key =>
+          if (StringUtils.isBlank(storageAccountName)) {
+            throw new InvalidParameterException("storageAccount name is null or empty")
+          }
+          if (StringUtils.isBlank(storageAccountKey)) {
+            throw new InvalidParameterException("storageAccount key is null or empty")
+          }
+          if (StringUtils.isBlank(blobContainer)) {
+            throw new InvalidParameterException("blob container name is null or empty")
+          }
+        case _ =>
+      }
   }
 
   private[kusto] def parseSas(url: String): Unit = {
@@ -104,21 +198,151 @@ final case class TransientStorageCredentials() {
     }
   }
 
+  private[kusto] def parseOneLake(url: String): Unit = {
+    val trimmedSuffix = url.stripSuffix(TransientStorageParameters.ImpersonationString)
+    val parsed =
+      try new java.net.URI(trimmedSuffix)
+      catch {
+        case e: java.net.URISyntaxException =>
+          throw new InvalidParameterException(
+            s"OneLake URL couldn't be parsed (malformed): $url (${e.getMessage})")
+      }
+
+    val scheme = Option(parsed.getScheme).map(_.toLowerCase).getOrElse("")
+    val host = parsed.getHost
+    val rawPath = Option(parsed.getRawPath).getOrElse("")
+    val decodedPath = Option(parsed.getPath).getOrElse("")
+    val port = parsed.getPort
+
+    if (parsed.getRawQuery != null) {
+      throw new InvalidParameterException(
+        s"OneLake URL must not include a query string (no SAS/secrets are supported here): $url")
+    }
+    if (parsed.getRawFragment != null) {
+      throw new InvalidParameterException(s"OneLake URL must not include a fragment: $url")
+    }
+    if (port != -1) {
+      throw new InvalidParameterException(s"OneLake URL must not include an explicit port: $url")
+    }
+    if (decodedPath.contains("/../") || decodedPath.contains("/./") ||
+      decodedPath.endsWith("/..") || decodedPath.endsWith("/.") ||
+      decodedPath == ".." || decodedPath == ".") {
+      throw new InvalidParameterException(s"OneLake URL path must not contain '..' or '.': $url")
+    }
+
+    val (endpoint, workspace, artifactPath) = scheme match {
+      case "abfss" | "abfs" =>
+        val ws = parsed.getUserInfo
+        if (StringUtils.isBlank(ws) || ws.contains(":") || StringUtils.isBlank(
+            host) || rawPath.length <= 1) {
+          throw new InvalidParameterException(
+            s"OneLake abfss URL must be 'abfss://<workspace>@<endpoint>/<artifact>/Files/...': $url")
+        }
+        (host, ws, rawPath.stripPrefix("/").stripSuffix("/"))
+      case "https" =>
+        if (parsed.getUserInfo != null) {
+          throw new InvalidParameterException(
+            s"OneLake https URL must not contain userInfo: $url")
+        }
+        if (StringUtils.isBlank(host) || rawPath.length <= 1) {
+          throw new InvalidParameterException(
+            s"OneLake https URL must be 'https://<endpoint>/<workspace>/<artifact>/Files/...': $url")
+        }
+        val parts = rawPath.stripPrefix("/").stripSuffix("/").split("/", 2)
+        if (parts.length < 2 || parts(0).isEmpty || parts(1).isEmpty) {
+          throw new InvalidParameterException(
+            s"OneLake https URL must include workspace and artifact path: $url")
+        }
+        (host, parts(0), parts(1))
+      case other =>
+        throw new InvalidParameterException(
+          s"Unsupported scheme '$other' for OneLake URL (expected 'https' or 'abfss'): $url")
+    }
+
+    // Reject IP-literal, localhost, and single-label hosts for security.
+    val hostLower = endpoint.toLowerCase
+    if (hostLower == "localhost" || !hostLower.contains(".") ||
+      hostLower.startsWith("[") || hostLower.matches("""\d{1,3}(\.\d{1,3}){3}""")) {
+      throw new InvalidParameterException(
+        s"OneLake URL host must not be localhost, an IP literal, or a single-label host: $url")
+    }
+
+    // Enforce Lakehouse Files path shape: '<artifact>/Files/<subpath>' with non-empty
+    // segments and no consecutive slashes. This blocks accidental targeting of Tables/
+    // (which would clash with Delta semantics) and catches typos early.
+    val artifactSegments = artifactPath.split("/", -1)
+    if (artifactSegments.exists(_.isEmpty)) {
+      throw new InvalidParameterException(
+        s"OneLake artifact path must not contain empty segments: $url")
+    }
+    // URL-decoded traversal check on workspace and all artifact segments
+    if ((workspace +: artifactSegments).exists { seg =>
+        val decoded = java.net.URLDecoder.decode(seg, "UTF-8")
+        decoded == "." || decoded == ".." || decoded.contains("/") || decoded.contains("\\")
+      }) {
+      throw new InvalidParameterException(s"OneLake URL path must not contain '..' or '.': $url")
+    }
+    if (artifactSegments.length < 3 || !artifactSegments(1).equalsIgnoreCase("Files")) {
+      throw new InvalidParameterException(
+        s"OneLake artifact path must be '<lakehouse>(.Lakehouse)?/Files/<subpath>': $url")
+    }
+
+    this.oneLakeEndpoint = endpoint
+    this.oneLakeWorkspace = workspace
+    this.oneLakeArtifactPath = artifactPath
+    // Always store the canonical https form. Kusto .export has been verified to accept
+    // 'https://<onelake-host>/<workspace>/<artifact-path>'; abfss is converted here so
+    // CSL emission stays uniform.
+    this.oneLakeUrl = s"https://$endpoint/$workspace/$artifactPath"
+    validate()
+  }
+
   override def toString: String = {
     // TODO next breaking - change to "authMethod:"
-    s"BlobContainer: $blobContainer ,Storage: $storageAccountName , IsSasKeyDefined: ${authMethod == AuthMethod.Sas}"
+    if (isOneLake) {
+      s"OneLake workspace: $oneLakeWorkspace, endpoint: $oneLakeEndpoint, artifactPath: $oneLakeArtifactPath"
+    } else {
+      s"BlobContainer: $blobContainer ,Storage: $storageAccountName , IsSasKeyDefined: ${authMethod == AuthMethod.Sas}"
+    }
   }
 
 }
 
 object TransientStorageParameters {
   val ImpersonationString = ";impersonate"
+
   private[kusto] def fromString(json: String): TransientStorageParameters = {
-    new ObjectMapper()
+    val params = new ObjectMapper()
       .registerModule(new JavaTimeModule())
       .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
       .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+      .configure(
+        com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES,
+        true)
       .readValue(json, classOf[TransientStorageParameters])
+
+    // Always re-derive OneLake fields from the user-supplied URL so attacker-controlled
+    // JSON cannot pre-populate `oneLakeWorkspace`/`oneLakeEndpoint`/`oneLakeArtifactPath`
+    // to a different target than `oneLakeUrl`. The derived fields are also @JsonIgnore on
+    // the credential class for defense in depth.
+    if (params.storageCredentials != null) {
+      params.storageCredentials.foreach { cred =>
+        if (cred != null) {
+          // Reset any user-supplied derived fields before parsing.
+          cred.oneLakeWorkspace = null
+          cred.oneLakeEndpoint = null
+          cred.oneLakeArtifactPath = null
+
+          // OneLake is only triggered by the explicit oneLakeUrl field.
+          // sasUrl remains exclusively for blob/ADLS2 storage.
+          if (StringUtils.isNotBlank(cred.oneLakeUrl)) {
+            cred.parseOneLake(cred.oneLakeUrl)
+          }
+        }
+      }
+    }
+    params.validate()
+    params
   }
 }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -174,21 +174,26 @@ private[kusto] object CslCommandsGenerator {
       additionalExportOptions: Map[String, String] = Map.empty[String, String],
       supportNewParquetWriter: Boolean = true): String = {
     val getFullUrlFromParams = (storage: TransientStorageCredentials) => {
-      val secretString =
-        storage.authMethod match {
-          case AuthMethod.Key => s""";" h@"${storage.storageAccountKey}""""
-          case AuthMethod.Sas =>
-            if (storage.sasKey(0) == '?') {
-              s"""" h@"${storage.sasKey}""""
-            } else {
-              s"""?" h@"${storage.sasKey}""""
-            }
-          case AuthMethod.Impersonation =>
-            s"""${TransientStorageParameters.ImpersonationString}""""
-        }
-      val blobUri =
-        s"https://${storage.storageAccountName}.blob.${storageParameters.endpointSuffix}"
-      s"$blobUri/${storage.blobContainer}$secretString"
+      if (storage.isOneLake) {
+        // OneLake URL accepted by Kusto .export as-is, with ;impersonate (engine uses caller AAD).
+        s"""${storage.oneLakeUrl}${TransientStorageParameters.ImpersonationString}""""
+      } else {
+        val secretString =
+          storage.authMethod match {
+            case AuthMethod.Key => s""";" h@"${storage.storageAccountKey}""""
+            case AuthMethod.Sas =>
+              if (storage.sasKey.startsWith("?")) {
+                s"""" h@"${storage.sasKey}""""
+              } else {
+                s"""?" h@"${storage.sasKey}""""
+              }
+            case AuthMethod.Impersonation =>
+              s"""${TransientStorageParameters.ImpersonationString}""""
+          }
+        val blobUri =
+          s"https://${storage.storageAccountName}.blob.${storageParameters.endpointSuffix}"
+        s"$blobUri/${storage.blobContainer}$secretString"
+      }
     }
     // if we pass in compress as 'none' explicitly then do not compress, else compress
     val compress =

--- a/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
@@ -208,22 +208,23 @@ class TransientStorageParametersTest extends AnyFlatSpec {
     cred.oneLakeArtifactPath shouldEqual "reallh.Lakehouse/Files/exports"
   }
 
-  "OneLake path validation" should "reject artifact paths without /Files/ segment" in {
-    val thrown = intercept[java.security.InvalidParameterException] {
-      TransientStorageParameters.fromString(
-        "{\"storageCredentials\": [{\"oneLakeUrl\": " +
-          "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Tables/secret\"}]}")
-    }
-    thrown.getMessage should include("Files")
-  }
-
-  it should "reject artifact paths with too few segments" in {
+  "OneLake path validation" should "reject artifact paths with too few segments" in {
     val thrown = intercept[java.security.InvalidParameterException] {
       TransientStorageParameters.fromString(
         "{\"storageCredentials\": [{\"oneLakeUrl\": " +
           "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse\"}]}")
     }
     thrown.getMessage should include("artifact")
+  }
+
+  it should "allow non-Files subfolders like Ingestions" in {
+    val url =
+      "https://msit-westcentralus-api.onelake.fabric.microsoft.com/615b69b6-0f61-46f0-b42c-8acdf9fd82e1/a9a1c710-951c-4f90-bd36-e84948307119/Ingestions/20260612-lakedata"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$url"}]}"""
+    val cred = TransientStorageParameters.fromString(json).storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeArtifactPath shouldEqual "a9a1c710-951c-4f90-bd36-e84948307119/Ingestions/20260612-lakedata"
   }
 
   it should "reject path traversal" in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
@@ -4,7 +4,11 @@
 package com.microsoft.kusto.spark.datasource
 
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.{
+  convertToAnyShouldWrapper,
+  convertToStringShouldWrapper,
+  include
+}
 
 class TransientStorageParametersTest extends AnyFlatSpec {
 
@@ -55,5 +59,282 @@ class TransientStorageParametersTest extends AnyFlatSpec {
     tsString shouldEqual s"[BlobContainer: kusto ,Storage: ateststorage , IsSasKeyDefined: false${System
         .lineSeparator()}" +
       s"BlobContainer: kusto2 ,Storage: ateststorage2 , IsSasKeyDefined: false, domain: core.windows.net]"
+  }
+
+  "TransientStorageCredentials" should "recognize OneLake https URL form via fromString" in {
+    val url =
+      "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$url"}]}"""
+    val cred = TransientStorageParameters.fromString(json).storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.authMethod shouldEqual AuthMethod.Impersonation
+    cred.oneLakeWorkspace shouldEqual "myws"
+    cred.oneLakeEndpoint shouldEqual "onelake.dfs.fabric.microsoft.com"
+    cred.oneLakeArtifactPath shouldEqual "mylake.Lakehouse/Files/exports"
+    cred.oneLakeAbfssBase shouldEqual
+      "abfss://myws@onelake.dfs.fabric.microsoft.com/mylake.Lakehouse/Files/exports"
+    cred.oneLakeUrl shouldEqual url
+  }
+
+  it should "recognize OneLake abfss URL form and canonicalize to https" in {
+    val url =
+      "abfss://myws@onelake.dfs.fabric.microsoft.com/mylake.Lakehouse/Files/exports;impersonate"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$url"}]}"""
+    val cred = TransientStorageParameters.fromString(json).storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeWorkspace shouldEqual "myws"
+    cred.oneLakeEndpoint shouldEqual "onelake.dfs.fabric.microsoft.com"
+    cred.oneLakeArtifactPath shouldEqual "mylake.Lakehouse/Files/exports"
+    // ;impersonate suffix stripped, and abfss canonicalized to https so CSL emission
+    // always uses the form verified to work with Kusto .export.
+    cred.oneLakeUrl shouldEqual
+      "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports"
+  }
+
+  it should "round-trip OneLake credentials via JSON" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{\"oneLakeUrl\": " +
+        "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"}]," +
+        "\"endpointSuffix\": \"fabric.microsoft.com\"}"
+    val params = TransientStorageParameters.fromString(transientStorage)
+    params.storageCredentials.length shouldEqual 1
+    val cred = params.storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeAbfssBase shouldEqual
+      "abfss://myws@onelake.dfs.fabric.microsoft.com/mylake.Lakehouse/Files/exports"
+
+    // Re-serialize and re-parse to verify Jackson handles the OneLake fields cleanly
+    val roundTripped = TransientStorageParameters.fromString(params.toInsecureString)
+    roundTripped.storageCredentials.head.isOneLake shouldEqual true
+    roundTripped.storageCredentials.head.oneLakeWorkspace shouldEqual "myws"
+  }
+
+  it should "parse OneLake credentials on a custom (edog) domain" in {
+    val url =
+      "https://onelake-int-edog.dfs.pbidedicated.windows-int.net/myws/mylake.Lakehouse/Files/exports"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$url"}]}"""
+    val cred = TransientStorageParameters.fromString(json).storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeEndpoint shouldEqual "onelake-int-edog.dfs.pbidedicated.windows-int.net"
+    cred.oneLakeWorkspace shouldEqual "myws"
+    cred.oneLakeArtifactPath shouldEqual "mylake.Lakehouse/Files/exports"
+  }
+
+  it should "parse OneLake JSON when only oneLakeUrl is supplied" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{\"oneLakeUrl\": " +
+        "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"}]}"
+    val params = TransientStorageParameters.fromString(transientStorage)
+    val cred = params.storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeWorkspace shouldEqual "myws"
+    cred.oneLakeArtifactPath shouldEqual "mylake.Lakehouse/Files/exports"
+  }
+
+  it should "not treat sasUrl as OneLake even if it looks like one" in {
+    // sasUrl is always treated as blob — only oneLakeUrl triggers OneLake
+    val transientStorage =
+      "{\"storageCredentials\": [{\"sasUrl\": " +
+        "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"}]}"
+    val cred = TransientStorageParameters.fromString(transientStorage).storageCredentials.head
+    cred.isOneLake shouldEqual false
+  }
+
+  it should "default to blob for existing configs with neither type nor oneLakeUrl (backward compat)" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{\"storageAccountName\": \"acct\", \"blobContainer\": \"c\"," +
+        "\"sasUrl\": \"https://acct.blob.core.windows.net/c\", \"sasKey\": \"?sig=x\"}]," +
+        "\"endpointSuffix\": \"core.windows.net\"}"
+    val cred = TransientStorageParameters.fromString(transientStorage).storageCredentials.head
+    cred.isOneLake shouldEqual false
+    cred.storageAccountName shouldEqual "acct"
+    cred.blobContainer shouldEqual "c"
+  }
+
+  "TransientStorageParameters mixing" should "reject OneLake + Blob credentials together" in {
+    val transientStorage =
+      "{\"storageCredentials\": [" +
+        "{\"oneLakeUrl\": \"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"}," +
+        "{\"sasUrl\": \"https://ateststorage.blob.core.windows.net/kusto;impersonate\"}" +
+        "]}"
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(transientStorage)
+    }
+    thrown.getMessage should include("cannot mix OneLake and non-OneLake")
+  }
+
+  it should "reject same-credential mixing of OneLake URL with blob fields" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{" +
+        "\"oneLakeUrl\": \"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"," +
+        "\"storageAccountName\": \"evilstorage\"," +
+        "\"blobContainer\": \"kusto\"" +
+        "}]}"
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(transientStorage)
+    }
+    thrown.getMessage should include("cannot also specify blob storage fields")
+  }
+
+  it should "reject same-credential mixing of OneLake URL with sasKey" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{" +
+        "\"oneLakeUrl\": \"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports\"," +
+        "\"sasKey\": \"?sp=racwdl&sig=xxxx\"" +
+        "}]}"
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(transientStorage)
+    }
+    thrown.getMessage should include("cannot also specify blob storage fields")
+  }
+
+  "OneLake JSON injection" should "ignore attacker-supplied derived fields and recompute from URL" in {
+    // Attacker tries to set oneLakeWorkspace to a workspace they don't own while
+    // oneLakeUrl points elsewhere — derived fields must always come from the URL.
+    val transientStorage =
+      "{\"storageCredentials\": [{" +
+        "\"oneLakeUrl\": \"https://onelake.dfs.fabric.microsoft.com/realws/reallh.Lakehouse/Files/exports\"," +
+        "\"oneLakeWorkspace\": \"victimws\"," +
+        "\"oneLakeEndpoint\": \"victim.dfs.fabric.microsoft.com\"," +
+        "\"oneLakeArtifactPath\": \"victimlh.Lakehouse/Files/secret\"" +
+        "}]}"
+    val params = TransientStorageParameters.fromString(transientStorage)
+    val cred = params.storageCredentials.head
+    cred.oneLakeWorkspace shouldEqual "realws"
+    cred.oneLakeEndpoint shouldEqual "onelake.dfs.fabric.microsoft.com"
+    cred.oneLakeArtifactPath shouldEqual "reallh.Lakehouse/Files/exports"
+  }
+
+  "OneLake path validation" should "reject artifact paths without /Files/ segment" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(
+        "{\"storageCredentials\": [{\"oneLakeUrl\": " +
+          "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Tables/secret\"}]}")
+    }
+    thrown.getMessage should include("Files")
+  }
+
+  it should "reject artifact paths with too few segments" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(
+        "{\"storageCredentials\": [{\"oneLakeUrl\": " +
+          "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse\"}]}")
+    }
+    thrown.getMessage should include("artifact")
+  }
+
+  it should "reject path traversal" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString(
+        "{\"storageCredentials\": [{\"oneLakeUrl\": " +
+          "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/../secret\"}]}")
+    }
+    thrown.getMessage should include("..")
+  }
+
+  it should "reject explicit port" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      TransientStorageParameters.fromString("{\"storageCredentials\": [{\"oneLakeUrl\": " +
+        "\"https://onelake.dfs.fabric.microsoft.com:8443/myws/mylake.Lakehouse/Files/exports\"}]}")
+    }
+    thrown.getMessage should include("port")
+  }
+
+  it should "reject query strings" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl =
+        "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports?sig=evil"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("query")
+  }
+
+  it should "reject encoded path traversal" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl =
+        "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/%2e%2e/secret"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("..")
+  }
+
+  it should "reject encoded traversal in the workspace segment" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl = "https://onelake.dfs.fabric.microsoft.com/%2e%2e/mylake.Lakehouse/Files/x"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("..")
+  }
+
+  it should "reject localhost or IP literal hosts" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl = "abfss://ws@localhost/lh.Lakehouse/Files/x"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("localhost")
+  }
+
+  it should "reject a fragment" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl =
+        "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/x#frag"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("fragment")
+  }
+
+  it should "reject userInfo on an https OneLake URL" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl =
+        "https://user@onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/x"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("userInfo")
+  }
+
+  it should "reject empty path segments (double slash)" in {
+    val thrown = intercept[java.security.InvalidParameterException] {
+      val cred = new TransientStorageCredentials()
+      cred.oneLakeUrl = "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files//x"
+      cred.parseOneLake(cred.oneLakeUrl)
+    }
+    thrown.getMessage should include("empty segments")
+  }
+
+  it should "classify a blob account+key JSON credential as blob (backward compat)" in {
+    val transientStorage =
+      "{\"storageCredentials\": [{\"storageAccountName\": \"acct\", \"storageAccountKey\": \"key\"," +
+        "\"blobContainer\": \"c\"}], \"endpointSuffix\": \"core.windows.net\"}"
+    val cred = TransientStorageParameters.fromString(transientStorage).storageCredentials.head
+    cred.isOneLake shouldEqual false
+    cred.storageAccountName shouldEqual "acct"
+  }
+
+  it should "reject a SAS credential with a null sasUrl without NPE" in {
+    val cred = new TransientStorageCredentials()
+    cred.sasKey = "?sig=x" // authMethod => Sas, sasUrl left null
+    val thrown = intercept[java.security.InvalidParameterException] {
+      cred.validate()
+    }
+    thrown.getMessage should include("sasUrl is null or empty")
+  }
+
+  it should "reject a SAS credential with an empty sasKey without index crash" in {
+    val cred = new TransientStorageCredentials()
+    cred.sasUrl = "https://acct.blob.core.windows.net/c"
+    cred.sasKey = "" // empty => authMethod Sas, must be rejected before sasKey(0) is used
+    val thrown = intercept[java.security.InvalidParameterException] {
+      cred.validate()
+    }
+    thrown.getMessage should include("sasKey is null or empty")
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -84,4 +84,49 @@ class CslCommandsGeneratorTest extends AnyFlatSpec {
       assert(commandResult == expectedResult)
     }
   }
+
+  "TestGenerateExportDataCommand" should "emit OneLake URL with ;impersonate for OneLake credentials" in {
+    val oneLakeUrl =
+      "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$oneLakeUrl"}]}"""
+    val params = TransientStorageParameters.fromString(json)
+
+    val commandResult = CslCommandsGenerator.generateExportDataCommand(
+      "Storms | take 100",
+      "storms/data/",
+      1,
+      params,
+      Option.empty[String],
+      additionalExportOptions = Map.empty[String, String])
+
+    val expectedResult = ".export async compressed to parquet " +
+      s"""("$oneLakeUrl;impersonate") """ +
+      "with ( namePrefix=\"storms/data/part1\", compressionType=\"snappy\",) " +
+      "<| Storms | take 100"
+    assert(commandResult == expectedResult)
+  }
+
+  it should "canonicalize OneLake abfss URL to https in the .export command" in {
+    val abfssUrl =
+      "abfss://myws@onelake.dfs.fabric.microsoft.com/mylake.Lakehouse/Files/exports"
+    val canonicalHttpsUrl =
+      "https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Files/exports"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$abfssUrl"}]}"""
+    val params = TransientStorageParameters.fromString(json)
+
+    val commandResult = CslCommandsGenerator.generateExportDataCommand(
+      "Storms | take 100",
+      "storms/data/",
+      1,
+      params,
+      Option.empty[String],
+      additionalExportOptions = Map.empty[String, String])
+
+    // Kusto .export accepts the https form of the OneLake URL; the abfss input is
+    // canonicalized at parse time so the emitted CSL is always uniform.
+    assert(commandResult.contains(s"$canonicalHttpsUrl;impersonate"))
+    assert(!commandResult.contains("abfss://"))
+  }
 }

--- a/docs/KustoSource.md
+++ b/docs/KustoSource.md
@@ -184,6 +184,47 @@ transientStorage = "{\"storageCredentials\": [{\"storageAccountName\": \"atestst
   option("transientStorage", transientStorage). \
 ```
 
+##### OneLake Transient Storage (Fabric)
+
+For Fabric environments, you can use **OneLake** as transient storage instead of Azure Blob/ADLS2. Kusto exports data using `;impersonate` (writes as the calling user) and Spark reads back over `abfss://` using ambient AAD.
+
+**Requirements:**
+- Workspace Contributor access to the OneLake lakehouse
+- Kusto cluster must be able to reach the OneLake endpoint
+- Spark runtime must have AAD configured for ABFSS (automatic in Fabric notebooks)
+
+**JSON format** — use the `oneLakeUrl` field (not `sasUrl`):
+
+```python
+import json
+
+transient_storage = json.dumps({
+    "storageCredentials": [
+        {"oneLakeUrl": "https://onelake.dfs.fabric.microsoft.com/<workspace-id>/<lakehouse-id>/Files/kusto-transient"}
+    ]
+})
+
+df = spark.read \
+    .format("com.microsoft.kusto.spark.datasource") \
+    .option("kustoCluster", "https://mycluster.kusto.fabric.microsoft.com") \
+    .option("kustoDatabase", "mydb") \
+    .option("kustoQuery", "MyTable | take 1000") \
+    .option("accessToken", token) \
+    .option("readMode", "ForceDistributedMode") \
+    .option("transientStorage", transient_storage) \
+    .load()
+```
+
+**Supported URL formats:**
+
+```
+# HTTPS form:
+https://<endpoint>/<workspace>/<lakehouse>/Files/<subpath>
+
+# ABFSS form:
+abfss://<workspace>@<endpoint>/<lakehouse>/Files/<subpath>
+```
+
 ### Examples
  
  **Using simplified syntax**

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.0</revision>
+        <revision>7.1.0-SNAPSHOT-120626</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.0-SNAPSHOT-120626</revision>
+        <revision>7.1.1</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.0.7</revision>
+        <revision>7.1.0</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>


### PR DESCRIPTION
## Summary
Port of PR #491 and subsequent fixes from master to the Spark 3 branch.

Adds OneLake (Fabric Lakehouse) as transient storage for distributed reads.

## Key Changes
- New `oneLakeUrl` field in `storageCredentials` JSON for Fabric OneLake URLs
- Kusto exports via `.export to oneLakeUrl;impersonate`; Spark reads back over abfss with ambient AAD
- Automatic `fs.azure.abfs.valid.endpoints` allowlisting for OneLake hosts
- Supports both `https://` and `abfss://` URL formats (canonicalized internally)
- Security: reject IP-literal, localhost, single-label hosts, path traversal for OneLake URLs
- Version bump to 7.1.0

## Spark 3 Adaptations
- Scala 2.12 constructor syntax (`def this(...) {` instead of `= {`)
- All 36 tests pass (TransientStorageParametersTest + CslCommandsGeneratorTest)
- Clean compile verified

## Files Changed
- `TransientStorageParameters.scala` — OneLake parsing, validation, security checks
- `KustoReader.scala` — OneLake read path (abfss + ambient AAD)
- `KustoSourceOptions.scala` — storageProtocol option
- `CslCommandsGenerator.scala` — OneLake export command generation
- Tests + docs + CHANGELOG