### PR TITLE
Fix NullPointerException in blob rollover when ensureNoDuplicatedBlobs is enabled

### DIFF
--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -667,14 +667,14 @@ object KustoWriter {
         if (shouldNotCommitBlockBlob) {
           blobWriter
         } else {
+          KDSU.logInfo(
+            className,
+            s"Sealing blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
+              s"blob number ${row._2}, with size $count")
+          finalizeBlobWrite(blobWriter)
           if (parameters.writeOptions.kustoCustomDebugWriteOptions.ensureNoDuplicatedBlobs) {
             taskMap.put(curBlobUUID, blobWriter)
           } else {
-            KDSU.logInfo(
-              className,
-              s"Sealing blob in partition $partitionIdString for requestId: '${parameters.writeOptions.requestId}', " +
-                s"blob number ${row._2}, with size $count")
-            finalizeBlobWrite(blobWriter)
             ingest(
               blobWriter,
               blobWriter.sas,
@@ -682,9 +682,9 @@ object KustoWriter {
                 !parameters.writeOptions.kustoCustomDebugWriteOptions.disableFlushImmediately,
               curBlobUUID,
               kustoClient)
-            curBlobUUID = UUID.randomUUID().toString
-            createBlobWriter(parameters, kustoClient, partitionIdString, row._2, curBlobUUID)
           }
+          curBlobUUID = UUID.randomUUID().toString
+          createBlobWriter(parameters, kustoClient, partitionIdString, row._2, curBlobUUID)
         }
     }
 

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoSinkBatchE2E.scala
@@ -423,6 +423,49 @@ class KustoSinkBatchE2E extends AnyFlatSpec with BeforeAndAfterAll {
     }
   }
 
+  "KustoBatchSinkSync" should "roll over blobs with duplicate protection enabled" taggedAs KustoE2E in {
+    val expectedRows = 3
+    val payload = "x" * (600 * 1024)
+    val df = (1 to expectedRows).map(id => (id, payload)).toDF("id", "payload").coalesce(1)
+    val prefix =
+      KustoQueryUtils.simplifyName(s"KustoBatchSinkE2E_DeduplicatedRollover_${UUID.randomUUID()}")
+    val table = s"${prefix}_Table"
+    val engineKcsb = ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+      kustoTestConnectionOptions.cluster,
+      kustoTestConnectionOptions.accessToken)
+    val kustoAdminClient = ClientFactory.createClient(engineKcsb)
+    kustoAdminClient.executeMgmt(
+      kustoTestConnectionOptions.database,
+      generateTempTableCreateCommand(table, columnsTypesAndNames = "Id:int, Payload:string"))
+
+    try {
+      df.write
+        .format("com.microsoft.kusto.spark.datasource")
+        .option(KustoSinkOptions.KUSTO_CLUSTER, kustoTestConnectionOptions.cluster)
+        .option(KustoSinkOptions.KUSTO_DATABASE, kustoTestConnectionOptions.database)
+        .option(KustoSinkOptions.KUSTO_TABLE, table)
+        .option(KustoSinkOptions.KUSTO_ACCESS_TOKEN, kustoTestConnectionOptions.accessToken)
+        .option(KustoSinkOptions.KUSTO_CLIENT_BATCHING_LIMIT, "1")
+        .option(KustoDebugOptions.KUSTO_ENSURE_NO_DUPLICATED_BLOBS, true.toString)
+        .option(KustoSinkOptions.KUSTO_TIMEOUT_LIMIT, (8 * 60).toString)
+        .mode(SaveMode.Append)
+        .save()
+
+      KustoTestUtils.validateResultsAndCleanup(
+        kustoAdminClient,
+        table,
+        kustoTestConnectionOptions.database,
+        expectedRows,
+        timeoutMs,
+        cleanupAllTables = false)
+    } finally {
+      KustoTestUtils.tryDropAllTablesByPrefix(
+        kustoAdminClient,
+        kustoTestConnectionOptions.database,
+        prefix)
+    }
+  }
+
   "KustoBatchSinkAsync" should "ingest structured data to a Kusto cluster in async mode" taggedAs KustoE2E in {
     val df = rows.toDF("name", "value")
     val prefix = "KustoBatchSinkE2EIngestAsync"


### PR DESCRIPTION
When ensureNoDuplicatedBlobs=true and partition size reaches clientBatchingLimit, the connector throws NullPointerException because ConcurrentHashMap.put() returns null for new keys. Solution: unified rollover branches to finalize blob, retain it in taskMap, rotate UUID, and always return a new valid writer to foldLeft.