### PR TITLE
[SYNAPSE]fix: correct queued ingestion timeout for 5.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [5.3.6] - 2026-09-01
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- Corrected the queued-ingestion request timeout from 40,000 seconds to the intended 40 seconds.
+
 ## [5.3.5] - 2026-06-02
 
 ### Changed

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -68,6 +68,14 @@ object KustoWriter {
     .maxAttempts(MaxIngestRetryAttempts)
     .retryExceptions(classOf[IngestionServiceException])
     .build
+  private[kusto] def queueRequestOptions: RequestRetryOptions =
+    new RequestRetryOptions(
+      RetryPolicyType.FIXED,
+      KCONST.QueueRetryAttempts,
+      Duration.ofMillis(KCONST.DefaultTimeoutQueueing.toLong),
+      null,
+      null,
+      null)
   private val formatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("HH-mm-ss-SSSSSS").withZone(ZoneId.systemDefault)
   private val objectMapper = new ObjectMapper()
@@ -505,6 +513,8 @@ object KustoWriter {
       parameters.coordinates.ingestionUrl,
       parameters.coordinates.clusterAlias)
     val ingestClient = clientCache.ingestClient
+    // Apply the queue policy before making subsequent SDK calls so newly created queue resources use it.
+    ingestClient.setQueueRequestOptions(queueRequestOptions)
     // Pre-warm the CloudInfo cache on the executor to avoid an extra metadata
     // fetch during authentication. We call retrieveCloudInfoForCluster (which
     // caches internally) instead of manuallyAddToCache to avoid a direct
@@ -512,15 +522,6 @@ object KustoWriter {
     // uber-jar and can cause NoSuchMethodError when an unshaded CloudInfo is
     // loaded from the Databricks/Spark runtime classpath.
     CloudInfo.retrieveCloudInfoForCluster(clientCache.ingestKcsb.getClusterUrl)
-
-    val reqRetryOpts = new RequestRetryOptions(
-      RetryPolicyType.FIXED,
-      KCONST.QueueRetryAttempts,
-      Duration.ofSeconds(KCONST.DefaultTimeoutQueueing),
-      null,
-      null,
-      null)
-    ingestClient.setQueueRequestOptions(reqRetryOpts)
     // We force blocking here, since the driver can only complete the ingestion process
     // once all partitions are ingested into the temporary table
     ingestRowsIntoKusto(

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -17,6 +17,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{BufferedWriter, ByteArrayOutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
+import java.time.Duration
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TimeZone
@@ -127,6 +128,13 @@ class WriterTests extends AnyFlatSpec with Matchers {
 
     verify(buffer, times(1)).flush()
     verify(buffer, times(1)).close()
+  }
+
+  "queueRequestOptions" should "use the intended 40 second timeout" in {
+    val options = KustoWriter.queueRequestOptions
+
+    options.getTryTimeoutDuration shouldEqual Duration.ofSeconds(40)
+    options.getMaxTries shouldEqual KustoConstants.QueueRetryAttempts
   }
 
   "getColumnsSchema" should "parse table schema correctly" in {

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>5.3.5</revision>
+        <revision>5.3.6</revision>
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>
         <scalafmt.plugin.version>1.1.1640084764.9f463a9</scalafmt.plugin.version>


### PR DESCRIPTION
Corrects the queued-ingestion timeout unit regression that interpreted the existing 40,000-millisecond value as 40,000 seconds. The queue request timeout is now configured as the intended 40 seconds.

This is a minimal Spark 3 maintenance fix: Kusto SDK remains at 5.1.1, no dependencies are upgraded, and version 5.3.6 plus its changelog entry are included. The focused Spark 3 writer tests pass 8/8, and the final shaded artifact was successfully built and bytecode-verified.

Breaking Changes: None
Features: None
Fixes: Correct queued-ingestion request timeout from 40,000 seconds to the intended 40 seconds.