### PR TITLE
chore: bump version to 7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 - None
 
 ### Fixed
+- None
+
+## [7.1.2] - 2026-07-29
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
 - Read queries ending in a single-line comment (`// ...`) no longer disable the connector's appended operators. The generated `| take`, `| count`, `| evaluate estimate_rows_count()`, `| where`, and `| project` are now placed on a new line so a trailing comment cannot swallow them — fixing reads that failed with `E_QUERY_RESULT_SET_TOO_LARGE` on large results and a silent column-pruning corruption (#267)
 
 ## [7.1.1] - 2026-06-12

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.1</revision>
+        <revision>7.1.2</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.3.6</azure.bom.version>


### PR DESCRIPTION
Bumps the Spark 4 (master) connector version **7.1.1 → 7.1.2** and finalizes the changelog for the 7.1.2 release.

- `pom.xml`: `<revision>` 7.1.1 → 7.1.2
- `CHANGELOG.md`: moved the already-merged #267 fix from `[Unreleased]` into a new `## [7.1.2] - 2026-07-29` section, and reset `[Unreleased]` to `None`.

No functional/code changes — this is release-prep only. The #267 fix itself landed on master in #499. Paired with the matching bump on `release/spark3` (#500) so both tag lines cut 7.1.2 together. After merge, the release is triggered by tagging `v4.0_7.1.2`.

---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Read queries ending in a single-line comment (`// ...`) no longer disable the connector's appended operators (`| take`, `| count`, `| evaluate estimate_rows_count()`, `| where`, `| project`), fixing read failures with `E_QUERY_RESULT_SET_TOO_LARGE` on large results and a silent column-pruning corruption (#267)