### PR TITLE
fix: prevent CloudInfo executor stalls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [5.3.6] - 2026-09-01
+
+### Changed
+- None
+
+### Added
+- None
+
+### Fixed
+- Prevent queued and transactional writes from blocking Spark executors during ingestion metadata retrieval
+
 ## [5.3.5] - 2026-06-02
 
 ### Changed

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.CollectionAccumulator
 
 import java.io._
+import java.lang.reflect.{InvocationTargetException, Method, Modifier}
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.security.InvalidParameterException
@@ -592,31 +593,108 @@ object KustoWriter {
       clusterUrl: String,
       timeoutMillis: Long = CloudInfoTimeoutMillis,
       fetch: Callable[CloudInfo] = null): CloudInfo = {
-    require(timeoutMillis > 0, "timeoutMillis must be positive")
     val cloudInfoFetch = Option(fetch).getOrElse(new Callable[CloudInfo] {
       override def call(): CloudInfo = {
         val cloudInfo = CloudInfo.retrieveCloudInfoForCluster(clusterUrl)
-        CloudInfo.manuallyAddToCache(clusterUrl, cloudInfo)
+        invokeCloudInfoCacheSeed(classOf[CloudInfo], null, clusterUrl, cloudInfo)
         cloudInfo
       }
     })
-    val fetchTask = cloudInfoExecutor.submit(cloudInfoFetch)
+    executeCloudInfoOperation(
+      clusterUrl,
+      timeoutMillis,
+      "retrieving cluster metadata",
+      cloudInfoFetch)
+  }
+
+  private[kusto] def seedCloudInfoCache(
+      clusterUrl: String,
+      cloudInfo: CloudInfo,
+      timeoutMillis: Long = CloudInfoTimeoutMillis,
+      seed: Callable[Void] = null): Unit = {
+    val cloudInfoSeed = Option(seed).getOrElse(new Callable[Void] {
+      override def call(): Void = {
+        invokeCloudInfoCacheSeed(classOf[CloudInfo], null, clusterUrl, cloudInfo)
+        null
+      }
+    })
+    executeCloudInfoOperation(
+      clusterUrl,
+      timeoutMillis,
+      "seeding cluster metadata cache",
+      cloudInfoSeed)
+  }
+
+  private[kusto] def invokeCloudInfoCacheSeed(
+      cacheClass: Class[_],
+      cacheTarget: AnyRef,
+      clusterUrl: String,
+      cloudInfo: AnyRef): Unit = {
+    val cacheMethods = cacheClass.getMethods.filter { method =>
+      method.getName == "manuallyAddToCache" &&
+      method.getParameterTypes.toSeq.headOption.contains(classOf[String]) &&
+      method.getParameterCount == 2 &&
+      (cacheTarget != null || Modifier.isStatic(method.getModifiers))
+    }
+
+    val directSeed = cacheMethods
+      .find(_.getParameterTypes.apply(1).isAssignableFrom(cloudInfo.getClass))
+      .map(method => (method, cloudInfo))
+    val compatibleSeed = directSeed.orElse(
+      cacheMethods.iterator
+        .flatMap { method =>
+          val wrapperType = method.getParameterTypes.apply(1)
+          wrapperType.getMethods
+            .find(factory =>
+              factory.getName == "just" &&
+                Modifier.isStatic(factory.getModifiers) &&
+                factory.getParameterTypes.toSeq == Seq(classOf[Object]) &&
+                wrapperType.isAssignableFrom(factory.getReturnType))
+            .map(factory => (method, invokeReflective(factory, null, cloudInfo)))
+        }
+        .toSeq
+        .headOption)
+
+    val (cacheMethod, cacheValue) = compatibleSeed.getOrElse {
+      val signatures = cacheMethods.map(_.toGenericString).mkString(", ")
+      throw new NoSuchMethodException(
+        s"No compatible CloudInfo.manuallyAddToCache method found; candidates: $signatures")
+    }
+    invokeReflective(cacheMethod, cacheTarget, clusterUrl, cacheValue)
+  }
+
+  private def invokeReflective(method: Method, target: AnyRef, arguments: AnyRef*): AnyRef = {
     try {
-      fetchTask.get(timeoutMillis, TimeUnit.MILLISECONDS)
+      method.invoke(target, arguments: _*)
+    } catch {
+      case exception: InvocationTargetException =>
+        throw Option(exception.getCause).getOrElse(exception)
+    }
+  }
+
+  private def executeCloudInfoOperation[T](
+      clusterUrl: String,
+      timeoutMillis: Long,
+      operationDescription: String,
+      operation: Callable[T]): T = {
+    require(timeoutMillis > 0, "timeoutMillis must be positive")
+    val operationTask = cloudInfoExecutor.submit(operation)
+    try {
+      operationTask.get(timeoutMillis, TimeUnit.MILLISECONDS)
     } catch {
       case exception: TimeoutException =>
-        fetchTask.cancel(true)
+        operationTask.cancel(true)
         throw new DataServiceException(
           clusterUrl,
-          "Timed out retrieving cluster metadata",
+          s"Timed out $operationDescription",
           exception,
           false)
       case exception: InterruptedException =>
-        fetchTask.cancel(true)
+        operationTask.cancel(true)
         Thread.currentThread.interrupt()
         throw new DataServiceException(
           clusterUrl,
-          "Interrupted while retrieving cluster metadata",
+          s"Interrupted while $operationDescription",
           exception,
           false)
       case exception: ExecutionException =>
@@ -632,9 +710,7 @@ object KustoWriter {
   private[kusto] def initializeIngestClient(
       client: ExtendedKustoClient,
       cloudInfo: CloudInfo): QueuedIngestClient = {
-    CloudInfo.manuallyAddToCache(
-      getEffectiveIngestionEndpoint(client.ingestKcsb.getClusterUrl),
-      cloudInfo)
+    seedCloudInfoCache(getEffectiveIngestionEndpoint(client.ingestKcsb.getClusterUrl), cloudInfo)
     client.ingestClient
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasink/KustoWriter.scala
@@ -7,6 +7,7 @@ import com.azure.storage.common.policy.{RequestRetryOptions, RetryPolicyType}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.microsoft.azure.kusto.data.ClientRequestProperties
 import com.microsoft.azure.kusto.data.auth.CloudInfo
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException
 import com.microsoft.azure.kusto.ingest.IngestionProperties.DataFormat
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException
 import com.microsoft.azure.kusto.ingest.resources.ContainerWithSas
@@ -15,7 +16,8 @@ import com.microsoft.azure.kusto.ingest.source.{BlobSourceInfo, StreamSourceInfo
 import com.microsoft.azure.kusto.ingest.{
   IngestClient,
   IngestionProperties,
-  ManagedStreamingIngestClient
+  ManagedStreamingIngestClient,
+  QueuedIngestClient
 }
 import com.microsoft.azure.storage.blob.{BlobRequestOptions, CloudBlockBlob}
 import com.microsoft.kusto.spark.authentication.KustoAuthentication
@@ -38,6 +40,7 @@ import com.microsoft.kusto.spark.utils.{
 }
 import io.github.resilience4j.retry.RetryConfig
 import org.apache.commons.io.IOUtils
+import org.apache.http.conn.util.InetAddressUtils
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
@@ -50,6 +53,14 @@ import java.nio.charset.StandardCharsets
 import java.security.InvalidParameterException
 import java.time.{Clock, Duration, Instant}
 import java.util
+import java.util.concurrent.{
+  Callable,
+  ExecutionException,
+  ScheduledThreadPoolExecutor,
+  ThreadFactory,
+  TimeUnit,
+  TimeoutException
+}
 import java.util.zip.GZIPOutputStream
 import java.util.{TimeZone, UUID}
 import scala.collection.JavaConverters._
@@ -61,6 +72,20 @@ import java.util.concurrent.ConcurrentHashMap
 
 object KustoWriter {
   private val className = this.getClass.getSimpleName
+  private val CloudInfoTimeoutMillis = TimeUnit.SECONDS.toMillis(40)
+  private val cloudInfoExecutor = {
+    val executor = new ScheduledThreadPoolExecutor(
+      1,
+      new ThreadFactory {
+        override def newThread(runnable: Runnable): Thread = {
+          val thread = new Thread(runnable, "kusto-cloud-info-fetch")
+          thread.setDaemon(true)
+          thread
+        }
+      })
+    executor.setRemoveOnCancelPolicy(true)
+    executor
+  }
   val TempIngestionTablePrefix = "sparkTempTable_"
   val DelayPeriodBetweenCalls: Int = KCONST.DefaultPeriodicSamplePeriod.toMillis.toInt
   private val GzipBufferSize: Int = 1000 * KCONST.DefaultBufferSize
@@ -149,7 +174,12 @@ object KustoWriter {
             "Temp table name provided but the table does not exist. Either drop this " +
               "option or create the table beforehand.")
         }
-      } else {
+      }
+
+      // Resolve and cache ingestion metadata before creating or altering Kusto resources.
+      val cloudInfo = getCloudInfoForIngestion(writeOptions.writeMode, kustoClient)
+
+      if (writeOptions.userTempTableName.isEmpty) {
         // KustoWriter will create a temporary table ingesting the data to it.
         // Only if all executors succeeded the table will be appended to the original destination table.
         kustoClient.initializeTablesBySchema(
@@ -187,7 +217,7 @@ object KustoWriter {
       val sinkStartTime = getCreationTime(stagingTableIngestionProperties)
       if (writeOptions.isAsync) {
         val asyncWork = rdd.foreachPartitionAsync { rows =>
-          ingestRowsIntoTempTbl(rows, batchIdIfExists, partitionsResults, parameters)
+          ingestRowsIntoTempTbl(rows, batchIdIfExists, partitionsResults, parameters, cloudInfo)
         }
         KDSU.logInfo(className, s"asynchronous write to Kusto table '$table' in progress")
         // This part runs back on the driver
@@ -230,7 +260,7 @@ object KustoWriter {
       } else {
         try
           rdd.foreachPartition { rows =>
-            ingestRowsIntoTempTbl(rows, batchIdIfExists, partitionsResults, parameters)
+            ingestRowsIntoTempTbl(rows, batchIdIfExists, partitionsResults, parameters, cloudInfo)
           }
         catch {
           case exception: Exception =>
@@ -274,7 +304,8 @@ object KustoWriter {
       rows: Iterator[InternalRow],
       batchIdForTracing: String,
       partitionsResults: CollectionAccumulator[PartitionResult],
-      parameters: KustoWriteResource): Unit = {
+      parameters: KustoWriteResource,
+      cloudInfo: Option[CloudInfo]): Unit = {
     if (rows.isEmpty) {
       KDSU.logWarn(
         className,
@@ -297,7 +328,8 @@ object KustoWriter {
           rows,
           partitionsResults,
           ingestionProperties,
-          parameters)
+          parameters,
+          cloudInfo.get)
       }
     }
   }
@@ -494,7 +526,8 @@ object KustoWriter {
       rows: Iterator[InternalRow],
       partitionsResults: CollectionAccumulator[PartitionResult],
       ingestionProperties: IngestionProperties,
-      parameters: KustoWriteResource): Unit = {
+      parameters: KustoWriteResource,
+      cloudInfo: CloudInfo): Unit = {
     val partitionId = TaskContext.getPartitionId
     KDSU.logInfo(
       className,
@@ -504,14 +537,7 @@ object KustoWriter {
       parameters.authentication,
       parameters.coordinates.ingestionUrl,
       parameters.coordinates.clusterAlias)
-    val ingestClient = clientCache.ingestClient
-    // Pre-warm the CloudInfo cache on the executor to avoid an extra metadata
-    // fetch during authentication. We call retrieveCloudInfoForCluster (which
-    // caches internally) instead of manuallyAddToCache to avoid a direct
-    // dependency on reactor.core.publisher.Mono, which is shaded in the
-    // uber-jar and can cause NoSuchMethodError when an unshaded CloudInfo is
-    // loaded from the Databricks/Spark runtime classpath.
-    CloudInfo.retrieveCloudInfoForCluster(clientCache.ingestKcsb.getClusterUrl)
+    val ingestClient = initializeIngestClient(clientCache, cloudInfo)
 
     val reqRetryOpts = new RequestRetryOptions(
       RetryPolicyType.FIXED,
@@ -530,6 +556,86 @@ object KustoWriter {
       partitionsResults,
       batchIdForTracing,
       parameters)
+  }
+
+  private[kusto] def getCloudInfoForIngestion(
+      writeMode: WriteMode.Value,
+      client: ExtendedKustoClient): Option[CloudInfo] = {
+    if (writeMode == WriteMode.KustoStreaming) {
+      None
+    } else {
+      Some(
+        retrieveCloudInfoForCluster(
+          getEffectiveIngestionEndpoint(client.ingestKcsb.getClusterUrl)))
+    }
+  }
+
+  private[kusto] def getEffectiveIngestionEndpoint(clusterUrl: String): String = {
+    val uri = URI.create(clusterUrl)
+    val authority = Option(uri.getAuthority).getOrElse("").toLowerCase
+    val isReserved = !uri.isAbsolute ||
+      authority.contains("localhost") ||
+      InetAddressUtils.isIPv4Address(authority) ||
+      InetAddressUtils.isIPv6Address(authority) ||
+      authority.equalsIgnoreCase("onebox.dev.kusto.windows.net")
+
+    if (clusterUrl.contains("ingest-") || isReserved) {
+      clusterUrl
+    } else if (clusterUrl.contains("://")) {
+      clusterUrl.replaceFirst("://", "://ingest-")
+    } else {
+      s"ingest-$clusterUrl"
+    }
+  }
+
+  private[kusto] def retrieveCloudInfoForCluster(
+      clusterUrl: String,
+      timeoutMillis: Long = CloudInfoTimeoutMillis,
+      fetch: Callable[CloudInfo] = null): CloudInfo = {
+    require(timeoutMillis > 0, "timeoutMillis must be positive")
+    val cloudInfoFetch = Option(fetch).getOrElse(new Callable[CloudInfo] {
+      override def call(): CloudInfo = {
+        val cloudInfo = CloudInfo.retrieveCloudInfoForCluster(clusterUrl)
+        CloudInfo.manuallyAddToCache(clusterUrl, cloudInfo)
+        cloudInfo
+      }
+    })
+    val fetchTask = cloudInfoExecutor.submit(cloudInfoFetch)
+    try {
+      fetchTask.get(timeoutMillis, TimeUnit.MILLISECONDS)
+    } catch {
+      case exception: TimeoutException =>
+        fetchTask.cancel(true)
+        throw new DataServiceException(
+          clusterUrl,
+          "Timed out retrieving cluster metadata",
+          exception,
+          false)
+      case exception: InterruptedException =>
+        fetchTask.cancel(true)
+        Thread.currentThread.interrupt()
+        throw new DataServiceException(
+          clusterUrl,
+          "Interrupted while retrieving cluster metadata",
+          exception,
+          false)
+      case exception: ExecutionException =>
+        exception.getCause match {
+          case cause: DataServiceException => throw cause
+          case cause: RuntimeException => throw cause
+          case cause: Error => throw cause
+          case cause => throw new RuntimeException(cause)
+        }
+    }
+  }
+
+  private[kusto] def initializeIngestClient(
+      client: ExtendedKustoClient,
+      cloudInfo: CloudInfo): QueuedIngestClient = {
+    CloudInfo.manuallyAddToCache(
+      getEffectiveIngestionEndpoint(client.ingestKcsb.getClusterUrl),
+      cloudInfo)
+    client.ingestClient
   }
 
   private def createBlobWriter(

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -4,8 +4,15 @@
 package com.microsoft.kusto.spark
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException
+import com.microsoft.azure.kusto.data.auth.{CloudInfo, ConnectionStringBuilder}
+import com.microsoft.azure.kusto.ingest.QueuedIngestClient
 import com.microsoft.kusto.spark.datasink._
-import com.microsoft.kusto.spark.utils.{KustoConstants, KustoDataSourceUtils => KDSU}
+import com.microsoft.kusto.spark.utils.{
+  ExtendedKustoClient,
+  KustoConstants,
+  KustoDataSourceUtils => KDSU
+}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
@@ -14,13 +21,23 @@ import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.io.{BufferedWriter, ByteArrayOutputStream, OutputStreamWriter}
+import java.io.{
+  BufferedWriter,
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  ObjectInputStream,
+  ObjectOutputStream,
+  OutputStreamWriter
+}
+import java.net.{InetSocketAddress, ServerSocket}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TimeZone
+import java.util.concurrent.{Callable, CountDownLatch}
 import java.util.zip.GZIPOutputStream
+import com.sun.net.httpserver.HttpServer
 
 class WriterTests extends AnyFlatSpec with Matchers {
 
@@ -127,6 +144,185 @@ class WriterTests extends AnyFlatSpec with Matchers {
 
     verify(buffer, times(1)).flush()
     verify(buffer, times(1)).close()
+  }
+
+  "initializeIngestClient" should "seed CloudInfo before creating the queued client" in {
+    val socket = new ServerSocket(0)
+    val endpoint = s"http://localhost:${socket.getLocalPort}"
+    socket.close()
+    val cloudInfo = new CloudInfo(
+      false,
+      "https://login.microsoftonline.com",
+      "client-id",
+      "http://localhost",
+      "https://kusto.kusto.windows.net",
+      "https://login.microsoftonline.com/common")
+    val expectedIngestClient = mock(classOf[QueuedIngestClient])
+    val client = new ExtendedKustoClient(
+      new ConnectionStringBuilder("https://engine.kusto.windows.net"),
+      new ConnectionStringBuilder(endpoint),
+      "engine") {
+      override lazy val ingestClient: QueuedIngestClient = {
+        CloudInfo.retrieveCloudInfoForCluster(endpoint) shouldEqual cloudInfo
+        expectedIngestClient
+      }
+    }
+
+    KustoWriter.initializeIngestClient(client, cloudInfo) should be theSameInstanceAs
+      expectedIngestClient
+  }
+
+  "getCloudInfoForIngestion" should "skip metadata lookup for streaming writes" in {
+    val client = new ExtendedKustoClient(
+      new ConnectionStringBuilder("https://engine.kusto.windows.net"),
+      new ConnectionStringBuilder("http://127.0.0.1:1"),
+      "engine")
+
+    KustoWriter.getCloudInfoForIngestion(WriteMode.KustoStreaming, client) shouldBe None
+  }
+
+  "getEffectiveIngestionEndpoint" should "match SDK 5.1.1 endpoint correction" in {
+    KustoWriter.getEffectiveIngestionEndpoint("https://cluster.kusto.windows.net") shouldEqual
+      "https://ingest-cluster.kusto.windows.net"
+    KustoWriter.getEffectiveIngestionEndpoint(
+      "https://ingest-cluster.kusto.windows.net") shouldEqual
+      "https://ingest-cluster.kusto.windows.net"
+    KustoWriter.getEffectiveIngestionEndpoint("http://127.0.0.1") shouldEqual
+      "http://127.0.0.1"
+    KustoWriter.getEffectiveIngestionEndpoint("http://localhost:1234") shouldEqual
+      "http://localhost:1234"
+    KustoWriter.getEffectiveIngestionEndpoint("https://dm.contoso.example") shouldEqual
+      "https://ingest-dm.contoso.example"
+    KustoWriter.getEffectiveIngestionEndpoint(
+      "https://INGEST-cluster.kusto.windows.net") shouldEqual
+      "https://ingest-INGEST-cluster.kusto.windows.net"
+  }
+
+  "retrieveCloudInfoForCluster" should "read SDK metadata from the exact endpoint" in {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    val metadata =
+      """{
+        |  "AzureAD": {
+        |    "LoginMfaRequired": true,
+        |    "LoginEndpoint": "https://login.sovereign.example",
+        |    "KustoClientAppId": "client-id",
+        |    "KustoClientRedirectUri": "https://redirect.sovereign.example",
+        |    "KustoServiceResourceId": "https://service.sovereign.example",
+        |    "FirstPartyAuthorityUrl": "https://authority.sovereign.example"
+        |  }
+        |}""".stripMargin
+    server.createContext(
+      "/v1/rest/auth/metadata",
+      exchange => {
+        val bytes = metadata.getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(200, bytes.length)
+        try {
+          exchange.getResponseBody.write(bytes)
+        } finally {
+          exchange.close()
+        }
+      })
+    server.start()
+    try {
+      val result =
+        KustoWriter.retrieveCloudInfoForCluster(s"http://127.0.0.1:${server.getAddress.getPort}")
+      result.isLoginMfaRequired shouldBe true
+      result.getLoginEndpoint shouldEqual "https://login.sovereign.example"
+      result.getKustoClientAppId shouldEqual "client-id"
+      result.getKustoClientRedirectUri shouldEqual "https://redirect.sovereign.example"
+      result.getKustoServiceResourceId shouldEqual "https://service.sovereign.example"
+      result.getFirstPartyAuthorityUrl shouldEqual "https://authority.sovereign.example"
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  it should "bound a metadata endpoint that does not respond" in {
+    val readyFetch = new Callable[CloudInfo] {
+      override def call(): CloudInfo = CloudInfo.DEFAULT_CLOUD
+    }
+    KustoWriter.retrieveCloudInfoForCluster(
+      "https://ingest.example",
+      timeoutMillis = 2000,
+      fetch = readyFetch) shouldEqual CloudInfo.DEFAULT_CLOUD
+
+    val fetchStarted = new CountDownLatch(1)
+    val releaseFetch = new CountDownLatch(1)
+    val uninterruptibleFetch = new Callable[CloudInfo] {
+      override def call(): CloudInfo = {
+        fetchStarted.countDown()
+        while (releaseFetch.getCount > 0) {
+          try {
+            releaseFetch.await()
+          } catch {
+            case _: InterruptedException => // Simulate an SDK transport call that ignores interruption.
+          }
+        }
+        CloudInfo.DEFAULT_CLOUD
+      }
+    }
+    val queuedFetch = new Callable[CloudInfo] {
+      override def call(): CloudInfo = CloudInfo.DEFAULT_CLOUD
+    }
+
+    try {
+      val firstStarted = System.nanoTime()
+      a[DataServiceException] should be thrownBy KustoWriter.retrieveCloudInfoForCluster(
+        "https://ingest.example",
+        timeoutMillis = 500,
+        fetch = uninterruptibleFetch)
+      fetchStarted.getCount shouldEqual 0L
+      (System.nanoTime() - firstStarted) / 1000000 should be < 5000L
+
+      val secondStarted = System.nanoTime()
+      a[DataServiceException] should be thrownBy KustoWriter.retrieveCloudInfoForCluster(
+        "https://ingest.example",
+        timeoutMillis = 500,
+        fetch = queuedFetch)
+      (System.nanoTime() - secondStarted) / 1000000 should be < 5000L
+    } finally {
+      releaseFetch.countDown()
+    }
+  }
+
+  it should "preserve SDK DataServiceException classification" in {
+    val expected = new DataServiceException("https://ingest.example", "metadata failed", true)
+    val fetch = new Callable[CloudInfo] {
+      override def call(): CloudInfo = throw expected
+    }
+
+    val actual = the[DataServiceException] thrownBy KustoWriter.retrieveCloudInfoForCluster(
+      "https://ingest.example",
+      fetch = fetch)
+    actual should be theSameInstanceAs expected
+    actual.isPermanent shouldBe true
+  }
+
+  "CloudInfo" should "serialize non-default cloud settings captured by executor closures" in {
+    val cloudInfo = new CloudInfo(
+      true,
+      "https://login.sovereign.example",
+      "sovereign-client-id",
+      "https://redirect.sovereign.example",
+      "https://service.sovereign.example",
+      "https://authority.sovereign.example")
+    val serialized = new ByteArrayOutputStream()
+    val objectOutput = new ObjectOutputStream(serialized)
+    try {
+      objectOutput.writeObject(Some(cloudInfo))
+    } finally {
+      objectOutput.close()
+    }
+
+    val objectInput = new ObjectInputStream(new ByteArrayInputStream(serialized.toByteArray))
+    val restored =
+      try {
+        objectInput.readObject().asInstanceOf[Option[CloudInfo]].get
+      } finally {
+        objectInput.close()
+      }
+
+    restored shouldEqual cloudInfo
   }
 
   "getColumnsSchema" should "parse table schema correctly" in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -262,6 +262,51 @@ class WriterTests extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "bound the actual SDK 5.1.1 cache monitor" in {
+    val warmEndpoint = "http://localhost:31003"
+    KustoWriter.seedCloudInfoCache(warmEndpoint, CloudInfo.DEFAULT_CLOUD, timeoutMillis = 2000)
+
+    val cacheField = classOf[CloudInfo].getDeclaredField("cache")
+    cacheField.setAccessible(true)
+    val cacheMonitor = cacheField.get(null).asInstanceOf[AnyRef]
+    val monitorHeld = new CountDownLatch(1)
+    val releaseMonitor = new CountDownLatch(1)
+    val monitorHolder = new Thread(
+      new Runnable {
+        override def run(): Unit = cacheMonitor.synchronized {
+          monitorHeld.countDown()
+          releaseMonitor.await()
+        }
+      },
+      "cloud-info-cache-monitor-holder")
+    monitorHolder.setDaemon(true)
+    monitorHolder.start()
+
+    val endpoint = "http://localhost:31004"
+    try {
+      monitorHeld.await(5, java.util.concurrent.TimeUnit.SECONDS) shouldBe true
+      val started = System.nanoTime()
+      val error = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
+        endpoint,
+        CloudInfo.DEFAULT_CLOUD,
+        timeoutMillis = 500)
+      val elapsedMillis = (System.nanoTime() - started) / 1000000L
+
+      error.getMessage should include("Timed out seeding cluster metadata cache")
+      error.isPermanent shouldBe false
+      elapsedMillis should be >= 400L
+      elapsedMillis should be < 2000L
+    } finally {
+      releaseMonitor.countDown()
+      monitorHolder.join(5000L)
+    }
+
+    monitorHolder.isAlive shouldBe false
+    KustoWriter.seedCloudInfoCache(endpoint, CloudInfo.DEFAULT_CLOUD, timeoutMillis = 5000)
+    CloudInfo.retrieveCloudInfoForCluster(endpoint) should be theSameInstanceAs
+      CloudInfo.DEFAULT_CLOUD
+  }
+
   "getCloudInfoForIngestion" should "skip metadata lookup for streaming writes" in {
     val client = new ExtendedKustoClient(
       new ConnectionStringBuilder("https://engine.kusto.windows.net"),

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -36,6 +36,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TimeZone
 import java.util.concurrent.{Callable, CountDownLatch}
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPOutputStream
 import com.sun.net.httpserver.HttpServer
 
@@ -170,6 +171,95 @@ class WriterTests extends AnyFlatSpec with Matchers {
 
     KustoWriter.initializeIngestClient(client, cloudInfo) should be theSameInstanceAs
       expectedIngestClient
+  }
+
+  "invokeCloudInfoCacheSeed" should "support direct and reactive SDK cache signatures" in {
+    val cloudInfo = new CloudInfo(
+      false,
+      "https://login.microsoftonline.com",
+      "client-id",
+      "http://localhost",
+      "https://kusto.kusto.windows.net",
+      "https://login.microsoftonline.com/common")
+    val directEndpoint = "http://localhost:31001"
+    KustoWriter.invokeCloudInfoCacheSeed(classOf[CloudInfo], null, directEndpoint, cloudInfo)
+    CloudInfo.retrieveCloudInfoForCluster(directEndpoint) should be theSameInstanceAs cloudInfo
+
+    class ReactiveCacheApi {
+      var cachedEndpoint: String = _
+      var cachedCloudInfo: CloudInfo = _
+      def manuallyAddToCache(
+          clusterUrl: String,
+          cloudInfoPublisher: reactor.core.publisher.Mono[CloudInfo]): Unit = {
+        cachedEndpoint = clusterUrl
+        cachedCloudInfo = cloudInfoPublisher.block()
+      }
+    }
+    val reactiveCache = new ReactiveCacheApi
+    val reactiveEndpoint = "http://localhost:31002"
+    KustoWriter.invokeCloudInfoCacheSeed(
+      reactiveCache.getClass,
+      reactiveCache,
+      reactiveEndpoint,
+      cloudInfo)
+    reactiveCache.cachedEndpoint shouldEqual reactiveEndpoint
+    reactiveCache.cachedCloudInfo should be theSameInstanceAs cloudInfo
+  }
+
+  "seedCloudInfoCache" should "bound a seed blocked on the SDK cache monitor" in {
+    val readySeed = new Callable[Void] {
+      override def call(): Void = null
+    }
+    KustoWriter.seedCloudInfoCache(
+      "https://ingest.example",
+      CloudInfo.DEFAULT_CLOUD,
+      timeoutMillis = 2000,
+      seed = readySeed)
+
+    val seedStarted = new CountDownLatch(1)
+    val releaseSeed = new CountDownLatch(1)
+    val queuedExecutions = new AtomicInteger(0)
+    val uninterruptibleSeed = new Callable[Void] {
+      override def call(): Void = {
+        seedStarted.countDown()
+        while (releaseSeed.getCount > 0) {
+          try {
+            releaseSeed.await()
+          } catch {
+            case _: InterruptedException => // Simulate waiting on an SDK monitor held by a stuck call.
+          }
+        }
+        null
+      }
+    }
+    val queuedSeed = new Callable[Void] {
+      override def call(): Void = {
+        queuedExecutions.incrementAndGet()
+        null
+      }
+    }
+
+    try {
+      val firstError = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
+        "https://ingest.example",
+        CloudInfo.DEFAULT_CLOUD,
+        timeoutMillis = 500,
+        seed = uninterruptibleSeed)
+      seedStarted.getCount shouldEqual 0L
+      firstError.getMessage should include("Timed out seeding cluster metadata cache")
+
+      val secondStarted = System.nanoTime()
+      val secondError = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
+        "https://ingest.example",
+        CloudInfo.DEFAULT_CLOUD,
+        timeoutMillis = 500,
+        seed = queuedSeed)
+      (System.nanoTime() - secondStarted) / 1000000 should be < 5000L
+      secondError.getMessage should include("Timed out seeding cluster metadata cache")
+      queuedExecutions.get() shouldEqual 0
+    } finally {
+      releaseSeed.countDown()
+    }
   }
 
   "getCloudInfoForIngestion" should "skip metadata lookup for streaming writes" in {

--- a/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/WriterTests.scala
@@ -35,7 +35,7 @@ import java.sql.{Date, Timestamp}
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.TimeZone
-import java.util.concurrent.{Callable, CountDownLatch}
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPOutputStream
 import com.sun.net.httpserver.HttpServer
@@ -206,29 +206,81 @@ class WriterTests extends AnyFlatSpec with Matchers {
     reactiveCache.cachedCloudInfo should be theSameInstanceAs cloudInfo
   }
 
-  "seedCloudInfoCache" should "bound a seed blocked on the SDK cache monitor" in {
-    val readySeed = new Callable[Void] {
+  "seedCloudInfoCache" should "cancel a queued caller without affecting its peers" in {
+    val runningSeedStarted = new CountDownLatch(1)
+    val releaseRunningSeed = new CountDownLatch(1)
+    val cancelledExecutions = new AtomicInteger(0)
+    val callers = Executors.newSingleThreadExecutor()
+    val runningSeed = new Callable[Void] {
+      override def call(): Void = {
+        runningSeedStarted.countDown()
+        releaseRunningSeed.await()
+        null
+      }
+    }
+    val cancelledSeed = new Callable[Void] {
+      override def call(): Void = {
+        cancelledExecutions.incrementAndGet()
+        null
+      }
+    }
+    val laterSeed = new Callable[Void] {
       override def call(): Void = null
     }
-    KustoWriter.seedCloudInfoCache(
-      "https://ingest.example",
-      CloudInfo.DEFAULT_CLOUD,
-      timeoutMillis = 2000,
-      seed = readySeed)
 
-    val seedStarted = new CountDownLatch(1)
-    val releaseSeed = new CountDownLatch(1)
+    try {
+      val runningCaller = callers.submit(new Callable[String] {
+        override def call(): String = {
+          KustoWriter.seedCloudInfoCache(
+            "https://running-peer.example",
+            CloudInfo.DEFAULT_CLOUD,
+            timeoutMillis = 5000,
+            seed = runningSeed)
+          "completed"
+        }
+      })
+      runningSeedStarted.await(5, TimeUnit.SECONDS) shouldBe true
+
+      val cancelledError = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
+        "https://cancelled-queued.example",
+        CloudInfo.DEFAULT_CLOUD,
+        timeoutMillis = 500,
+        seed = cancelledSeed)
+      cancelledError.getMessage should include("Timed out seeding cluster metadata cache")
+
+      releaseRunningSeed.countDown()
+      runningCaller.get(5, TimeUnit.SECONDS) shouldEqual "completed"
+      KustoWriter.seedCloudInfoCache(
+        "https://later-peer.example",
+        CloudInfo.DEFAULT_CLOUD,
+        timeoutMillis = 2000,
+        seed = laterSeed)
+      cancelledExecutions.get() shouldEqual 0
+    } finally {
+      releaseRunningSeed.countDown()
+      callers.shutdownNow()
+      callers.awaitTermination(5, TimeUnit.SECONDS)
+    }
+  }
+
+  it should "cancel a running caller without affecting queued or later callers" in {
+    val runningSeedStarted = new CountDownLatch(1)
+    val releaseRunningSeed = new CountDownLatch(1)
+    val runningCompletions = new AtomicInteger(0)
     val queuedExecutions = new AtomicInteger(0)
-    val uninterruptibleSeed = new Callable[Void] {
+    val queuedCallerStarted = new CountDownLatch(1)
+    val callers = Executors.newFixedThreadPool(2)
+    val interruptionResistantSeed = new Callable[Void] {
       override def call(): Void = {
-        seedStarted.countDown()
-        while (releaseSeed.getCount > 0) {
+        runningSeedStarted.countDown()
+        while (releaseRunningSeed.getCount > 0) {
           try {
-            releaseSeed.await()
+            releaseRunningSeed.await()
           } catch {
-            case _: InterruptedException => // Simulate waiting on an SDK monitor held by a stuck call.
+            case _: InterruptedException => // Model Java monitor entry, which ignores interruption.
           }
         }
+        runningCompletions.incrementAndGet()
         null
       }
     }
@@ -240,25 +292,53 @@ class WriterTests extends AnyFlatSpec with Matchers {
     }
 
     try {
-      val firstError = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
-        "https://ingest.example",
-        CloudInfo.DEFAULT_CLOUD,
-        timeoutMillis = 500,
-        seed = uninterruptibleSeed)
-      seedStarted.getCount shouldEqual 0L
-      firstError.getMessage should include("Timed out seeding cluster metadata cache")
+      val runningCaller = callers.submit(new Callable[DataServiceException] {
+        override def call(): DataServiceException = {
+          try {
+            KustoWriter.seedCloudInfoCache(
+              "https://cancelled-running.example",
+              CloudInfo.DEFAULT_CLOUD,
+              timeoutMillis = 1000,
+              seed = interruptionResistantSeed)
+            null
+          } catch {
+            case exception: DataServiceException => exception
+          }
+        }
+      })
+      runningSeedStarted.await(5, TimeUnit.SECONDS) shouldBe true
 
-      val secondStarted = System.nanoTime()
-      val secondError = the[DataServiceException] thrownBy KustoWriter.seedCloudInfoCache(
-        "https://ingest.example",
+      val queuedCaller = callers.submit(new Callable[String] {
+        override def call(): String = {
+          queuedCallerStarted.countDown()
+          KustoWriter.seedCloudInfoCache(
+            "https://queued-peer.example",
+            CloudInfo.DEFAULT_CLOUD,
+            timeoutMillis = 5000,
+            seed = queuedSeed)
+          "completed"
+        }
+      })
+      queuedCallerStarted.await(5, TimeUnit.SECONDS) shouldBe true
+
+      val cancelledError = runningCaller.get(5, TimeUnit.SECONDS)
+      cancelledError should not be null
+      cancelledError.getMessage should include("Timed out seeding cluster metadata cache")
+
+      releaseRunningSeed.countDown()
+      queuedCaller.get(5, TimeUnit.SECONDS) shouldEqual "completed"
+      runningCompletions.get() shouldEqual 1
+      queuedExecutions.get() shouldEqual 1
+      KustoWriter.seedCloudInfoCache(
+        "https://post-cancellation-peer.example",
         CloudInfo.DEFAULT_CLOUD,
-        timeoutMillis = 500,
+        timeoutMillis = 2000,
         seed = queuedSeed)
-      (System.nanoTime() - secondStarted) / 1000000 should be < 5000L
-      secondError.getMessage should include("Timed out seeding cluster metadata cache")
-      queuedExecutions.get() shouldEqual 0
+      queuedExecutions.get() shouldEqual 2
     } finally {
-      releaseSeed.countDown()
+      releaseRunningSeed.countDown()
+      callers.shutdownNow()
+      callers.awaitTermination(5, TimeUnit.SECONDS)
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <properties>
-        <revision>5.3.5</revision>
+        <revision>5.3.6</revision>
         <!-- Spark dependencies -->
         <scala.version.major>2.12</scala.version.major>
         <scalafmt.plugin.version>1.1.1640084764.9f463a9</scalafmt.plugin.version>


### PR DESCRIPTION
## Problem

Queued and Transactional writes could stall indefinitely when Kusto SDK 5.1.1 performed repeated executor-side `CloudInfo` metadata requests under a JVM-wide lock. A single non-responsive request could block every Spark executor slot.

## Fix

- Retrieve ingestion metadata once on the driver with a 40-second caller deadline.
- Perform metadata preflight before Kusto resource mutations or Spark partition execution.
- Pass the resulting `CloudInfo` to executors.
- Seed each executor cache through the same bounded helper before evaluating the lazy queued-ingestion client.
- Discover the runtime cache API reflectively, supporting both `(String, CloudInfo)` and `(String, Mono<CloudInfo>)` without a direct cache-method or Reactor descriptor in `KustoWriter` bytecode.
- Preserve existing Streaming behavior, SDK exception classification, and the five-field `KustoWriteResource` shape.


## Validation

- Java 8 focused tests: **17/17 passed**.
- Clean shaded package: **SUCCESS**.
- Databricks validation passed all 19 mandatory gates and both optional write gates.

## Known limitation

The caller deadline does not terminate SDK 5.1.1’s underlying Apache socket read. A true metadata blackhole can leave that JVM’s SDK cache monitor/helper poisoned, so later callers fail at their own deadlines and the driver must be restarted.

This hotfix prevents Spark executor-slot starvation; it does not make the affected JVM self-healing.

The private Synapse wrapper/VHD must also verify that driver and executors load the same `CloudInfo` class version before production rollout.

## Scope

Limited to the executor-liveness mitigation. It does not include the separate queue-timeout unit correction, an SDK upgrade, or unrelated dependency changes.

---

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Prevent Queued and Transactional writes from indefinitely consuming Spark executor slots when Kusto metadata retrieval or cache insertion stalls.