### PR TITLE
fix(ci): stop materializing the Azure AD access token in CI (CWE-532)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,6 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: "Run az commands"
-        run: |
-              access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
-              # Register the derived token as a secret so it is redacted from logs.
-              # GitHub only auto-masks values that come from secrets.*, not values derived from them.
-              echo "::add-mask::$access_token"
-              echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         timeout-minutes: 40
         env:
@@ -48,7 +41,6 @@ jobs:
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-          accessToken: ${{env.ACCESS_TOKEN}}
           storageAccountUrl: '${{secrets.STORAGE_CONTAINER_URL}}'
           ingestStorageUrl: ${{ secrets.INGEST_STORAGE_URL }}
           ingestStorageContainer: ${{ secrets.INGEST_STORAGE_CONTAINER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: "Run az commands"
         run: |
               access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+              # Register the derived token as a secret so it is redacted from logs.
+              # GitHub only auto-masks values that come from secrets.*, not values derived from them.
+              echo "::add-mask::$access_token"
               echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         timeout-minutes: 40
@@ -50,7 +53,7 @@ jobs:
           ingestStorageUrl: ${{ secrets.INGEST_STORAGE_URL }}
           ingestStorageContainer: ${{ secrets.INGEST_STORAGE_CONTAINER }}
         run: |
-          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}} -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
+          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
           
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,20 +50,12 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: "Run az commands"
-        run: |
-          access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
-          # Register the derived token as a secret so it is redacted from logs.
-          # GitHub only auto-masks values that come from secrets.*, not values derived from them.
-          echo "::add-mask::$access_token"
-          echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         env:
           kustoAadAuthorityID: ${{ secrets.TENANT_ID }}
           kustoDatabase: ${{ secrets.DATABASE }}
           kustoCluster: ${{ secrets.CLUSTER }}
           kustoAadAppId: ${{secrets.APP_ID}}
-          accessToken: ${{env.ACCESS_TOKEN}}
           storageAccountUrl: ${{ secrets.STORAGE_CONTAINER_URL }}
         run: |
           mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       - name: "Run az commands"
         run: |
           access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+          # Register the derived token as a secret so it is redacted from logs.
+          # GitHub only auto-masks values that come from secrets.*, not values derived from them.
+          echo "::add-mask::$access_token"
           echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         env:
@@ -63,7 +66,7 @@ jobs:
           accessToken: ${{env.ACCESS_TOKEN}}
           storageAccountUrl: ${{ secrets.STORAGE_CONTAINER_URL }}
         run: |
-          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
+          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }}
       - name: Get versions
         id: get_version
         run: |


### PR DESCRIPTION
Follow-up to #502 (stacked on it — please merge #502 first).

## Problem

#502 stopped the token leaking into public logs by registering it with `::add-mask::`. That closes the disclosure, but the token is still **minted as a workflow-level value**: the `Run az commands` step wrote a live Azure AD bearer token to `$GITHUB_ENV`, and it was then injected into the Maven step's `env:` block.

Masking is a redaction control, not containment. On a public repository the safer property is for the credential to never become a workflow value at all.

## Change

Delete the `Run az commands` step and the `accessToken:` env var from `build.yml` and `release.yml`. Nothing added — 8 lines removed from each file.

`azure/login@v2` is retained.

## Why this is safe

`KustoTestUtils.getKustoConnectionOptions` already has exactly this fallback:

```scala
val maybeAccessTokenEnv = Option(getSystemVariable(KustoSinkOptions.KUSTO_ACCESS_TOKEN))
val accessToken: String = maybeAccessTokenEnv match {
  case Some(at) => at
  case None     => new AzureCliCredentialBuilder().build().getToken(tokenRequestContext).block()
}
```
(`KustoTestUtils.scala:208-233`)

With the variable unset, the credential chain acquires the token **inside the JVM** from the CLI session `azure/login@v2` established. It is never a workflow value, so there is nothing to mask.

The prerequisite is already proven in CI: `KustoSourceE2E.scala:199` calls `generateSasDelegationWithAzCli`, which shells out to `az` and depends on that same authenticated session.

Note this also required removing the `env:` line, not just the step — `getSystemVariable` returns the env var if present, and `accessToken: ${{env.ACCESS_TOKEN}}` with `ACCESS_TOKEN` unset yields an **empty string**, which `Option("")` would wrongly treat as `Some("")`.

## Verified

- `KUSTO_ACCESS_TOKEN` is literally `"accessToken"` (`KustoOptions.scala:36`) — matches the removed env var
- No other consumer of that env var or system property exists in `connector/` or `samples/`
- No residual `ACCESS_TOKEN` reference in either workflow
- Both workflows still parse as valid YAML
- The scope is now correctly `https://<cluster>.kusto.windows.net/.default` (via `clusterToKustoFQDN`), the standard Kusto AAD scope

`accessToken` remains a fully supported connector option — only CI stops supplying it.

## Consistency

This matches the pattern in `azure-kusto-python`, `azure-kusto-java`, `azure-kusto-go` and `azure-kusto-node`, which authenticate with OIDC and let the SDK credential chain acquire tokens in-process. `azure-kusto-spark` was one of only two Kusto repos that materialized a raw token.

Related: IcM 842305145 (Glasswing Mythos – July).