### PR TITLE
chore: prepare Spark 4 release 7.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.1.3] - 2026-09-08
+
+### Changed
+- None
+
+### Added
+- Opt-in Data Management export storage discovery for distributed reads, supporting Fabric Private Link while preserving existing read and ingestion behavior by default (#509)
+
+### Fixed
+- Retry export storage discovery promptly after transient API failures instead of caching legacy fallback for the full refresh interval (#509)
+- Mask Azure access tokens in GitHub Actions build and release logs (#504)
+
 ## [7.1.2] - 2026-07-29
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.2</revision>
+        <revision>7.1.3</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.3.6</azure.bom.version>


### PR DESCRIPTION
#### Pull Request Description

Prepare the Spark 4 / Scala 2.13 release following SKILL.md. Bump the root revision from 7.1.2 to 7.1.3 and record changes since v4.0_7.1.2. Includes the already merged #509 and #504; no Spark/Scala/SDK dependency changes or read-option documentation changes.

Release tag after approval, successful CI, and squash merge: `v4.0_7.1.3`. This PR does not create or push tags.

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- Opt-in Data Management export storage discovery for distributed reads.

**Fixes:**
- Prompt rediscovery after transient API failures while preserving default-off legacy behavior.
- Mask Azure access tokens in build and release workflow logs.

Validation: Maven reactor validate and diff checks passed; implementation CI passed on #509. Full PR CI must pass before merge.