### PR TITLE
fix: prevent trailing // comment from swallowing appended query operators (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 - None
 
 ### Fixed
-- None
+- Read queries ending in a single-line comment (`// ...`) no longer disable the connector's appended operators. The generated `| take`, `| count`, `| evaluate estimate_rows_count()`, `| where`, and `| project` are now placed on a new line so a trailing comment cannot swallow them — fixing reads that failed with `E_QUERY_RESULT_SET_TOO_LARGE` on large results and a silent column-pruning corruption (#267)
 
 ## [7.1.1] - 2026-06-12
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoFilter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoFilter.scala
@@ -29,7 +29,9 @@ object KustoFilter {
   def buildColumnsClause(columns: Array[String], timespanColumns: Set[String]): String = {
     if (columns.isEmpty) ""
     else {
-      " | project " + columns
+      // Start the projection on a new line so that a query ending with a single-line
+      // comment (// ...) does not swallow the appended '| project' operator (issue #267).
+      "\n| project " + columns
         .map(col => if (timespanColumns.contains(col)) s"tostring(['$col'])" else s"['$col']")
         .mkString(", ")
     }
@@ -38,7 +40,9 @@ object KustoFilter {
   def buildFiltersClause(schema: StructType, filters: Seq[Filter]): String = {
     val filterExpressions =
       filters.flatMap(f => buildFilterExpression(schema, f)).mkString(" and ")
-    if (filterExpressions.isEmpty) "" else " | where " + filterExpressions
+    // Start the filter on a new line so that a query ending with a single-line comment
+    // (// ...) does not swallow the appended '| where' operator (issue #267).
+    if (filterExpressions.isEmpty) "" else "\n| where " + filterExpressions
   }
 
   def buildFilterExpression(schema: StructType, filter: Filter): Option[String] = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/CslCommandsGenerator.scala
@@ -231,11 +231,15 @@ private[kusto] object CslCommandsGenerator {
   }
 
   def generateCountQuery(query: String): String = {
-    query + "| count"
+    // Append the operator on a new line so that a query ending with a single-line
+    // comment (// ...) does not swallow the appended '| count' operator (issue #267).
+    query + "\n| count"
   }
 
   def generateEstimateRowsCountQuery(query: String): String = {
-    query + "| evaluate estimate_rows_count()"
+    // Append the operator on a new line so that a query ending with a single-line
+    // comment (// ...) does not swallow the appended '| evaluate' operator (issue #267).
+    query + "\n| evaluate estimate_rows_count()"
   }
 
   def generateTableCount(table: String): String = {

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoQueryUtils.scala
@@ -12,7 +12,9 @@ object KustoQueryUtils {
   }
 
   def limitQuery(query: String, limit: Int): String = {
-    query + s"| take $limit"
+    // Append the operator on a new line so that a query ending with a single-line
+    // comment (// ...) does not swallow the appended '| take' operator (issue #267).
+    query + s"\n| take $limit"
   }
 
   def getQuerySchemaQuery(query: String): String = {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoFilterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoFilterTests.scala
@@ -157,7 +157,7 @@ class KustoFilterTests extends AnyFlatSpec with MockFactory with Matchers {
 
   "Non-empty columns filter" should "construct a project statement" in {
     val expr = KustoFilter.buildColumnsClause(Array("ColA", "ColB"), Set("ColB"))
-    expr shouldBe " | project ['ColA'], tostring(['ColB'])"
+    expr shouldBe "\n| project ['ColA'], tostring(['ColB'])"
   }
 
   "Providing multiple filters" should "lead to and-concatenation of these filters" in {
@@ -167,7 +167,7 @@ class KustoFilterTests extends AnyFlatSpec with MockFactory with Matchers {
       Array(StringEndsWith("ColA", "EndingString"), LessThanOrEqual("ColB", 5))
     val expr = KustoFilter.buildFiltersClause(testSchema, filters.toIndexedSeq)
 
-    expr shouldBe " | where ['ColA'] endswith_cs 'EndingString' and ['ColB'] <= 5"
+    expr shouldBe "\n| where ['ColA'] endswith_cs 'EndingString' and ['ColB'] <= 5"
   }
 
   "Providing two filters when one is resolved to NONE" should "only apply the second filter" in {
@@ -177,7 +177,7 @@ class KustoFilterTests extends AnyFlatSpec with MockFactory with Matchers {
       Array(StringEndsWith("ColA", "EndingString"), LessThanOrEqual("ColNotInTheSchema", 5))
     val expr = KustoFilter.buildFiltersClause(testSchema, filters.toIndexedSeq)
 
-    expr shouldBe " | where ['ColA'] endswith_cs 'EndingString'"
+    expr shouldBe "\n| where ['ColA'] endswith_cs 'EndingString'"
   }
 
   "Requesting only column pruning" should "adjust the query with prune expression" in {
@@ -192,6 +192,21 @@ class KustoFilterTests extends AnyFlatSpec with MockFactory with Matchers {
       originalQuery,
       KustoFiltering(columns, filters))
 
-    query shouldBe "MyTable | take 100 | where ['ColA'] endswith_cs 'EndingString' and ['ColB'] <= 5 | project tostring(['ColA']), ['ColB']"
+    query shouldBe "MyTable | take 100\n| where ['ColA'] endswith_cs 'EndingString' and ['ColB'] <= 5\n| project tostring(['ColA']), ['ColB']"
+  }
+
+  "pruneAndFilter" should "not let a trailing single-line comment swallow the where/project operators (issue #267)" in {
+    val testSchema =
+      StructType(Seq(StructField("ColA", StringType), StructField("ColB", IntegerType)))
+    val originalQuery = "MyTable // trailing comment"
+    val columns = Array("ColA", "ColB")
+    val filters: Array[Filter] =
+      Array(StringEndsWith("ColA", "EndingString"), LessThanOrEqual("ColB", 5))
+    val query = KustoFilter.pruneAndFilter(
+      KustoSchema(testSchema, Set("ColA")),
+      originalQuery,
+      KustoFiltering(columns, filters))
+
+    query shouldBe "MyTable // trailing comment\n| where ['ColA'] endswith_cs 'EndingString' and ['ColB'] <= 5\n| project tostring(['ColA']), ['ColB']"
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoQueryUtilsTest.scala
@@ -25,13 +25,27 @@ class KustoQueryUtilsTest
     val query = "Table | where column1 = 'abc' | summarize by count()"
 
     KustoQueryUtils.getQuerySchemaQuery(query) should be(
-      "Table | where column1 = 'abc' | summarize by count()| take 0")
+      "Table | where column1 = 'abc' | summarize by count()\n| take 0")
+  }
+
+  it should "not let a trailing single-line comment swallow the take operator" in {
+    val query = "range _ from 1 to 500001 step 1 // this comment causes issue"
+
+    KustoQueryUtils.getQuerySchemaQuery(query) should be(
+      "range _ from 1 to 500001 step 1 // this comment causes issue\n| take 0")
   }
 
   "limitQuery" should "add limit" in {
     val query = "Table | where column1 = 'abc' | summarize by count()"
 
     KustoQueryUtils.limitQuery(query, 5) should be(
-      "Table | where column1 = 'abc' | summarize by count()| take 5")
+      "Table | where column1 = 'abc' | summarize by count()\n| take 5")
+  }
+
+  it should "not let a trailing single-line comment swallow the take operator" in {
+    val query = "range _ from 1 to 500001 step 1 // this comment causes issue"
+
+    KustoQueryUtils.limitQuery(query, 5) should be(
+      "range _ from 1 to 500001 step 1 // this comment causes issue\n| take 5")
   }
 }

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/CslCommandsGeneratorTest.scala
@@ -129,4 +129,34 @@ class CslCommandsGeneratorTest extends AnyFlatSpec {
     assert(commandResult.contains(s"$canonicalHttpsUrl;impersonate"))
     assert(!commandResult.contains("abfss://"))
   }
+
+  "generateCountQuery" should "append the count operator on a new line" in {
+    val query = "Storms | take 100"
+
+    assert(CslCommandsGenerator.generateCountQuery(query) == "Storms | take 100\n| count")
+  }
+
+  it should "not let a trailing single-line comment swallow the count operator (issue #267)" in {
+    val query = "range _ from 1 to 500001 step 1 // this comment causes issue"
+
+    assert(
+      CslCommandsGenerator.generateCountQuery(query) ==
+        "range _ from 1 to 500001 step 1 // this comment causes issue\n| count")
+  }
+
+  "generateEstimateRowsCountQuery" should "append the evaluate operator on a new line" in {
+    val query = "Storms | take 100"
+
+    assert(
+      CslCommandsGenerator.generateEstimateRowsCountQuery(query) ==
+        "Storms | take 100\n| evaluate estimate_rows_count()")
+  }
+
+  it should "not let a trailing single-line comment swallow the evaluate operator (issue #267)" in {
+    val query = "range _ from 1 to 500001 step 1 // this comment causes issue"
+
+    assert(
+      CslCommandsGenerator.generateEstimateRowsCountQuery(query) ==
+        "range _ from 1 to 500001 step 1 // this comment causes issue\n| evaluate estimate_rows_count()")
+  }
 }


### PR DESCRIPTION
A KQL // comment runs to end-of-line, but the connector appended its operators on the
same line as the user query — so a query ending in // comment silently swallowed them.

This fixes two failures:

Read fails on large results (#267): the schema probe | take 0 and the
| count / | evaluate estimate_rows_count() queries were absorbed into the comment,
so the raw query ran and tripped E_QUERY_RESULT_SET_TOO_LARGE past truncationmaxrecords.
Silent wrong data: filter/column pushdown | where / | project were also swallowed;
a dropped | project returned all columns and Spark mapped them positionally, so
df.select(col) could return another column's values.
Fix: append these operators after a newline (\n) instead of a space — semantically
identical KQL for normal queries, but it terminates any trailing comment. Sites changed:
KustoQueryUtils.limitQuery, CslCommandsGenerator.generateCountQuery /
generateEstimateRowsCountQuery, KustoFilter.buildFiltersClause / buildColumnsClause.

Future Release Comment
Fixes:

Read queries ending in a single-line comment (// ...) no longer disable the connector's
appended operators (| take, | count, | evaluate estimate_rows_count(), | where,
| project), fixing read failures on large results and a silent column-pruning corruption (#267)
