### PR TITLE
fix(ci): prevent Azure AD access token leaking into public workflow logs (CWE-532)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: "Run az commands"
         run: |
               access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+              # Register the derived token as a secret so it is redacted from logs.
+              # GitHub only auto-masks values that come from secrets.*, not values derived from them.
+              echo "::add-mask::$access_token"
               echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         timeout-minutes: 40
@@ -50,7 +53,7 @@ jobs:
           ingestStorageUrl: ${{ secrets.INGEST_STORAGE_URL }}
           ingestStorageContainer: ${{ secrets.INGEST_STORAGE_CONTAINER }}
         run: |
-          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}} -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
+          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
           
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       - name: "Run az commands"
         run: |
           access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+          # Register the derived token as a secret so it is redacted from logs.
+          # GitHub only auto-masks values that come from secrets.*, not values derived from them.
+          echo "::add-mask::$access_token"
           echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         env:
@@ -63,7 +66,7 @@ jobs:
           accessToken: ${{env.ACCESS_TOKEN}}
           storageAccountUrl: ${{ secrets.STORAGE_CONTAINER_URL }}
         run: |
-          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
+          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Get versions
         id: get_version
         run: |


### PR DESCRIPTION
Remediation for IcM 842305145 (Glasswing Mythos - July, follow-on wave to Twin Flames).

## Issue

`.github/workflows/build.yml` obtained a live Azure AD bearer token and propagated it unmasked:

```yaml
access_token=$(az account get-access-token ... --query accessToken -o tsv)
echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV   # never masked
...
mvn clean verify ... -DaccessToken=${{env.ACCESS_TOKEN}}   # expanded into the printed command
```

GitHub Actions only auto-masks values that come from the `secrets.*` context, not values derived from them at runtime. The token was therefore never registered as a secret, and the runner prints both the resolved `run:` block and the step environment into the job log. Because this repository is public, any user with read access could download a run log and recover a live Azure AD bearer token for the test cluster.

## Fix

- Emit `::add-mask::` for the token before it is written to `$GITHUB_ENV`, so it is redacted anywhere it surfaces. Masking is not retroactive, so it has to precede the write.
- Drop `-DaccessToken=${{env.ACCESS_TOKEN}}` from the `mvn` command line. This was the value being expanded into the printed command, and it was redundant:
  - `KustoOptions.scala:36` defines the option name as the literal string `accessToken`
  - `KustoTestUtils.getSystemVariable` (`KustoTestUtils.scala:250-255`) reads `System.getenv` before falling back to `System.getProperty`
  - the step `env:` block already sets an environment variable named `accessToken`, which the forked test JVM inherits
  - `scalatest-maven-plugin` (`connector/pom.xml:268-276`) declares an `<argLine>` but no `<systemProperties>`, so Maven user properties were not forwarded into the fork anyway

The `env: accessToken` entry is deliberately retained, because not every E2E test is covered by `<tagsToExclude>KustoE2E</tagsToExclude>` (for example `KustoSourceE2E.scala:130,190,197,237`), so those tests still need the value at runtime.

- The same pattern existed in `.github/workflows/release.yml`, which was not flagged by the scan. Fixed there too.

## Validation

- Both workflow files parse as valid YAML.
- No remaining unmasked path from the token to a logged command.
- `.azuredevops/build.yml` and `.azuredevops/release.yml` were checked and are 3-line placeholders with no equivalent issue.

## Follow-up, not in this PR

- The credential behind `secrets.APP_ID` should be rotated, since this fix prevents future exposure but does not undo past exposure.
- `actions/checkout` persists GitHub credentials by default; `persist-credentials: false` is worth considering for these privileged jobs.