### PR TITLE
fix: remove /Files/ subfolder restriction from OneLake path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.1.1] - 2026-06-12
+
+### Fixed
+- Removed `/Files/` subfolder restriction from OneLake path validation — allows any subfolder (e.g., `/Ingestions/`)
+- Removed `isOneLakeUrl` method and host string checks (simplification)
+
 ## [7.1.0] - 2026-06-10
 
 ### Changed

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/TransientStorageParameters.scala
@@ -236,7 +236,7 @@ final case class TransientStorageCredentials() {
         if (StringUtils.isBlank(ws) || ws.contains(":") || StringUtils.isBlank(
             host) || rawPath.length <= 1) {
           throw new InvalidParameterException(
-            s"OneLake abfss URL must be 'abfss://<workspace>@<endpoint>/<artifact>/Files/...': $url")
+            s"OneLake abfss URL must be 'abfss://<workspace>@<endpoint>/<artifact>/<subpath>/...': $url")
         }
         (host, ws, rawPath.stripPrefix("/").stripSuffix("/"))
       case "https" =>
@@ -246,7 +246,7 @@ final case class TransientStorageCredentials() {
         }
         if (StringUtils.isBlank(host) || rawPath.length <= 1) {
           throw new InvalidParameterException(
-            s"OneLake https URL must be 'https://<endpoint>/<workspace>/<artifact>/Files/...': $url")
+            s"OneLake https URL must be 'https://<endpoint>/<workspace>/<artifact>/<subpath>/...': $url")
         }
         val parts = rawPath.stripPrefix("/").stripSuffix("/").split("/", 2)
         if (parts.length < 2 || parts(0).isEmpty || parts(1).isEmpty) {
@@ -267,9 +267,7 @@ final case class TransientStorageCredentials() {
         s"OneLake URL host must not be localhost, an IP literal, or a single-label host: $url")
     }
 
-    // Enforce Lakehouse Files path shape: '<artifact>/Files/<subpath>' with non-empty
-    // segments and no consecutive slashes. This blocks accidental targeting of Tables/
-    // (which would clash with Delta semantics) and catches typos early.
+    // Ensure non-empty path segments (no consecutive slashes) and basic traversal protection.
     val artifactSegments = artifactPath.split("/", -1)
     if (artifactSegments.exists(_.isEmpty)) {
       throw new InvalidParameterException(
@@ -282,9 +280,11 @@ final case class TransientStorageCredentials() {
       }) {
       throw new InvalidParameterException(s"OneLake URL path must not contain '..' or '.': $url")
     }
-    if (artifactSegments.length < 3 || !artifactSegments(1).equalsIgnoreCase("Files")) {
+    // Require at least two path segments (artifact + subpath) to avoid targeting the
+    // artifact root directly without a subfolder.
+    if (artifactSegments.length < 2) {
       throw new InvalidParameterException(
-        s"OneLake artifact path must be '<lakehouse>(.Lakehouse)?/Files/<subpath>': $url")
+        s"OneLake artifact path must include at least '<artifact>/<subpath>': $url")
     }
 
     this.oneLakeEndpoint = endpoint

--- a/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/datasource/TransientStorageParametersTest.scala
@@ -208,22 +208,23 @@ class TransientStorageParametersTest extends AnyFlatSpec {
     cred.oneLakeArtifactPath shouldEqual "reallh.Lakehouse/Files/exports"
   }
 
-  "OneLake path validation" should "reject artifact paths without /Files/ segment" in {
-    val thrown = intercept[java.security.InvalidParameterException] {
-      TransientStorageParameters.fromString(
-        "{\"storageCredentials\": [{\"oneLakeUrl\": " +
-          "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse/Tables/secret\"}]}")
-    }
-    thrown.getMessage should include("Files")
-  }
-
-  it should "reject artifact paths with too few segments" in {
+  "OneLake path validation" should "reject artifact paths with too few segments" in {
     val thrown = intercept[java.security.InvalidParameterException] {
       TransientStorageParameters.fromString(
         "{\"storageCredentials\": [{\"oneLakeUrl\": " +
           "\"https://onelake.dfs.fabric.microsoft.com/myws/mylake.Lakehouse\"}]}")
     }
     thrown.getMessage should include("artifact")
+  }
+
+  it should "allow non-Files subfolders like Ingestions" in {
+    val url =
+      "https://msit-westcentralus-api.onelake.fabric.microsoft.com/615b69b6-0f61-46f0-b42c-8acdf9fd82e1/a9a1c710-951c-4f90-bd36-e84948307119/Ingestions/20260612-lakedata"
+    val json =
+      s"""{"storageCredentials": [{"oneLakeUrl": "$url"}]}"""
+    val cred = TransientStorageParameters.fromString(json).storageCredentials.head
+    cred.isOneLake shouldEqual true
+    cred.oneLakeArtifactPath shouldEqual "a9a1c710-951c-4f90-bd36-e84948307119/Ingestions/20260612-lakedata"
   }
 
   it should "reject path traversal" in {

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.0</revision>
+        <revision>7.1.1</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.3.6</azure.bom.version>


### PR DESCRIPTION
## Summary
Removes the restriction that OneLake artifact paths must use the `/Files/` subfolder. Real OneLake URLs can use other subfolders like `/Ingestions/`.

## Problem
```
IllegalArgumentException: OneLake artifact path must be '<lakehouse>(.Lakehouse)?/Files/<subpath>'
```
This was thrown for legitimate OneLake URLs like:
```
https://msit-westcentralus-api.onelake.fabric.microsoft.com/<workspace>/<artifact>/Ingestions/<path>
```

## Fix
- Remove `artifactSegments(1).equalsIgnoreCase("Files")" check
- Only require at least 2 path segments (artifact + subpath)
- Keep all security checks (traversal, empty segments, IP/localhost)
- Also includes post-merge simplifications (remove isOneLakeUrl, host string checks)