### PR TITLE
feat: backport export storage discovery and prepare Spark 3 release 7.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: "Run az commands"
         run: |
               access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+              echo "::add-mask::$access_token"
               echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         timeout-minutes: 40
@@ -50,7 +51,7 @@ jobs:
           ingestStorageUrl: ${{ secrets.INGEST_STORAGE_URL }}
           ingestStorageContainer: ${{ secrets.INGEST_STORAGE_CONTAINER }}
         run: |
-          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}} -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
+          mvn clean verify -B -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken="$ACCESS_TOKEN" -DingestStorageUrl=${{secrets.INGEST_STORAGE_URL}} -DingestStorageContainer=${{secrets.INGEST_STORAGE_CONTAINER}}
           
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
       - name: "Run az commands"
         run: |
           access_token=$(az account get-access-token --resource=${{ secrets.APP_ID }} --scope=${{ secrets.CLUSTER }}/.default --query accessToken -o tsv)
+          echo "::add-mask::$access_token"
           echo "ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
       - name: Run the Maven verify phase
         env:
@@ -63,7 +64,7 @@ jobs:
           accessToken: ${{env.ACCESS_TOKEN}}
           storageAccountUrl: ${{ secrets.STORAGE_CONTAINER_URL }}
         run: |
-          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken=${{env.ACCESS_TOKEN}}
+          mvn clean verify -DkustoAadAppId=${{ secrets.APP_ID }} -DkustoAadAuthorityID=${{ secrets.TENANT_ID }} -DkustoDatabase=${{ secrets.DATABASE }} -DkustoCluster=${{ secrets.CLUSTER }} -DaccessToken="$ACCESS_TOKEN"
       - name: Get versions
         id: get_version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Tags are created as `v4.0_{version}` (Spark 4 / master) and `v3.0_{version}` (Sp
 ### Fixed
 - None
 
+## [7.1.3] - 2026-09-08
+
+### Changed
+- None
+
+### Added
+- Opt-in Data Management export storage discovery for distributed reads, supporting Fabric Private Link while preserving existing read and ingestion behavior by default (#509)
+
+### Fixed
+- Retry export storage discovery promptly after transient API failures instead of caching legacy fallback for the full refresh interval (#509)
+- Mask Azure access tokens in GitHub Actions build and release logs (#504)
+
 ## [7.1.2] - 2026-07-29
 
 ### Changed

--- a/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/common/KustoOptions.scala
@@ -107,6 +107,9 @@ private[kusto] object KustoDebugOptions {
   // Default: 'true'
   val KUSTO_DBG_BLOB_COMPRESS_ON_EXPORT: String = newOption("dbgBlobCompressOnExport")
 
+  // Internal rollout switch. Public connector behavior must remain disabled by default.
+  val KUSTO_ENABLE_EXPORT_STORAGE_API: String = newOption("enableExportStorageApi")
+
   // Partitioning parameters, CURRENTLY NOT USED
   // CURRENTLY NOT USED
   val KUSTO_READ_PARTITION_MODE: String = newOption("partitionMode")

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoReader.scala
@@ -56,7 +56,8 @@ private[kusto] case class KustoReadOptions(
     distributedReadModeTransientCacheEnabled: Boolean = false,
     queryFilterPushDown: Option[Boolean],
     additionalExportOptions: Map[String, String] = Map.empty,
-    storageProtocol: Option[String] = None)
+    storageProtocol: Option[String] = None,
+    enableExportStorageApi: Boolean = false)
 
 private[kusto] case class PartitionOptions(
     amount: Int,
@@ -66,7 +67,8 @@ private[kusto] case class PartitionOptions(
 private[kusto] case class DistributedReadModeTransientCacheKey(
     query: String,
     kustoCoordinates: KustoCoordinates,
-    authentication: KustoAuthentication)
+    authentication: KustoAuthentication,
+    enableExportStorageApi: Boolean)
 
 object KustoReader {
   private val className = this.getClass.getSimpleName
@@ -144,7 +146,8 @@ object KustoReader {
       val key = DistributedReadModeTransientCacheKey(
         request.query,
         request.kustoCoordinates,
-        request.authentication)
+        request.authentication,
+        options.enableExportStorageApi)
       if (distributedReadModeTransientCache.contains(key)) {
         KDSU.logInfo(
           className,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoRelation.scala
@@ -63,7 +63,8 @@ private[kusto] case class KustoRelation(
       kustoCoordinates.clusterUrl,
       authentication,
       kustoCoordinates.ingestionUrl,
-      kustoCoordinates.clusterAlias)
+      kustoCoordinates.clusterAlias,
+      readOptions.enableExportStorageApi)
     val isUserOptionForceSingleMode = readOptions.readMode.contains(ReadMode.ForceSingleMode)
     val (useSingleMode, estimatedRecordCount) = readOptions.readMode match {
       // if the user provides a specific option , this is to be used no matter what
@@ -209,7 +210,8 @@ private[kusto] case class KustoRelation(
         kustoCoordinates.clusterUrl,
         authentication,
         kustoCoordinates.ingestionUrl,
-        kustoCoordinates.clusterAlias),
+        kustoCoordinates.clusterAlias,
+        readOptions.enableExportStorageApi),
       clientRequestProperties)
   }
 

--- a/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/datasource/KustoSourceOptions.scala
@@ -32,6 +32,11 @@ object KustoSourceOptions extends KustoOptions {
   //     (Fabric notebooks). The caller must have at least Workspace Contributor / item-level Write on the
   //     target Lakehouse Files path. Useful with DEP / OAP environments where Kusto-managed export blobs
   //     are unreachable from executors.
+  //     Private Link: the global `onelake.dfs.fabric.microsoft.com` host shown above resolves to a PUBLIC
+  //     address and is NOT reachable from a Private Link enabled workspace. There, use the
+  //     workspace-specific host the service itself returns, of the form
+  //     `<workspaceIdNoDashes>.z<nn>.<...>onelake.<...>` - note it carries NO `.dfs.` label, and the
+  //     `.dfs.`-bearing variant of that host does not resolve at all. Both forms are accepted here.
   //   The storage kind is determined solely by which field is populated: an entry with `oneLakeUrl`
   //   is treated as OneLake, otherwise it is treated as Azure blob/ADLS2.
   val KUSTO_TRANSIENT_STORAGE: String = newOption("transientStorage")

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/ContainerProvider.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/ContainerProvider.scala
@@ -13,6 +13,7 @@ import com.microsoft.azure.kusto.ingest.exceptions.{
   IngestionServiceException
 }
 import com.microsoft.kusto.spark.datasink.IngestionStorageParameters
+import com.microsoft.kusto.spark.datasource.{AuthMethod, TransientStorageCredentials}
 import com.microsoft.kusto.spark.exceptions.{ExceptionUtils, NoStorageContainersException}
 import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
 import io.github.resilience4j.core.IntervalFunction
@@ -20,8 +21,10 @@ import io.github.resilience4j.retry.{Retry, RetryConfig}
 import io.vavr.CheckedFunction0
 import org.apache.http.conn.HttpHostConnectException
 
-import java.time.{Clock, Instant, OffsetDateTime}
-import java.util.concurrent.ConcurrentHashMap
+import java.net.URI
+import java.security.InvalidParameterException
+import java.time.{Clock, Duration, Instant, OffsetDateTime}
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import java.util.function.Predicate
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.collection.mutable
@@ -31,10 +34,24 @@ class ContainerProvider(
     val client: ExtendedKustoClient,
     val clusterAlias: String,
     val command: String,
-    cacheExpirySeconds: Int = KustoConstants.StorageExpirySeconds) { // Refactored for tests with short cache
+    cacheExpirySeconds: Int =
+      KustoConstants.StorageExpirySeconds, // Refactored for tests with short cache
+    maybeExportStorageClient: Option[DmExportStorageClient] = None) {
+
+  def this(
+      client: ExtendedKustoClient,
+      clusterAlias: String,
+      command: String,
+      cacheExpirySeconds: Int) =
+    this(client, clusterAlias, command, cacheExpirySeconds, None)
+
   private var roundRobinIdx = 0
   private var storageUris: Seq[ContainerAndSas] = Seq.empty
   private var lastRefresh: Instant = Instant.now(Clock.systemUTC())
+
+  // Only opt-in export discovery uses service-driven expiry and serialized refreshes.
+  private var exportStorageExpiresAtNanos = 0L
+  private val exportStorageRefreshLock = new Object
   private val className = this.getClass.getSimpleName
   private val maxCommandsRetryAttempts = 8
   private val retryConfigExportContainers = buildRetryConfig((e: Throwable) =>
@@ -96,39 +113,28 @@ class ContainerProvider(
     }
   }
 
-  def getExportContainers: Seq[ContainerAndSas] = {
-    val now = Instant.now(Clock.systemUTC())
-    val secondsElapsed =
-      now.getEpochSecond - lastRefresh.getEpochSecond // get the seconds between now and last refresh
-    if (storageUris.isEmpty || secondsElapsed > cacheExpirySeconds) {
-      refresh(true)
-    }
-    storageUris
+  def getExportContainers: Seq[ContainerAndSas] = maybeExportStorageClient match {
+    case Some(exportStorageClient) =>
+      exportStorageRefreshLock.synchronized {
+        if (storageUris.isEmpty || exportStorageExpiresAtNanos == 0L ||
+          System.nanoTime() - exportStorageExpiresAtNanos >= 0) {
+          refreshExportStorage(exportStorageClient)
+        }
+        storageUris
+      }
+    case None =>
+      val now = Instant.now(Clock.systemUTC())
+      val secondsElapsed =
+        now.getEpochSecond - lastRefresh.getEpochSecond // get the seconds between now and last refresh
+      if (storageUris.isEmpty || secondsElapsed > cacheExpirySeconds) {
+        refresh(true)
+      }
+      storageUris
   }
 
   private def refresh(exportContainer: Boolean = false): ContainerAndSas = {
     if (exportContainer) {
-      Try(
-        client.executeDM(
-          command,
-          None,
-          "refreshContainers",
-          Some(retryConfigExportContainers))) match {
-        case Success(res) =>
-          val storage = res.getPrimaryResults.getData.asScala.map(row => {
-            val parts = row.get(0).toString.split('?')
-            ContainerAndSas(parts(0), s"?${parts(1)}")
-          })
-          processContainerResults(storage)
-        case Failure(exception) =>
-          KDSU.reportExceptionAndThrow(
-            className,
-            exception,
-            "Error querying for create export containers",
-            clusterAlias,
-            shouldNotThrow = storageUris.nonEmpty)
-          storageUris(roundRobinIdx)
-      }
+      refreshExportContainersViaCommand()
     } else {
       val retryExecute: CheckedFunction0[ContainerAndSas] = Retry.decorateCheckedSupplier(
         Retry.of("refresh ingestion resources", retryConfigIngestionRefresh),
@@ -150,6 +156,88 @@ class ContainerProvider(
           }
         })
       retryExecute.apply()
+    }
+  }
+
+  private def refreshExportStorage(
+      exportStorageClient: DmExportStorageClient): ContainerAndSas = {
+    val resolution = exportStorageClient.resolveExportStorage
+    resolution.targets match {
+      case Some(targets) if targets.lakeFolders.nonEmpty =>
+        val validFolders = targets.lakeFolders.flatMap(ContainerProvider.parseValidApiLakeFolder)
+        logRejectedTargets(targets.lakeFolders.size - validFolders.size, "OneLake folder")
+        processApiTargetsOrFallback(
+          validFolders,
+          "Rest/Lake",
+          "OneLake folder",
+          resolution.refreshInterval)
+      case Some(targets) if targets.containers.nonEmpty =>
+        val validContainers =
+          targets.containers.flatMap(ContainerProvider.parseValidApiContainerWithSas)
+        logRejectedTargets(targets.containers.size - validContainers.size, "blob container")
+        processApiTargetsOrFallback(
+          validContainers,
+          "Rest/Storage",
+          "blob container",
+          resolution.refreshInterval)
+      case _ => refreshExportContainersViaCommand(Some(resolution.refreshInterval))
+    }
+  }
+
+  private def logRejectedTargets(rejectedCount: Int, targetType: String): Unit =
+    if (rejectedCount > 0) {
+      KDSU.logWarn(
+        className,
+        s"The export storage API of 'ingest-$clusterAlias' returned $rejectedCount invalid " +
+          s"$targetType target(s); those targets were ignored.")
+    }
+
+  private def processApiTargetsOrFallback(
+      targets: Seq[ContainerAndSas],
+      mode: String,
+      targetType: String,
+      refreshInterval: Duration): ContainerAndSas =
+    if (targets.nonEmpty) {
+      KDSU.logInfo(
+        className,
+        s"Using export storage mode $mode for 'ingest-$clusterAlias' with " +
+          s"${targets.size} validated $targetType target(s).")
+      val result = processContainerResults(targets.toBuffer)
+      exportStorageExpiresAtNanos = System.nanoTime() + refreshInterval.toNanos
+      result
+    } else {
+      KDSU.logWarn(
+        className,
+        s"Export storage mode $mode returned no valid $targetType targets for " +
+          s"'ingest-$clusterAlias'. Falling back to the export containers command.")
+      refreshExportContainersViaCommand(Some(refreshInterval))
+    }
+
+  private def refreshExportContainersViaCommand(
+      apiRefreshInterval: Option[Duration] = None): ContainerAndSas = {
+    Try(
+      client
+        .executeDM(command, None, "refreshContainers", Some(retryConfigExportContainers))) match {
+      case Success(res) =>
+        val storage = res.getPrimaryResults.getData.asScala.map(row => {
+          val parts = row.get(0).toString.split('?')
+          ContainerAndSas(parts(0), s"?${parts(1)}")
+        })
+        val result = processContainerResults(storage)
+        apiRefreshInterval.foreach(interval =>
+          exportStorageExpiresAtNanos = System.nanoTime() + interval.toNanos)
+        result
+      case Failure(exception) =>
+        KDSU.reportExceptionAndThrow(
+          className,
+          exception,
+          "Error querying for create export containers",
+          clusterAlias,
+          shouldNotThrow = storageUris.nonEmpty)
+        apiRefreshInterval.foreach(_ =>
+          exportStorageExpiresAtNanos =
+            System.nanoTime() + ContainerProvider.RefreshFailureBackoffNanos)
+        storageUris(roundRobinIdx)
     }
   }
 
@@ -242,7 +330,60 @@ class ContainerProvider(
 }
 
 object ContainerProvider {
+  private val DnsLabel = """[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"""
+  private val OneLakeLabel = s"(?:$DnsLabel-)?onelake(?:-$DnsLabel)?"
+  private val TrustedOneLakeHostPatterns = Seq(
+    s"(?i)^$OneLakeLabel\\.dfs\\.fabric\\.microsoft\\.com$$".r,
+    s"(?i)^(?:$DnsLabel\\.)+$OneLakeLabel\\.fabric\\.microsoft\\.com$$".r,
+    s"(?i)^$OneLakeLabel\\.dfs\\.pbidedicated\\.windows-int\\.net$$".r)
+
   private val className = this.getClass.getSimpleName
+  private val RefreshFailureBackoffNanos = TimeUnit.SECONDS.toNanos(5)
+
+  /**
+   * Splits a container URL of the form `https://account.blob.suffix/container?sv=...` into its
+   * URL and SAS parts. URLs without a query string yield an empty SAS rather than failing.
+   */
+  private[kusto] def parseContainerWithSas(containerUrlWithSas: String): ContainerAndSas = {
+    val sasSeparatorIdx = containerUrlWithSas.indexOf('?')
+    if (sasSeparatorIdx < 0) {
+      ContainerAndSas(containerUrlWithSas, KustoConstants.EmptyString)
+    } else {
+      ContainerAndSas(
+        containerUrlWithSas.substring(0, sasSeparatorIdx),
+        containerUrlWithSas.substring(sasSeparatorIdx))
+    }
+  }
+
+  private[kusto] def parseValidApiContainerWithSas(
+      containerUrlWithSas: String): Option[ContainerAndSas] =
+    Try {
+      val credentials = new TransientStorageCredentials(containerUrlWithSas)
+      credentials.validate()
+      if (credentials.authMethod != AuthMethod.Sas) {
+        throw new InvalidParameterException(
+          "The API-provided blob container must use SAS authentication")
+      }
+      parseContainerWithSas(containerUrlWithSas)
+    }.toOption
+
+  private[kusto] def parseValidApiLakeFolder(path: String): Option[ContainerAndSas] =
+    Try {
+      if (!isSupportedApiOneLakeHost(path)) {
+        throw new InvalidParameterException(
+          "The API-provided OneLake URL does not use a supported OneLake host")
+      }
+      val target = new OneLakeContainerAndSas(path)
+      ExtendedKustoClient.toTransientStorageCredentials(target)
+      target
+    }.toOption
+
+  private[kusto] def isSupportedApiOneLakeHost(path: String): Boolean =
+    Try(new URI(path)).toOption
+      .filter(uri => Option(uri.getScheme).exists(_.equalsIgnoreCase("https")))
+      .flatMap(uri => Option(uri.getHost))
+      .exists(host => TrustedOneLakeHostPatterns.exists(_.pattern.matcher(host).matches()))
+
   protected[kusto] def getUserDelegatedSas(
       cacheExpirySeconds: Long,
       listPermissions: Boolean,

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/DmExportStorageClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/DmExportStorageClient.scala
@@ -27,7 +27,7 @@ import java.time.format.DateTimeFormatter
 import java.time.{Duration, Instant, ZonedDateTime}
 import java.util.UUID
 import java.util.zip.{GZIPInputStream, InflaterInputStream}
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 /** ExportStorage targets: SAS blob containers and OneLake folders. */

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/DmExportStorageClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/DmExportStorageClient.scala
@@ -1,0 +1,694 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.azure.core.http.{HttpClient, HttpHeaderName, HttpMethod, HttpRequest, HttpResponse}
+import com.azure.core.util.Context
+import com.fasterxml.jackson.databind.JsonNode
+import com.microsoft.azure.kusto.data.{StringUtils, UriUtils, Utils}
+import com.microsoft.azure.kusto.data.auth.endpoints.KustoTrustedEndpoints
+import com.microsoft.azure.kusto.data.exceptions.KustoClientInvalidConnectionStringException
+import com.microsoft.azure.kusto.data.auth.{
+  ConnectionStringBuilder,
+  TokenProviderBase,
+  TokenProviderFactory
+}
+import com.microsoft.azure.kusto.data.format.CslTimespanFormat
+import com.microsoft.azure.kusto.data.http.{HttpRequestBuilder, HttpStatus}
+import com.microsoft.kusto.spark.utils.{KustoDataSourceUtils => KDSU}
+import io.github.resilience4j.core.IntervalFunction
+import io.github.resilience4j.retry.RetryConfig
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.format.DateTimeFormatter
+import java.time.{Duration, Instant, ZonedDateTime}
+import java.util.UUID
+import java.util.zip.{GZIPInputStream, InflaterInputStream}
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+/** ExportStorage targets: SAS blob containers and OneLake folders. */
+private[kusto] final case class ExportStorageTargets(
+    containers: Seq[String],
+    lakeFolders: Seq[String]) {
+  def isEmpty: Boolean = containers.isEmpty && lakeFolders.isEmpty
+}
+
+private[kusto] sealed trait ExportStorageMode {
+  def select(targets: ExportStorageTargets): ExportStorageTargets
+}
+
+private[kusto] object ExportStorageMode {
+  case object LakeFolders extends ExportStorageMode {
+    override def select(targets: ExportStorageTargets): ExportStorageTargets =
+      targets.copy(containers = Seq.empty)
+  }
+
+  case object BlobContainers extends ExportStorageMode {
+    override def select(targets: ExportStorageTargets): ExportStorageTargets =
+      targets.copy(lakeFolders = Seq.empty)
+  }
+
+  case object LegacyCommand extends ExportStorageMode {
+    override def select(targets: ExportStorageTargets): ExportStorageTargets =
+      ExportStorageTargets(Seq.empty, Seq.empty)
+  }
+}
+
+private[kusto] final case class ExportStorageDecision(
+    mode: ExportStorageMode,
+    refreshInterval: Duration)
+
+private[kusto] final case class ExportStorageResolution(
+    targets: Option[ExportStorageTargets],
+    refreshInterval: Duration)
+
+/** A value cached until its monotonic deadline. */
+private[kusto] final case class Memo[A](value: A, expiresAtNanos: Long) {
+  def unexpired: Option[A] =
+    if (System.nanoTime() - expiresAtNanos < 0) Some(value) else None
+}
+
+private[kusto] object Memo {
+  def of[A](value: A, ttl: Duration): Memo[A] = Memo(value, System.nanoTime() + ttl.toNanos)
+}
+
+/** Configuration fields used to select the export-storage path. */
+private[kusto] final case class IngestionConfiguration(
+    lakeFolders: Seq[String],
+    preferredUploadMethod: Option[String],
+    preferredIngestionMethod: Option[String],
+    refreshInterval: Option[Duration] = None,
+    invalidRefreshInterval: Boolean = false) {
+
+  def exportStorageMode: ExportStorageMode =
+    (preferredIngestionMethod, preferredUploadMethod) match {
+      case (Some(ingestion), Some(upload))
+          if ingestion.equalsIgnoreCase(IngestionConfiguration.IngestionMethodRest) &&
+            upload.equalsIgnoreCase(IngestionConfiguration.UploadMethodLake) =>
+        ExportStorageMode.LakeFolders
+      case (Some(ingestion), Some(upload))
+          if ingestion.equalsIgnoreCase(IngestionConfiguration.IngestionMethodRest) &&
+            upload.equalsIgnoreCase(IngestionConfiguration.UploadMethodStorage) =>
+        ExportStorageMode.BlobContainers
+      // Missing, unknown, and all non-Rest combinations retain the legacy path.
+      case _ => ExportStorageMode.LegacyCommand
+    }
+}
+
+private[kusto] object IngestionConfiguration {
+  val UploadMethodLake = "Lake"
+  val UploadMethodStorage = "Storage"
+  val IngestionMethodRest = "Rest"
+}
+
+/** Resolves export storage through the Data Management REST APIs. */
+private[kusto] class DmExportStorageClient(
+    val ingestKcsb: ConnectionStringBuilder,
+    val clusterAlias: String) {
+
+  private val className = this.getClass.getSimpleName
+  private val objectMapper = Utils.getObjectMapper
+
+  /** Avoids repeated export-storage 404s within one refresh window. */
+  @volatile private var endpointUnsupported: Option[Memo[Duration]] = None
+
+  private def unsupportedRefreshInterval: Option[Duration] =
+    endpointUnsupported.flatMap(_.unexpired)
+
+  /** Caches the selected mode for the service-provided refresh interval. */
+  @volatile private var exportStorageModeState: Option[Memo[ExportStorageDecision]] = None
+  private val exportStorageModeLock = new Object
+
+  protected lazy val httpClient: HttpClient = HttpClient.createDefault()
+
+  private lazy val maybeTokenProvider: Option[TokenProviderBase] =
+    Try(Option(TokenProviderFactory.createTokenProvider(ingestKcsb, httpClient))) match {
+      case Success(provider) => provider
+      case Failure(exception) =>
+        KDSU.logWarn(
+          className,
+          s"Could not create a token provider for the export storage API on '$clusterAlias': " +
+            s"${exception.getMessage}. Falling back to the export containers command.")
+        None
+    }
+
+  private lazy val normalizedClusterUrl: String =
+    UriUtils.createClusterURLFrom(ingestKcsb.getClusterUrl.trim)
+
+  private lazy val exportStorageUrl: String =
+    UriUtils.appendPathToUri(normalizedClusterUrl, KustoConstants.ExportStorageRestApiPath)
+
+  private lazy val ingestionConfigurationUrl: String =
+    UriUtils.appendPathToUri(
+      normalizedClusterUrl,
+      KustoConstants.IngestionConfigurationRestApiPath)
+
+  private val retryConfig = RetryConfig.custom
+    .maxAttempts(DmExportStorageClient.MaxRetryAttempts)
+    .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(
+      ExtendedKustoClient.BaseIntervalMs,
+      IntervalFunction.DEFAULT_MULTIPLIER,
+      IntervalFunction.DEFAULT_RANDOMIZATION_FACTOR,
+      ExtendedKustoClient.MaxRetryIntervalMs))
+    .retryOnException((e: Throwable) =>
+      !e.isInstanceOf[PermanentExportStorageApiException] &&
+        !e.isInstanceOf[InterruptedException])
+    .build
+
+  private val GateMaxAttempts = 2
+  private val gateRetryConfig = RetryConfig.from(retryConfig).maxAttempts(GateMaxAttempts).build
+
+  /** Returns selected API targets, or `None` to use `.show export containers`. */
+  def getExportStorage: Option[ExportStorageTargets] = resolveExportStorage.targets
+
+  /** Resolves targets and the interval after which a new resolution is required. */
+  private[kusto] def resolveExportStorage: ExportStorageResolution = {
+    unsupportedRefreshInterval match {
+      case Some(refreshInterval) =>
+        ExportStorageResolution(None, refreshInterval)
+      case None if maybeTokenProvider.isEmpty =>
+        ExportStorageResolution(None, DmExportStorageClient.DefaultRefreshInterval)
+      case None =>
+        resolveSupportedExportStorage()
+    }
+  }
+
+  private def resolveSupportedExportStorage(): ExportStorageResolution = {
+    val decision = exportStorageDecision
+    if (decision.mode == ExportStorageMode.LegacyCommand) {
+      ExportStorageResolution(None, decision.refreshInterval)
+    } else {
+      Try(
+        preserveInterrupt(
+          KDSU.retryApplyFunction(
+            attempt => fetchExportStorage(attempt),
+            retryConfig,
+            "Get export storage from DM with retries"))) match {
+        case Success(targets) =>
+          val selected = decision.mode.select(targets)
+          if (!selected.isEmpty) {
+            KDSU.logInfo(
+              className,
+              s"Selected ${selected.containers.size} export container(s) and " +
+                s"${selected.lakeFolders.size} lake folder(s) from the export storage API of " +
+                s"'ingest-$clusterAlias' using mode ${decision.mode}")
+            ExportStorageResolution(Some(selected), decision.refreshInterval)
+          } else {
+            KDSU.logWarn(
+              className,
+              s"The export storage API of 'ingest-$clusterAlias' returned no targets for " +
+                s"mode ${decision.mode}. Falling back to the export containers command.")
+            ExportStorageResolution(None, decision.refreshInterval)
+          }
+        case Failure(_: UnsupportedExportStorageApiException) =>
+          endpointUnsupported = Some(Memo.of(decision.refreshInterval, decision.refreshInterval))
+          KDSU.logInfo(
+            className,
+            s"The export storage API is not available on 'ingest-$clusterAlias' (HTTP 404). " +
+              "Using the export containers command for this refresh window.")
+          ExportStorageResolution(None, decision.refreshInterval)
+        case Failure(exception: UntrustedEndpointException) =>
+          throw exception
+        case Failure(exception: PermanentExportStorageApiException) =>
+          KDSU.logWarn(
+            className,
+            s"Cannot use the export storage API of 'ingest-$clusterAlias': " +
+              s"${exception.getMessage}. Using the export containers command for this refresh window.")
+          ExportStorageResolution(None, decision.refreshInterval)
+        case Failure(exception) =>
+          KDSU.logWarn(
+            className,
+            s"Failed to get export storage from the API of 'ingest-$clusterAlias': " +
+              s"${exception.getMessage}. Falling back to the export containers command and " +
+              s"retrying discovery after ${DmExportStorageClient.TransientFailureRefreshInterval}.")
+          ExportStorageResolution(None, DmExportStorageClient.TransientFailureRefreshInterval)
+      }
+    }
+  }
+
+  private def preserveInterrupt[T](operation: => T): T =
+    try {
+      operation
+    } catch {
+      case interrupted: InterruptedException =>
+        Thread.currentThread().interrupt()
+        throw interrupted
+    }
+
+  /** Sends bearer tokens only to HTTPS endpoints trusted by the Kusto SDK. */
+  private def validateEndpoint(): Unit = {
+    val clusterUrl = ingestKcsb.getClusterUrl
+    if (!clusterUrl.toLowerCase.startsWith("https://")) {
+      throw new UntrustedEndpointException(
+        s"Refusing to send a bearer token over a non-https endpoint: $clusterUrl")
+    }
+    Try(KustoTrustedEndpoints.validateTrustedEndpoint(clusterUrl)) match {
+      case Failure(rejection: KustoClientInvalidConnectionStringException) =>
+        throw new UntrustedEndpointException(
+          s"Refusing to send a bearer token to '$clusterUrl': the Kusto SDK does not recognise " +
+            s"it as a trusted endpoint (${rejection.getMessage}). The export containers command " +
+            "applies the same check to the same url, so it will report the same problem.")
+      case Failure(undecided) =>
+        throw new PermanentExportStorageApiException(
+          s"Could not establish whether '$clusterUrl' is a trusted Kusto endpoint " +
+            s"(${undecided.getMessage}). Not sending a token until it is established.")
+      case _ =>
+    }
+  }
+
+  /** Bounds both compressed and decoded response bodies. */
+  private def readBody(response: HttpResponse, api: String): String = {
+    val declared =
+      Option(response.getHeaderValue(HttpHeaderName.CONTENT_LENGTH)).flatMap(value =>
+        Try(value.toLong).toOption)
+    declared.filter(_ > DmExportStorageClient.MaxResponseBodyBytes).foreach { length =>
+      throw new PermanentExportStorageApiException(
+        s"$api returned a $length byte body, above the " +
+          s"${DmExportStorageClient.MaxResponseBodyBytes} byte limit. Refusing to buffer it.")
+    }
+    val encoded = readLimited(response.getBody.toIterable.asScala, api)
+    val contentEncoding =
+      Option(response.getHeaderValue(HttpHeaderName.CONTENT_ENCODING)).map(_.toLowerCase)
+    val decoded = contentEncoding match {
+      case Some(value) if value.contains("gzip") =>
+        new GZIPInputStream(new ByteArrayInputStream(encoded))
+      case Some(value) if value.contains("deflate") =>
+        new InflaterInputStream(new ByteArrayInputStream(encoded))
+      case _ => new ByteArrayInputStream(encoded)
+    }
+    try {
+      new String(readLimited(decoded, api), StandardCharsets.UTF_8)
+    } finally {
+      decoded.close()
+    }
+  }
+
+  private def readLimited(input: InputStream, api: String): Array[Byte] = {
+    val output = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](8192)
+    var total = 0L
+    var count = input.read(buffer)
+    while (count >= 0) {
+      if (count > 0) {
+        total += count
+        ensureWithinBodyLimit(total, api)
+        output.write(buffer, 0, count)
+      }
+      count = input.read(buffer)
+    }
+    output.toByteArray
+  }
+
+  private def readLimited(chunks: Iterable[ByteBuffer], api: String): Array[Byte] = {
+    val output = new ByteArrayOutputStream()
+    var total = 0L
+    chunks.foreach { buffer =>
+      val count = buffer.remaining()
+      total += count
+      ensureWithinBodyLimit(total, api)
+      val bytes = new Array[Byte](count)
+      buffer.get(bytes)
+      output.write(bytes)
+    }
+    output.toByteArray
+  }
+
+  private def ensureWithinBodyLimit(total: Long, api: String): Unit =
+    if (total > DmExportStorageClient.MaxResponseBodyBytes) {
+      throw new PermanentExportStorageApiException(
+        s"$api exceeded the ${DmExportStorageClient.MaxResponseBodyBytes} byte body limit.")
+    }
+
+  private def honourRetryAfter(
+      response: HttpResponse,
+      api: String,
+      attempt: Int,
+      maxAttempts: Int): Unit =
+    if (attempt >= maxAttempts) {
+      ()
+    } else
+      DmExportStorageClient
+        .retryAfterMillis(Option(response.getHeaders.getValue("Retry-After")))
+        .foreach { waitMs =>
+          KDSU.logInfo(
+            className,
+            s"$api throttled 'ingest-$clusterAlias'; honouring Retry-After of ${waitMs}ms " +
+              "before the next attempt.")
+          try {
+            Thread.sleep(waitMs)
+          } catch {
+            case interrupted: InterruptedException =>
+              Thread.currentThread().interrupt()
+              throw interrupted
+          }
+        }
+
+  private def buildJsonGetRequest(
+      url: String,
+      clientRequestId: String,
+      operation: String): HttpRequest = {
+    val tokenProvider = maybeTokenProvider.getOrElse(
+      throw new PermanentExportStorageApiException(
+        s"No token provider is available for the $operation"))
+    val token = tokenProvider.acquireAccessToken().block()
+    if (StringUtils.isBlank(token)) {
+      throw new RuntimeException(s"Acquired an empty access token for the $operation")
+    }
+    new HttpRequestBuilder(HttpMethod.GET, url)
+      .withAuthorization(s"Bearer $token")
+      .withHeaders(
+        Map(
+          "x-ms-client-request-id" -> clientRequestId,
+          "x-ms-client-version" -> KustoConstants.ClientName).asJava)
+      .build()
+  }
+
+  /** Returns the cached configuration decision, using legacy mode for inconclusive calls. */
+  private def exportStorageDecision: ExportStorageDecision =
+    exportStorageModeState.flatMap(_.unexpired) match {
+      case Some(known) => known
+      case None =>
+        exportStorageModeLock.synchronized {
+          exportStorageModeState.flatMap(_.unexpired).getOrElse {
+            detectExportStorageDecision() match {
+              case Some(detected) =>
+                exportStorageModeState = Some(Memo.of(detected, detected.refreshInterval))
+                detected
+              case None =>
+                ExportStorageDecision(
+                  ExportStorageMode.LegacyCommand,
+                  DmExportStorageClient.TransientFailureRefreshInterval)
+            }
+          }
+        }
+    }
+
+  private[kusto] def exportStorageMode: ExportStorageMode = exportStorageDecision.mode
+
+  /** Returns `None` when configuration discovery was inconclusive. */
+  protected def detectExportStorageDecision(): Option[ExportStorageDecision] = {
+    Try(
+      preserveInterrupt(
+        KDSU.retryApplyFunction(
+          attempt => fetchIngestionConfiguration(attempt),
+          gateRetryConfig,
+          "Get ingestion configuration from DM with retries"))) match {
+      case Success(configuration) =>
+        val mode = configuration.exportStorageMode
+        val refreshInterval =
+          DmExportStorageClient.effectiveRefreshInterval(configuration.refreshInterval)
+        val modeName = mode match {
+          case ExportStorageMode.LakeFolders => "Rest/Lake"
+          case ExportStorageMode.BlobContainers => "Rest/Storage"
+          case ExportStorageMode.LegacyCommand => "LegacyCommand"
+        }
+        if (configuration.invalidRefreshInterval) {
+          KDSU.logWarn(
+            className,
+            s"The ingestion configuration of 'ingest-$clusterAlias' returned an invalid " +
+              s"refreshInterval; using ${DmExportStorageClient.DefaultRefreshInterval}.")
+        }
+        configuration.refreshInterval.filter(_ != refreshInterval).foreach { serviceInterval =>
+          KDSU.logWarn(
+            className,
+            s"The ingestion configuration refreshInterval $serviceInterval for " +
+              s"'ingest-$clusterAlias' was bounded to $refreshInterval.")
+        }
+        KDSU.logInfo(
+          className,
+          s"Selected export storage mode $modeName for 'ingest-$clusterAlias': " +
+            s"preferredUploadMethod=" +
+            s"${configuration.preferredUploadMethod.getOrElse("<absent>")}, " +
+            s"preferredIngestionMethod=" +
+            s"${configuration.preferredIngestionMethod.getOrElse("<absent>")} " +
+            s"(${configuration.lakeFolders.size} configuration lake folder(s), ignored for " +
+            s"selection), refreshInterval=$refreshInterval.")
+        Some(ExportStorageDecision(mode, refreshInterval))
+      case Failure(_: UnsupportedExportStorageApiException) =>
+        KDSU.logInfo(
+          className,
+          s"The ingestion configuration API is not available on 'ingest-$clusterAlias' " +
+            "(HTTP 404). Using the export containers command for this refresh window.")
+        Some(
+          ExportStorageDecision(
+            ExportStorageMode.LegacyCommand,
+            DmExportStorageClient.DefaultRefreshInterval))
+      case Failure(exception: UntrustedEndpointException) =>
+        throw exception
+      case Failure(exception: PermanentExportStorageApiException) =>
+        KDSU.logWarn(
+          className,
+          s"Cannot use the ingestion configuration API of 'ingest-$clusterAlias': " +
+            s"${exception.getMessage}. Using the export containers command for this refresh window.")
+        Some(
+          ExportStorageDecision(
+            ExportStorageMode.LegacyCommand,
+            DmExportStorageClient.DefaultRefreshInterval))
+      case Failure(exception) =>
+        KDSU.logWarn(
+          className,
+          s"Could not read the ingestion configuration of 'ingest-$clusterAlias': " +
+            s"${exception.getMessage}. Falling back to the export containers command and " +
+            s"retrying discovery after ${DmExportStorageClient.TransientFailureRefreshInterval}.")
+        None
+    }
+  }
+
+  private def fetchIngestionConfiguration(attempt: Int): IngestionConfiguration = {
+    validateEndpoint()
+    val clientRequestId = s"KSPARK.getIngestionConfiguration;${UUID.randomUUID()}"
+    val request =
+      buildJsonGetRequest(
+        ingestionConfigurationUrl,
+        clientRequestId,
+        "ingestion configuration API")
+
+    KDSU.logDebug(
+      className,
+      s"Calling ingestion configuration API $ingestionConfigurationUrl, id: $clientRequestId")
+
+    val response = httpClient.sendSync(request, Context.NONE)
+    try {
+      val status = response.getStatusCode
+      val body = readBody(response, "Ingestion configuration API")
+      if (status == HttpStatus.NOT_FOUND) {
+        throw new UnsupportedExportStorageApiException(
+          s"$ingestionConfigurationUrl is not available on this cluster")
+      }
+      if (status != HttpStatus.OK) {
+        val message = s"Ingestion configuration API returned HTTP $status. Body: " +
+          DmExportStorageClient.redactSecrets(
+            body.take(DmExportStorageClient.MaxLoggedErrorBodyChars))
+        if (DmExportStorageClient.isAuthorizationFailure(status)) {
+          throw new ExportStorageAuthorizationException(message)
+        }
+        if (DmExportStorageClient.isPermanentFailure(status)) {
+          throw new PermanentExportStorageApiException(message)
+        }
+        honourRetryAfter(response, "Ingestion configuration API", attempt, GateMaxAttempts)
+        throw new RuntimeException(message)
+      }
+      Try(DmExportStorageClient.parseIngestionConfiguration(objectMapper.readTree(body))) match {
+        case Success(configuration) => configuration
+        case Failure(exception) =>
+          throw new RuntimeException(
+            s"Failed to parse the ingestion configuration API response, id: $clientRequestId, " +
+              s"${exception.getClass.getSimpleName}")
+      }
+    } finally {
+      response.close()
+    }
+  }
+
+  protected def fetchExportStorage(attempt: Int): ExportStorageTargets = {
+    validateEndpoint()
+
+    val clientRequestId = s"KSPARK.getExportStorage;${UUID.randomUUID()}"
+    val request = buildJsonGetRequest(exportStorageUrl, clientRequestId, "export storage API")
+
+    KDSU.logDebug(
+      className,
+      s"Calling export storage API $exportStorageUrl, id: $clientRequestId")
+
+    val response = httpClient.sendSync(request, Context.NONE)
+    try {
+      val status = response.getStatusCode
+      val body = readBody(response, "Export storage API")
+      if (status == HttpStatus.NOT_FOUND) {
+        throw new UnsupportedExportStorageApiException(
+          s"$exportStorageUrl is not available on this cluster")
+      }
+      if (status != HttpStatus.OK) {
+        val message = s"Export storage API returned HTTP $status. Body: " +
+          DmExportStorageClient.redactSecrets(
+            body.take(DmExportStorageClient.MaxLoggedErrorBodyChars))
+        if (DmExportStorageClient.isAuthorizationFailure(status)) {
+          throw new ExportStorageAuthorizationException(message)
+        }
+        if (DmExportStorageClient.isPermanentFailure(status)) {
+          throw new PermanentExportStorageApiException(message)
+        }
+        honourRetryAfter(
+          response,
+          "Export storage API",
+          attempt,
+          DmExportStorageClient.MaxRetryAttempts)
+        throw new RuntimeException(message)
+      }
+      Try(DmExportStorageClient.parseExportStorageResponse(objectMapper.readTree(body))) match {
+        case Success(targets) => targets
+        case Failure(exception) =>
+          throw new RuntimeException(
+            s"Failed to parse the export storage API response, id: $clientRequestId, " +
+              s"${exception.getClass.getSimpleName}")
+      }
+    } finally {
+      response.close()
+    }
+  }
+}
+
+private[kusto] class PermanentExportStorageApiException(message: String)
+    extends RuntimeException(message)
+
+private[kusto] class UnsupportedExportStorageApiException(message: String)
+    extends PermanentExportStorageApiException(message)
+
+private[kusto] class ExportStorageAuthorizationException(message: String)
+    extends PermanentExportStorageApiException(message)
+
+private[kusto] class UntrustedEndpointException(message: String)
+    extends PermanentExportStorageApiException(message)
+
+private[kusto] object DmExportStorageClient {
+  private val MaxRetryAttempts = 3
+  private[kusto] val DefaultRefreshInterval: Duration =
+    Duration.ofSeconds(KustoConstants.StorageExpirySeconds.toLong)
+  private[kusto] val TransientFailureRefreshInterval: Duration = Duration.ofSeconds(5)
+  private val MinimumRefreshInterval = Duration.ofMinutes(10)
+
+  private val MaxLoggedErrorBodyChars = 1024
+
+  private[kusto] val MaxResponseBodyBytes = 8L * 1024 * 1024
+  private val RequestTimeoutStatus = 408
+
+  private val MaxRetryAfterSeconds = 5L
+  private val QueryStringPattern = """\?[^\s"'<>]+""".r
+
+  private[kusto] def redactSecrets(text: String): String =
+    QueryStringPattern.replaceAllIn(text, "?<redacted>")
+  private val ClientErrorStatusRange = 400 until 500
+  private val RedirectStatusRange = 300 until 400
+
+  private[kusto] def isPermanentFailure(status: Int): Boolean =
+    RedirectStatusRange.contains(status) ||
+      (ClientErrorStatusRange.contains(status) &&
+        status != HttpStatus.TOO_MANY_REQS &&
+        status != RequestTimeoutStatus)
+
+  private[kusto] def isAuthorizationFailure(status: Int): Boolean =
+    status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN
+
+  private[kusto] def retryAfterMillis(
+      header: Option[String],
+      now: Instant = Instant.now()): Option[Long] =
+    header.map(_.trim).filter(_.nonEmpty).flatMap { value =>
+      Try(Math.multiplyExact(value.toLong, 1000L)).toOption
+        .orElse(
+          Try(
+            ZonedDateTime
+              .parse(value, DateTimeFormatter.RFC_1123_DATE_TIME)
+              .toInstant
+              .toEpochMilli - now.toEpochMilli).toOption)
+        .filter(_ > 0)
+        .map(waitMs => Math.min(waitMs, MaxRetryAfterSeconds * 1000L))
+    }
+
+  private[kusto] def effectiveRefreshInterval(refreshInterval: Option[Duration]): Duration =
+    refreshInterval match {
+      case Some(interval) if interval.compareTo(MinimumRefreshInterval) < 0 =>
+        MinimumRefreshInterval
+      case Some(interval) if interval.compareTo(DefaultRefreshInterval) > 0 =>
+        DefaultRefreshInterval
+      case Some(interval) => interval
+      case None => DefaultRefreshInterval
+    }
+
+  private[kusto] def parseExportStorageResponse(root: JsonNode): ExportStorageTargets = {
+    val exportStorage = field(root, "exportStorage")
+      .filter(_.isObject)
+      .getOrElse(throw new RuntimeException(
+        "Export storage API response does not contain an 'exportStorage' object"))
+    ExportStorageTargets(
+      containers = paths(exportStorage, "containers"),
+      lakeFolders = paths(exportStorage, "lakeFolders"))
+  }
+
+  private[kusto] def parseIngestionConfiguration(root: JsonNode): IngestionConfiguration = {
+    val containerSettings = field(root, "containerSettings")
+      .filter(_.isObject)
+      .getOrElse(throw new RuntimeException(
+        "Ingestion configuration API response does not contain a 'containerSettings' object"))
+    val (refreshInterval, invalidRefreshInterval) =
+      parseRefreshInterval(field(containerSettings, "refreshInterval"))
+    IngestionConfiguration(
+      lakeFolders = paths(containerSettings, "lakeFolders"),
+      preferredUploadMethod = text(containerSettings, "preferredUploadMethod"),
+      preferredIngestionMethod =
+        field(root, "ingestionSettings").flatMap(text(_, "preferredIngestionMethod")),
+      refreshInterval = refreshInterval,
+      invalidRefreshInterval = invalidRefreshInterval)
+  }
+
+  private def parseRefreshInterval(value: Option[JsonNode]): (Option[Duration], Boolean) =
+    value match {
+      case None => (None, false)
+      case Some(node) =>
+        val parsed = Try {
+          if (node.isIntegralNumber) {
+            Duration.ofSeconds(node.longValue())
+          } else if (node.isTextual) {
+            new CslTimespanFormat(node.asText()).getValue
+          } else {
+            null
+          }
+        }.toOption.flatMap(Option(_)).filter(interval => !interval.isZero && !interval.isNegative)
+        (parsed, parsed.isEmpty)
+    }
+
+  private def text(node: JsonNode, name: String): Option[String] =
+    field(node, name).map(_.asText()).filter(StringUtils.isNotBlank)
+
+  private def paths(node: JsonNode, arrayName: String): Seq[String] = {
+    field(node, arrayName) match {
+      case Some(array) if array.isArray =>
+        array
+          .elements()
+          .asScala
+          .flatMap(element => field(element, "path"))
+          .map(_.asText())
+          .filter(StringUtils.isNotBlank)
+          .toSeq
+      case _ => Seq.empty
+    }
+  }
+
+  private def field(node: JsonNode, name: String): Option[JsonNode] = {
+    if (node == null || node.isNull) {
+      None
+    } else {
+      Option(node.get(name))
+        .orElse(
+          node
+            .fieldNames()
+            .asScala
+            .find(_.equalsIgnoreCase(name))
+            .flatMap(actual => Option(node.get(actual))))
+        .filterNot(_.isNull)
+    }
+  }
+}

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/ExtendedKustoClient.scala
@@ -61,10 +61,17 @@ class ExtendedKustoClient(
   lazy val ingestClient: QueuedIngestClient = IngestClientFactory.createClient(ingestKcsb)
   lazy val streamingClient: ManagedStreamingIngestClient =
     IngestClientFactory.createManagedStreamingIngestClient(ingestKcsb, engineKcsb)
+  private[kusto] def exportStorageApiEnabled: Boolean = false
   private lazy val ingestContainersContainerProvider =
     new ContainerProvider(this, clusterAlias, generateCreateTmpStorageCommand())
   private lazy val exportContainersContainerProvider =
-    new ContainerProvider(this, clusterAlias, generateGetExportContainersCommand())
+    new ContainerProvider(
+      this,
+      clusterAlias,
+      generateGetExportContainersCommand(),
+      maybeExportStorageClient =
+        if (exportStorageApiEnabled) Some(new DmExportStorageClient(ingestKcsb, clusterAlias))
+        else None)
   RetryConfig.ofDefaults()
   private val retryConfig = buildRetryConfig
   private val retryConfigAsyncOp = buildRetryConfigForAsyncOp
@@ -277,7 +284,8 @@ class ExtendedKustoClient(
   def getTempBlobsForExport: TransientStorageParameters = {
     val storage = exportContainersContainerProvider.getExportContainers
     val transientStorage =
-      storage.map(c => new TransientStorageCredentials(c.containerUrl + c.sas))
+      if (exportStorageApiEnabled) storage.map(ExtendedKustoClient.toTransientStorageCredentials)
+      else storage.map(c => new TransientStorageCredentials(c.containerUrl + c.sas))
     val endpointSuffix = transientStorage.head.domainSuffix
     if (StringUtils.isNotBlank(endpointSuffix)) {
       new TransientStorageParameters(transientStorage.toArray, endpointSuffix)
@@ -710,6 +718,22 @@ object ExtendedKustoClient {
   private val DefaultDb: String = "NetDefaultDB"
   val BaseIntervalMs: Long = 1000L
   val MaxRetryIntervalMs: Long = 1000L * 10
+
+  private[kusto] def toTransientStorageCredentials(
+      container: ContainerAndSas): TransientStorageCredentials = {
+    if (container.isInstanceOf[OneLakeContainerAndSas]) {
+      // OneLake export folders are returned without a SAS - Kusto exports with ';impersonate'
+      // and Spark reads back over abfss using the ambient AAD credentials.
+      val credentials = new TransientStorageCredentials()
+      credentials.parseOneLake(container.containerUrl)
+      credentials
+    } else {
+      new TransientStorageCredentials(container.containerUrl + container.sas)
+    }
+  }
 }
 
 case class ContainerAndSas(containerUrl: String, sas: String)
+
+private[kusto] final class OneLakeContainerAndSas(containerUrl: String)
+    extends ContainerAndSas(containerUrl, KustoConstants.EmptyString)

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoClientCache.scala
@@ -20,7 +20,27 @@ object KustoClientCache {
       authentication: KustoAuthentication,
       ingestionUrl: Option[String],
       clusterAlias: String): ExtendedKustoClient = {
-    val clusterAndAuth = ClusterAndAuth(clusterUrl, authentication, ingestionUrl, clusterAlias)
+    getClient(
+      clusterUrl,
+      authentication,
+      ingestionUrl,
+      clusterAlias,
+      enableExportStorageApi = false)
+  }
+
+  private[kusto] def getClient(
+      clusterUrl: String,
+      authentication: KustoAuthentication,
+      ingestionUrl: Option[String],
+      clusterAlias: String,
+      enableExportStorageApi: Boolean): ExtendedKustoClient = {
+    val clusterAndAuth =
+      ClusterAndAuth(
+        clusterUrl,
+        authentication,
+        ingestionUrl,
+        clusterAlias,
+        enableExportStorageApi)
     clientCache.computeIfAbsent(clusterAndAuth, adderSupplier)
   }
 
@@ -139,14 +159,21 @@ object KustoClientCache {
       null,
       Collections.singletonMap("spark.version", SPARK_VERSION))
 
-    new ExtendedKustoClient(engineKcsb, ingestKcsb, clusterAndAuth.clusterAlias)
+    if (clusterAndAuth.enableExportStorageApi) {
+      new ExtendedKustoClient(engineKcsb, ingestKcsb, clusterAndAuth.clusterAlias) {
+        override private[kusto] def exportStorageApiEnabled: Boolean = true
+      }
+    } else {
+      new ExtendedKustoClient(engineKcsb, ingestKcsb, clusterAndAuth.clusterAlias)
+    }
   }
 
   private[kusto] case class ClusterAndAuth(
       engineUrl: String,
       authentication: KustoAuthentication,
       ingestionUri: Option[String],
-      clusterAlias: String) {
+      clusterAlias: String,
+      enableExportStorageApi: Boolean = false) {
     val engineUri: String = engineUrl
     val ingestUri: String = ingestionUri.getOrElse(
       new URIBuilder()
@@ -156,7 +183,8 @@ object KustoClientCache {
 
     override def equals(that: Any): Boolean = that match {
       case aa: ClusterAndAuth =>
-        engineUrl == aa.engineUrl && authentication == aa.authentication && ingestUri == aa.ingestUri
+        engineUrl == aa.engineUrl && authentication == aa.authentication &&
+        ingestUri == aa.ingestUri && enableExportStorageApi == aa.enableExportStorageApi
       case _ => false
     }
 
@@ -166,7 +194,7 @@ object KustoClientCache {
       } else {
         authentication.hashCode()
       }
-      engineUri.hashCode + authenticationHash + ingestUri.hashCode
+      engineUri.hashCode + authenticationHash + ingestUri.hashCode + enableExportStorageApi.hashCode
     }
   }
 }

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoConstants.scala
@@ -41,6 +41,11 @@ object KustoConstants {
   val EmptyString = ""
   val QueueRetryAttempts = 1
   val SourceLocationColumnName = "ingestion_source_location_url_blob_internal"
+  // Data Management REST route that returns the export storage targets the engine should export
+  // to. Preferred over '.show export containers' as it works when the cluster is behind a private
+  // link or has outbound access protection enabled.
+  val ExportStorageRestApiPath = "v1/rest/ingestion/exportstorage"
+  val IngestionConfigurationRestApiPath = "v1/rest/ingestion/configuration"
   val storageProtocolAbfs = "abfs"
   val storageProtocolAbfss = "abfss"
   val storageProtocolWasbs = "wasbs"

--- a/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
+++ b/connector/src/main/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtils.scala
@@ -105,6 +105,10 @@ object KustoDataSourceUtils {
       .toBoolean
     val queryFilterPushDown =
       parameters.get(KustoSourceOptions.KUSTO_QUERY_FILTER_PUSH_DOWN).map(s => s.trim.toBoolean)
+    val enableExportStorageApi = parameters
+      .getOrElse(KustoDebugOptions.KUSTO_ENABLE_EXPORT_STORAGE_API, "false")
+      .trim
+      .toBoolean
     val partitionColumn = parameters.get(KustoDebugOptions.KUSTO_PARTITION_COLUMN)
     val partitionOptions = PartitionOptions(numPartitions, partitionColumn, partitioningMode)
     // Parse upfront and throw back an error if there is a wrongly formatted JSON
@@ -156,7 +160,8 @@ object KustoDataSourceUtils {
       distributedReadModeTransientCacheEnabled,
       queryFilterPushDown,
       additionalExportOptions,
-      storageProtocol)
+      storageProtocol,
+      enableExportStorageApi)
   }
 
   private def setNumPartitions(

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoLakeExportStorageE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoLakeExportStorageE2E.scala
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark
+
+import com.azure.core.credential.{AccessToken, TokenRequestContext}
+import com.azure.identity.AzureCliCredentialBuilder
+import com.microsoft.azure.kusto.data.StringUtils
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.common.KustoDebugOptions
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
+import com.microsoft.kusto.spark.datasink.KustoSinkOptions
+import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode}
+import com.microsoft.kusto.spark.utils.{
+  ContainerProvider,
+  DmExportStorageClient,
+  ExportStorageMode
+}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.azurebfs.extensions.CustomTokenProviderAdaptee
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{count, max, min, sum}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.{Collections, Date}
+
+/** Live validation of the feature-flagged `Rest/Lake` distributed-read path. */
+class KustoLakeExportStorageE2E extends AnyFlatSpec with BeforeAndAfterAll with Matchers {
+  private val expectedRows =
+    Option(System.getProperty("lakeExportExpectedRows")).map(_.toInt).getOrElse(200)
+  private val ingestionUri =
+    KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_INGESTION_URI)
+  private lazy val options: KustoConnectionOptions = getSystemTestOptions
+  private var skipReason: Option[String] = None
+
+  private val spark = SparkSession
+    .builder()
+    .appName("KustoLakeExportStorageE2E")
+    .master("local[4]")
+    .getOrCreate()
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    if (StringUtils.isBlank(ingestionUri)) {
+      skipReason = Some(s"${KustoSinkOptions.KUSTO_INGESTION_URI} is required")
+      return
+    }
+
+    val dmClient = new DmExportStorageClient(
+      ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+        ingestionUri,
+        options.accessToken),
+      clusterAlias = "lake-export-e2e")
+
+    if (dmClient.exportStorageMode != ExportStorageMode.LakeFolders) {
+      skipReason = Some("The target cluster is not configured for Rest/Lake")
+      return
+    }
+
+    val targets =
+      dmClient.getExportStorage.getOrElse(fail("ExportStorage returned no Rest/Lake targets"))
+    targets.containers shouldBe empty
+    val folders = targets.lakeFolders.flatMap(ContainerProvider.parseValidApiLakeFolder)
+    folders should have size targets.lakeFolders.size
+    folders.foreach { folder =>
+      val endpoint =
+        com.microsoft.kusto.spark.utils.ExtendedKustoClient
+          .toTransientStorageCredentials(folder)
+          .oneLakeEndpoint
+      spark.sparkContext.hadoopConfiguration
+        .set(s"fs.azure.account.auth.type.$endpoint", "Custom")
+      spark.sparkContext.hadoopConfiguration.set(
+        s"fs.azure.account.oauth.provider.type.$endpoint",
+        classOf[LakeExportAzCliTokenProvider].getName)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    try spark.stop()
+    finally super.afterAll()
+  }
+
+  "Rest/Lake distributed read" should
+    "export through an API-provided OneLake folder and read with Spark" taggedAs KustoE2E in {
+      assume(skipReason.isEmpty, skipReason.getOrElse(""))
+      val query =
+        s"range Id from 1 to $expectedRows step 1 | extend Value=strcat('rest-lake-', Id)"
+
+      val result = spark.read
+        .format("com.microsoft.kusto.spark.datasource")
+        .option(KustoSourceOptions.KUSTO_CLUSTER, options.cluster)
+        .option(KustoSourceOptions.KUSTO_INGESTION_URI, ingestionUri)
+        .option(KustoSourceOptions.KUSTO_DATABASE, options.database)
+        .option(KustoSourceOptions.KUSTO_QUERY, query)
+        .option(KustoSourceOptions.KUSTO_ACCESS_TOKEN, options.accessToken)
+        .option(KustoSourceOptions.KUSTO_READ_MODE, ReadMode.ForceDistributedMode.toString)
+        .option(KustoDebugOptions.KUSTO_ENABLE_EXPORT_STORAGE_API, true.toString)
+        .option(KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE, false.toString)
+        .load()
+
+      val summary = result
+        .agg(
+          count("*").as("rowCount"),
+          min("Id").as("minimumId"),
+          max("Id").as("maximumId"),
+          sum("Id").as("idSum"))
+        .first()
+
+      summary.getLong(0) shouldBe expectedRows.toLong
+      summary.getLong(1) shouldBe 1L
+      summary.getLong(2) shouldBe expectedRows.toLong
+      summary.getLong(3) shouldBe expectedRows.toLong * (expectedRows + 1L) / 2L
+    }
+}
+
+class LakeExportAzCliTokenProvider extends CustomTokenProviderAdaptee {
+  @volatile private var cachedToken: String = _
+  @volatile private var cachedExpiry = new Date(0L)
+
+  override def initialize(configuration: Configuration, accountName: String): Unit = {}
+
+  override def getAccessToken: String = {
+    if (cachedToken == null || cachedExpiry.getTime - System.currentTimeMillis() < 60000L) {
+      refresh()
+    }
+    cachedToken
+  }
+
+  override def getExpiryTime: Date = cachedExpiry
+
+  private def refresh(): Unit = synchronized {
+    val context = new TokenRequestContext()
+      .setScopes(Collections.singletonList("https://storage.azure.com/.default"))
+    val token: AccessToken = new AzureCliCredentialBuilder().build().getToken(context).block()
+    cachedToken = token.getToken
+    cachedExpiry = new Date(token.getExpiresAt.toInstant.toEpochMilli)
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoLegacyExportStorageE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoLegacyExportStorageE2E.scala
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark
+
+import com.microsoft.azure.kusto.data.StringUtils
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
+import com.microsoft.kusto.spark.datasink.KustoSinkOptions
+import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode}
+import com.microsoft.kusto.spark.utils.{
+  DmExportStorageClient,
+  ExportStorageMode,
+  KustoDataSourceUtils => KDSU
+}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{count, max, min, sum}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Live validation of the legacy distributed-read export-storage path. */
+class KustoLegacyExportStorageE2E extends AnyFlatSpec with BeforeAndAfterAll with Matchers {
+  private val expectedRows =
+    Option(System.getProperty("legacyExportExpectedRows")).map(_.toInt).getOrElse(200)
+  private val ingestionUri =
+    KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_INGESTION_URI)
+  private lazy val options: KustoConnectionOptions = getSystemTestOptions
+  private var skipReason: Option[String] = None
+
+  private val spark = SparkSession
+    .builder()
+    .appName("KustoLegacyExportStorageE2E")
+    .master("local[4]")
+    .getOrCreate()
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    if (StringUtils.isBlank(ingestionUri)) {
+      skipReason = Some(s"${KustoSinkOptions.KUSTO_INGESTION_URI} is required")
+      return
+    }
+
+    val dmClient = new DmExportStorageClient(
+      ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+        ingestionUri,
+        options.accessToken),
+      clusterAlias = "legacy-export-e2e")
+
+    if (dmClient.exportStorageMode != ExportStorageMode.LegacyCommand) {
+      skipReason = Some("The target cluster is not configured for the legacy export path")
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    try spark.stop()
+    finally super.afterAll()
+  }
+
+  "Legacy distributed read" should
+    "export through .show export containers and read the parquet with Spark" taggedAs KustoE2E in {
+      assume(skipReason.isEmpty, skipReason.getOrElse(""))
+      val requestId = s"KustoLegacyExportStorageE2E-${java.util.UUID.randomUUID()}"
+      val query =
+        s"range Id from 1 to $expectedRows step 1 | extend Value=strcat('legacy-', Id)"
+      KDSU.logInfo(getClass.getSimpleName, s"Starting live legacy read, id: $requestId")
+
+      val result = spark.read
+        .format("com.microsoft.kusto.spark.datasource")
+        .option(KustoSourceOptions.KUSTO_CLUSTER, options.cluster)
+        .option(KustoSourceOptions.KUSTO_INGESTION_URI, ingestionUri)
+        .option(KustoSourceOptions.KUSTO_DATABASE, options.database)
+        .option(KustoSourceOptions.KUSTO_QUERY, query)
+        .option(KustoSourceOptions.KUSTO_ACCESS_TOKEN, options.accessToken)
+        .option(KustoSourceOptions.KUSTO_READ_MODE, ReadMode.ForceDistributedMode.toString)
+        .option(KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE, false.toString)
+        .option(KustoSourceOptions.KUSTO_REQUEST_ID, requestId)
+        .load()
+
+      val summary = result
+        .agg(
+          count("*").as("rowCount"),
+          min("Id").as("minimumId"),
+          max("Id").as("maximumId"),
+          sum("Id").as("idSum"))
+        .first()
+
+      summary.getLong(0) shouldBe expectedRows.toLong
+      summary.getLong(1) shouldBe 1L
+      summary.getLong(2) shouldBe expectedRows.toLong
+      summary.getLong(3) shouldBe expectedRows.toLong * (expectedRows + 1L) / 2L
+    }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/KustoRestStorageExportE2E.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/KustoRestStorageExportE2E.scala
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark
+
+import com.microsoft.azure.kusto.data.StringUtils
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.kusto.spark.common.KustoDebugOptions
+import com.microsoft.kusto.spark.KustoTestUtils.{KustoConnectionOptions, getSystemTestOptions}
+import com.microsoft.kusto.spark.datasink.KustoSinkOptions
+import com.microsoft.kusto.spark.datasource.{KustoSourceOptions, ReadMode}
+import com.microsoft.kusto.spark.utils.{
+  ContainerProvider,
+  DmExportStorageClient,
+  ExportStorageMode,
+  KustoDataSourceUtils => KDSU
+}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{count, max, min, sum}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Live validation of the feature-flagged `Rest/Storage` distributed-read path. */
+class KustoRestStorageExportE2E extends AnyFlatSpec with BeforeAndAfterAll with Matchers {
+  private val expectedRows =
+    Option(System.getProperty("restStorageExpectedRows")).map(_.toInt).getOrElse(200)
+  private val ingestionUri =
+    KustoTestUtils.getSystemVariable(KustoSinkOptions.KUSTO_INGESTION_URI)
+  private lazy val kustoConnectionOptions: KustoConnectionOptions = getSystemTestOptions
+  private var skipReason: Option[String] = None
+
+  private val spark = SparkSession
+    .builder()
+    .appName("KustoRestStorageExportE2E")
+    .master("local[4]")
+    .getOrCreate()
+
+  private val query =
+    s"range Id from 1 to $expectedRows step 1 | extend Value=strcat('rest-storage-', Id)"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    if (StringUtils.isBlank(ingestionUri)) {
+      skipReason = Some(s"${KustoSinkOptions.KUSTO_INGESTION_URI} is required")
+      return
+    }
+
+    val dmClient = new DmExportStorageClient(
+      ConnectionStringBuilder.createWithAadAccessTokenAuthentication(
+        ingestionUri,
+        kustoConnectionOptions.accessToken),
+      clusterAlias = "rest-storage-e2e")
+
+    if (dmClient.exportStorageMode != ExportStorageMode.BlobContainers) {
+      skipReason = Some("The target cluster is not configured for Rest/Storage")
+      return
+    }
+
+    val targets = dmClient.getExportStorage.getOrElse(
+      fail("The Rest/Storage export storage API returned no usable blob targets"))
+    targets.lakeFolders shouldBe empty
+    targets.containers should not be empty
+    targets.containers.foreach { target =>
+      withClue("ExportStorage returned an invalid or SAS-less blob target") {
+        ContainerProvider.parseValidApiContainerWithSas(target) shouldBe defined
+      }
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      spark.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  "Rest/Storage distributed read" should
+    "export through an API-provided SAS container and read the parquet with Spark" taggedAs KustoE2E in {
+      assume(skipReason.isEmpty, skipReason.getOrElse(""))
+      val requestId = s"KustoRestStorageExportE2E-${java.util.UUID.randomUUID()}"
+      KDSU.logInfo(getClass.getSimpleName, s"Starting live Rest/Storage read, id: $requestId")
+
+      val result = spark.read
+        .format("com.microsoft.kusto.spark.datasource")
+        .option(KustoSourceOptions.KUSTO_CLUSTER, kustoConnectionOptions.cluster)
+        .option(KustoSourceOptions.KUSTO_INGESTION_URI, ingestionUri)
+        .option(KustoSourceOptions.KUSTO_DATABASE, kustoConnectionOptions.database)
+        .option(KustoSourceOptions.KUSTO_QUERY, query)
+        .option(KustoSourceOptions.KUSTO_ACCESS_TOKEN, kustoConnectionOptions.accessToken)
+        .option(KustoSourceOptions.KUSTO_READ_MODE, ReadMode.ForceDistributedMode.toString)
+        .option(KustoDebugOptions.KUSTO_ENABLE_EXPORT_STORAGE_API, true.toString)
+        .option(KustoSourceOptions.KUSTO_DISTRIBUTED_READ_MODE_TRANSIENT_CACHE, false.toString)
+        .option(KustoSourceOptions.KUSTO_REQUEST_ID, requestId)
+        .load()
+
+      val summary = result
+        .agg(
+          count("*").as("rowCount"),
+          min("Id").as("minimumId"),
+          max("Id").as("maximumId"),
+          sum("Id").as("idSum"))
+        .first()
+
+      summary.getLong(0) shouldBe expectedRows.toLong
+      summary.getLong(1) shouldBe 1L
+      summary.getLong(2) shouldBe expectedRows.toLong
+      summary.getLong(3) shouldBe expectedRows.toLong * (expectedRows + 1L) / 2L
+    }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderConcurrencyTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderConcurrencyTest.scala
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.azure.kusto.data.{ClientRequestProperties, KustoOperationResult}
+import io.github.resilience4j.retry.RetryConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import scala.collection.concurrent.TrieMap
+
+/** Thread-safety tests for opt-in export storage discovery. */
+class ContainerProviderConcurrencyTest extends AnyFlatSpec with Matchers {
+  private val clusterAlias = "somecluster"
+  private val dmUrl = "https://ingest-somecluster.kusto.fabric.microsoft.com"
+  private val engineUrl = "https://somecluster.kusto.fabric.microsoft.com"
+  private val exportContainersCommand = ".show export containers"
+  private val threads = 32
+
+  private class CountingKustoClient
+      extends ExtendedKustoClient(
+        new ConnectionStringBuilder(engineUrl),
+        new ConnectionStringBuilder(dmUrl),
+        clusterAlias) {
+    val commandCalls = new AtomicInteger(0)
+    @volatile var failRefresh = false
+
+    override def executeDM(
+        command: String,
+        maybeCrp: Option[ClientRequestProperties],
+        activityName: String,
+        retryConfig: Option[RetryConfig]): KustoOperationResult = {
+      command shouldBe exportContainersCommand
+      commandCalls.incrementAndGet()
+      if (failRefresh) throw new RuntimeException("temporary command failure")
+      new KustoOperationResult(
+        """{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"StorageRoot","DataType":"String","ColumnType":"string"}],
+          |"Rows":[["https://account.blob.core.windows.net/export?sv=x"]]}]}""".stripMargin,
+        "v1")
+    }
+  }
+
+  private class CountingExportStorageClient(
+      result: Option[ExportStorageTargets],
+      refreshInterval: Duration = DmExportStorageClient.DefaultRefreshInterval)
+      extends DmExportStorageClient(new ConnectionStringBuilder(dmUrl), clusterAlias) {
+    val callCount = new AtomicInteger(0)
+    override private[kusto] def resolveExportStorage: ExportStorageResolution = {
+      callCount.incrementAndGet()
+      // Widen the window a real HTTP round trip would have, so a stampede is visible.
+      Thread.sleep(50)
+      ExportStorageResolution(result, refreshInterval)
+    }
+  }
+
+  /** Releases every thread at once so the calls genuinely overlap. */
+  private def runConcurrently(count: Int)(body: Int => Unit): Seq[Throwable] = {
+    val pool = Executors.newFixedThreadPool(count)
+    val start = new CountDownLatch(1)
+    val done = new CountDownLatch(count)
+    val errors = TrieMap.empty[Int, Throwable]
+    (0 until count).foreach { i =>
+      pool.submit(new Runnable {
+        override def run(): Unit = {
+          try {
+            start.await()
+            body(i)
+          } catch {
+            case t: Throwable => errors.put(i, t)
+          } finally done.countDown()
+        }
+      })
+    }
+    try {
+      start.countDown()
+      done.await(60, TimeUnit.SECONDS) shouldBe true
+      errors.values.toSeq
+    } finally {
+      start.countDown()
+      pool.shutdownNow()
+    }
+  }
+
+  "getExportContainers" should "issue a single service call when many threads race on a cold cache" in {
+    val exportStorageClient = new CountingExportStorageClient(Some(ExportStorageTargets(
+      containers = Seq.empty,
+      lakeFolders = Seq(
+        "https://ws.z45.daily-onelake.fabric.microsoft.com/ws-guid/artifact/Ingestions/export/a"))))
+    val provider = new ContainerProvider(
+      new CountingKustoClient,
+      clusterAlias,
+      exportContainersCommand,
+      KustoConstants.StorageExpirySeconds,
+      Some(exportStorageClient))
+
+    val errors = runConcurrently(threads) { _ =>
+      provider.getExportContainers should not be empty
+    }
+
+    errors shouldBe empty
+    exportStorageClient.callCount.get() shouldBe 1
+  }
+
+  it should "issue one service refresh when callers race after the service interval" in {
+    val exportStorageClient = new CountingExportStorageClient(
+      Some(ExportStorageTargets(
+        containers = Seq.empty,
+        lakeFolders = Seq(
+          "https://ws.z45.daily-onelake.fabric.microsoft.com/ws-guid/artifact/Ingestions/export/a"))),
+      Duration.ofMillis(500))
+    val provider = new ContainerProvider(
+      new CountingKustoClient,
+      clusterAlias,
+      exportContainersCommand,
+      KustoConstants.StorageExpirySeconds,
+      Some(exportStorageClient))
+
+    provider.getExportContainers should not be empty
+    Thread.sleep(650)
+
+    val errors = runConcurrently(threads) { _ =>
+      provider.getExportContainers should not be empty
+    }
+
+    errors shouldBe empty
+    exportStorageClient.callCount.get() shouldBe 2
+  }
+
+  it should "serialize command fallback when API-enabled callers race on a cold cache" in {
+    val kustoClient = new CountingKustoClient
+    val exportStorageClient = new CountingExportStorageClient(None)
+    val provider = new ContainerProvider(
+      kustoClient,
+      clusterAlias,
+      exportContainersCommand,
+      KustoConstants.StorageExpirySeconds,
+      Some(exportStorageClient))
+
+    val errors = runConcurrently(threads) { _ =>
+      provider.getExportContainers should not be empty
+    }
+
+    errors shouldBe empty
+    exportStorageClient.callCount.get() shouldBe 1
+    kustoClient.commandCalls.get() shouldBe 1
+  }
+
+  it should "back off failed command refreshes only for API-enabled exports" in {
+    val kustoClient = new CountingKustoClient
+    val exportStorageClient = new CountingExportStorageClient(None, Duration.ofMillis(500))
+    val provider = new ContainerProvider(
+      kustoClient,
+      clusterAlias,
+      exportContainersCommand,
+      KustoConstants.StorageExpirySeconds,
+      Some(exportStorageClient))
+
+    provider.getExportContainers should not be empty
+    kustoClient.failRefresh = true
+    Thread.sleep(650)
+
+    val errors = runConcurrently(threads) { _ =>
+      provider.getExportContainers should not be empty
+    }
+
+    errors shouldBe empty
+    exportStorageClient.callCount.get() shouldBe 2
+    kustoClient.commandCalls.get() shouldBe 2
+
+    kustoClient.failRefresh = false
+    Thread.sleep(5100)
+    provider.getExportContainers should not be empty
+    exportStorageClient.callCount.get() shouldBe 3
+    kustoClient.commandCalls.get() shouldBe 3
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderExportStorageTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderExportStorageTest.scala
@@ -1,0 +1,433 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import com.microsoft.azure.kusto.data.{ClientRequestProperties, KustoOperationResult}
+import io.github.resilience4j.retry.RetryConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Duration
+
+class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
+  private val clusterAlias = "somecluster"
+  private val dmUrl = "https://ingest-somecluster.kusto.fabric.microsoft.com"
+  private val exportContainersCommand = ".show export containers"
+  private val commandContainer =
+    "https://commandacc.blob.core.windows.net/exportcontainer?sv=2018-03-28&sr=c&sp=rwl"
+  private val apiContainer =
+    "https://apiacc.blob.core.windows.net/exportcontainer?sv=2018-03-28&sr=c&sp=rwl"
+  private val lakeFolder =
+    "https://daily-onelake.dfs.fabric.microsoft.com/ws-guid/artifact-guid/Ingestions/export/20260806/hash"
+  // Shape observed from a real DM ExportStorage response: workspace-specific FQDN
+  // ({workspaceIdNoDashes}.z{first2}.{fqdn}) and NO '.dfs.' label in the host.
+  private val realWorkspaceFqdnLakeFolder =
+    "https://453f06078e38475d808c5451f2c0e516.z45.daily-onelake.fabric.microsoft.com/" +
+      "453f0607-8e38-475d-808c-5451f2c0e516/893bf5ee-77c1-437a-9b3a-2731c0576aef/" +
+      "Ingestions/export/20260817-lakedata/b879c86e7c71b6dfc48ffea1bb09c4a2"
+
+  private class StubExportStorageClient(
+      result: Option[ExportStorageTargets],
+      refreshInterval: Duration = DmExportStorageClient.DefaultRefreshInterval)
+      extends DmExportStorageClient(new ConnectionStringBuilder(dmUrl), clusterAlias) {
+    var callCount = 0
+    override private[kusto] def resolveExportStorage: ExportStorageResolution = {
+      callCount += 1
+      ExportStorageResolution(result, refreshInterval)
+    }
+  }
+
+  private class StubKustoClient
+      extends ExtendedKustoClient(
+        new ConnectionStringBuilder("https://somecluster.kusto.fabric.microsoft.com"),
+        new ConnectionStringBuilder(dmUrl),
+        clusterAlias) {
+    var executeDmCallCount = 0
+    var returnedContainer: String = commandContainer
+    var failRefresh = false
+    override def executeDM(
+        command: String,
+        maybeCrp: Option[ClientRequestProperties],
+        activityName: String,
+        retryConfig: Option[RetryConfig]): KustoOperationResult = {
+      executeDmCallCount += 1
+      command shouldBe exportContainersCommand
+      if (failRefresh) throw new RuntimeException("temporary command failure")
+      new KustoOperationResult(
+        s"""{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"StorageRoot","DataType":"String","ColumnType":"string"}],
+           |"Rows":[["$returnedContainer"]]}]}""".stripMargin,
+        "v1")
+    }
+  }
+
+  private def provider(
+      kustoClient: ExtendedKustoClient,
+      exportStorageClient: Option[DmExportStorageClient]) =
+    new ContainerProvider(
+      kustoClient,
+      clusterAlias,
+      exportContainersCommand,
+      KustoConstants.StorageExpirySeconds,
+      exportStorageClient)
+
+  "getExportContainers" should "use lake folders selected by the export storage client" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(ExportStorageTargets(containers = Seq.empty, lakeFolders = Seq(lakeFolder))))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe lakeFolder
+    containers.head.sas shouldBe ""
+    ExtendedKustoClient.toTransientStorageCredentials(containers.head).isOneLake shouldBe true
+    exportStorageClient.callCount shouldBe 1
+    kustoClient.executeDmCallCount shouldBe 0
+  }
+
+  it should "discard invalid lake folders when at least one valid target remains" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(
+        ExportStorageTargets(
+          containers = Seq.empty,
+          lakeFolders = Seq("not-a-url", s"$lakeFolder?sv=x", lakeFolder))))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe lakeFolder
+    containers.head.sas shouldBe ""
+    kustoClient.executeDmCallCount shouldBe 0
+  }
+
+  it should "fall back when every lake folder is invalid" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(
+        ExportStorageTargets(
+          containers = Seq.empty,
+          lakeFolders = Seq(
+            "not-a-url",
+            "https://daily-onelake.dfs.fabric.microsoft.com/workspace/artifact",
+            "https://onelake.attacker.example/workspace/artifact/path",
+            s"$lakeFolder?sv=x"))))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://commandacc.blob.core.windows.net/exportcontainer"
+    containers.head.sas shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  it should "use blob containers when the API returns no lake folders" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(ExportStorageTargets(containers = Seq(apiContainer), lakeFolders = Seq.empty)))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://apiacc.blob.core.windows.net/exportcontainer"
+    containers.head.sas shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    ExtendedKustoClient.toTransientStorageCredentials(containers.head).isOneLake shouldBe false
+    exportStorageClient.callCount shouldBe 1
+    kustoClient.executeDmCallCount shouldBe 0
+  }
+
+  it should "discard invalid API blob targets when at least one valid target remains" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(
+        ExportStorageTargets(
+          containers = Seq(
+            "not-a-url",
+            "https://apiacc.blob.core.windows.net/exportcontainer",
+            "https://apiacc.blob.core.windows.net/exportcontainer;impersonate",
+            apiContainer),
+          lakeFolders = Seq.empty)))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://apiacc.blob.core.windows.net/exportcontainer"
+    containers.head.sas shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    kustoClient.executeDmCallCount shouldBe 0
+  }
+
+  it should "fall back when every API blob target is invalid or SAS-less" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(
+        ExportStorageTargets(
+          containers = Seq(
+            "not-a-url",
+            "https://apiacc.blob.core.windows.net/exportcontainer",
+            "https://apiacc.blob.core.windows.net/exportcontainer;impersonate",
+            "http://apiacc.blob.core.windows.net/exportcontainer?sv=x"),
+          lakeFolders = Seq.empty)),
+      Duration.ofMillis(500))
+    val containerProvider = provider(kustoClient, Some(exportStorageClient))
+
+    val containers = containerProvider.getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://commandacc.blob.core.windows.net/exportcontainer"
+    containers.head.sas shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    kustoClient.executeDmCallCount shouldBe 1
+
+    Thread.sleep(650)
+
+    containerProvider.getExportContainers should not be empty
+    exportStorageClient.callCount shouldBe 2
+    kustoClient.executeDmCallCount shouldBe 2
+  }
+
+  it should "use lake folders when the API returns no blob containers" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(ExportStorageTargets(containers = Seq.empty, lakeFolders = Seq(lakeFolder))))
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe lakeFolder
+    containers.head.sas shouldBe ""
+    ExtendedKustoClient.toTransientStorageCredentials(containers.head).isOneLake shouldBe true
+    kustoClient.executeDmCallCount shouldBe 0
+  }
+
+  it should "fall back to the export containers command when the API is unavailable" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(None)
+
+    val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://commandacc.blob.core.windows.net/exportcontainer"
+    containers.head.sas shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    ExtendedKustoClient.toTransientStorageCredentials(containers.head).isOneLake shouldBe false
+    exportStorageClient.callCount shouldBe 1
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  it should "fall back to the export containers command when no API client is configured" in {
+    val kustoClient = new StubKustoClient
+
+    val containers = provider(kustoClient, None).getExportContainers
+
+    containers should have size 1
+    containers.head.containerUrl shouldBe "https://commandacc.blob.core.windows.net/exportcontainer"
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  it should "keep legacy results cached until the legacy expiry" in {
+    val kustoClient = new StubKustoClient
+    val containerProvider = provider(kustoClient, None)
+
+    containerProvider.getExportContainers shouldBe containerProvider.getExportContainers
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  it should "preserve legacy command parsing when no API client is configured" in {
+    val kustoClient = new StubKustoClient
+    kustoClient.returnedContainer = s"$commandContainer?extra"
+
+    provider(kustoClient, None).getExportContainers.head.sas shouldBe
+      "?sv=2018-03-28&sr=c&sp=rwl"
+
+    kustoClient.returnedContainer = "https://commandacc.blob.core.windows.net/exportcontainer"
+    intercept[ArrayIndexOutOfBoundsException] {
+      provider(kustoClient, None).getExportContainers
+    }
+  }
+
+  it should "retry each expired legacy refresh without the API backoff" in {
+    val kustoClient = new StubKustoClient
+    val containerProvider =
+      new ContainerProvider(kustoClient, clusterAlias, exportContainersCommand, -1)
+    val original = containerProvider.getExportContainers
+    kustoClient.failRefresh = true
+
+    containerProvider.getExportContainers shouldBe original
+    containerProvider.getExportContainers shouldBe original
+    kustoClient.executeDmCallCount shouldBe 3
+  }
+
+  it should "propagate a cold legacy command failure" in {
+    val kustoClient = new StubKustoClient
+    kustoClient.failRefresh = true
+
+    intercept[RuntimeException] {
+      provider(kustoClient, None).getExportContainers
+    }.getMessage shouldBe "temporary command failure"
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  "getTempBlobsForExport" should "use legacy blob credentials by default" in {
+    val kustoClient = new StubKustoClient
+
+    kustoClient.exportStorageApiEnabled shouldBe false
+    val credentials = kustoClient.getTempBlobsForExport.storageCredentials
+    credentials should have length 1
+    credentials.head.isOneLake shouldBe false
+    credentials.head.storageAccountName shouldBe "commandacc"
+    credentials.head.sasKey shouldBe "?sv=2018-03-28&sr=c&sp=rwl"
+    kustoClient.getTempBlobsForExport.storageCredentials.head.sasUrl shouldBe commandContainer
+    kustoClient.executeDmCallCount shouldBe 1
+  }
+
+  "getExportContainers" should "refresh legacy results after the legacy expiry" in {
+    val kustoClient = new StubKustoClient
+    val containerProvider =
+      new ContainerProvider(kustoClient, clusterAlias, exportContainersCommand, 0)
+
+    containerProvider.getExportContainers should not be empty
+    Thread.sleep(1100)
+    containerProvider.getExportContainers should not be empty
+    kustoClient.executeDmCallCount shouldBe 2
+  }
+
+  it should "refresh API targets after the service interval" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient = new StubExportStorageClient(
+      Some(ExportStorageTargets(containers = Seq.empty, lakeFolders = Seq(lakeFolder))),
+      Duration.ofMillis(500))
+    val containerProvider = provider(kustoClient, Some(exportStorageClient))
+
+    containerProvider.getExportContainers should not be empty
+    containerProvider.getExportContainers should not be empty
+    exportStorageClient.callCount shouldBe 1
+
+    Thread.sleep(650)
+
+    containerProvider.getExportContainers should not be empty
+    exportStorageClient.callCount shouldBe 2
+  }
+
+  it should "refresh a legacy fallback after the service interval" in {
+    val kustoClient = new StubKustoClient
+    val exportStorageClient =
+      new StubExportStorageClient(None, Duration.ofMillis(500))
+    val containerProvider = provider(kustoClient, Some(exportStorageClient))
+
+    containerProvider.getExportContainers should not be empty
+    containerProvider.getExportContainers should not be empty
+    kustoClient.executeDmCallCount shouldBe 1
+
+    Thread.sleep(650)
+
+    containerProvider.getExportContainers should not be empty
+    exportStorageClient.callCount shouldBe 2
+    kustoClient.executeDmCallCount shouldBe 2
+  }
+
+  "parseContainerWithSas" should "split the container url from its SAS" in {
+    val parsed = ContainerProvider.parseContainerWithSas(
+      "https://acc.blob.core.windows.net/c?sv=2018-03-28&sr=c")
+    parsed.containerUrl shouldBe "https://acc.blob.core.windows.net/c"
+    parsed.sas shouldBe "?sv=2018-03-28&sr=c"
+    parsed.productArity shouldBe 2
+  }
+
+  it should "return an empty SAS when the url has no query string" in {
+    val parsed = ContainerProvider.parseContainerWithSas("https://acc.blob.core.windows.net/c")
+    parsed.containerUrl shouldBe "https://acc.blob.core.windows.net/c"
+    parsed.sas shouldBe ""
+  }
+
+  "parseValidApiContainerWithSas" should "use the existing transient-storage SAS validation" in {
+    ContainerProvider.parseValidApiContainerWithSas(apiContainer) shouldBe defined
+    ContainerProvider.parseValidApiContainerWithSas(
+      "https://apiacc.blob.core.windows.net/exportcontainer") shouldBe empty
+    ContainerProvider.parseValidApiContainerWithSas(
+      "https://apiacc.blob.core.windows.net/exportcontainer;impersonate") shouldBe empty
+    ContainerProvider.parseValidApiContainerWithSas(
+      "https://apiacc.blob.core.windows.net/exportcontainer/?sv=x") shouldBe defined
+    ContainerProvider.parseValidApiContainerWithSas(
+      "http://apiacc.blob.core.windows.net/exportcontainer?sv=x") shouldBe empty
+    ContainerProvider.parseValidApiContainerWithSas("not-a-url") shouldBe empty
+  }
+
+  "parseValidApiLakeFolder" should "accept only valid OneLake folder paths" in {
+    ContainerProvider.parseValidApiLakeFolder(lakeFolder) shouldBe defined
+    ContainerProvider.parseValidApiLakeFolder(realWorkspaceFqdnLakeFolder) shouldBe defined
+    ContainerProvider.parseValidApiLakeFolder(
+      "https://onelake-int-edog.dfs.pbidedicated.windows-int.net/ws/artifact/path") shouldBe defined
+    ContainerProvider.parseValidApiLakeFolder(s"$lakeFolder?sv=x") shouldBe empty
+    ContainerProvider.parseValidApiLakeFolder(
+      "https://daily-onelake.dfs.fabric.microsoft.com/workspace/artifact") shouldBe empty
+    ContainerProvider.parseValidApiLakeFolder(
+      "https://onelake.attacker.example/workspace/artifact/path") shouldBe empty
+    ContainerProvider.parseValidApiLakeFolder(
+      "https://storage.fabric.microsoft.com/workspace/artifact/path") shouldBe empty
+    ContainerProvider.parseValidApiLakeFolder(
+      "https://onelake.dfs.fabric.microsoft.com.evil.example/workspace/artifact/path") shouldBe empty
+    ContainerProvider.parseValidApiLakeFolder("not-a-url") shouldBe empty
+  }
+
+  "toTransientStorageCredentials" should "build a OneLake credential for lake folders" in {
+    val credentials = ExtendedKustoClient.toTransientStorageCredentials(
+      ContainerProvider.parseValidApiLakeFolder(lakeFolder).get)
+
+    credentials.isOneLake shouldBe true
+    credentials.oneLakeEndpoint shouldBe "daily-onelake.dfs.fabric.microsoft.com"
+    credentials.oneLakeWorkspace shouldBe "ws-guid"
+    credentials.oneLakeArtifactPath shouldBe "artifact-guid/Ingestions/export/20260806/hash"
+    credentials.oneLakeAbfssBase shouldBe
+      "abfss://ws-guid@daily-onelake.dfs.fabric.microsoft.com/artifact-guid/Ingestions/export/20260806/hash"
+  }
+
+  it should "build a SAS credential for blob containers" in {
+    val credentials = ExtendedKustoClient.toTransientStorageCredentials(
+      ContainerAndSas(
+        "https://apiacc.blob.core.windows.net/exportcontainer",
+        "?sv=2018-03-28&sr=c&sp=rwl"))
+
+    credentials.isOneLake shouldBe false
+    credentials.storageAccountName shouldBe "apiacc"
+    credentials.blobContainer shouldBe "exportcontainer"
+    credentials.domainSuffix shouldBe "core.windows.net"
+  }
+
+  it should "accept a workspace-specific FQDN that has no '.dfs.' label" in {
+    val credentials = ExtendedKustoClient.toTransientStorageCredentials(
+      ContainerProvider.parseValidApiLakeFolder(realWorkspaceFqdnLakeFolder).get)
+
+    credentials.isOneLake shouldBe true
+    credentials.oneLakeEndpoint shouldBe
+      "453f06078e38475d808c5451f2c0e516.z45.daily-onelake.fabric.microsoft.com"
+    credentials.oneLakeWorkspace shouldBe "453f0607-8e38-475d-808c-5451f2c0e516"
+    credentials.oneLakeArtifactPath shouldBe
+      "893bf5ee-77c1-437a-9b3a-2731c0576aef/Ingestions/export/20260817-lakedata/b879c86e7c71b6dfc48ffea1bb09c4a2"
+    credentials.oneLakeAbfssBase shouldBe
+      "abfss://453f0607-8e38-475d-808c-5451f2c0e516@453f06078e38475d808c5451f2c0e516.z45." +
+      "daily-onelake.fabric.microsoft.com/893bf5ee-77c1-437a-9b3a-2731c0576aef/Ingestions/" +
+      "export/20260817-lakedata/b879c86e7c71b6dfc48ffea1bb09c4a2"
+  }
+
+  it should "accept the shorter lake folder shape returned by the live service" in {
+    val credentials = ExtendedKustoClient.toTransientStorageCredentials(
+      ContainerProvider
+        .parseValidApiLakeFolder(
+          "https://453f06078e38475d808c5451f2c0e516.z45.daily-onelake.fabric.microsoft.com/" +
+            "453f0607-8e38-475d-808c-5451f2c0e516/893bf5ee-77c1-437a-9b3a-2731c0576aef/" +
+            "Ingestions/20260822-lakedata")
+        .get)
+
+    credentials.isOneLake shouldBe true
+    credentials.oneLakeArtifactPath shouldBe
+      "893bf5ee-77c1-437a-9b3a-2731c0576aef/Ingestions/20260822-lakedata"
+  }
+
+  "public compatibility" should "retain the existing JVM constructor and product shape" in {
+    classOf[ContainerProvider].getConstructors.map(_.getParameterCount) should contain(4)
+
+    val container = ContainerAndSas("https://account.blob.core.windows.net/container", "?sv=x")
+    container.productArity shouldBe 2
+    ContainerAndSas.unapply(container) shouldBe Some((container.containerUrl, container.sas))
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderExportStorageTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderExportStorageTest.scala
@@ -74,7 +74,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   "getExportContainers" should "use lake folders selected by the export storage client" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(ExportStorageTargets(containers = Seq.empty, lakeFolders = Seq(lakeFolder))))
 
     val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
@@ -89,7 +89,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "discard invalid lake folders when at least one valid target remains" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(
         ExportStorageTargets(
           containers = Seq.empty,
@@ -105,7 +105,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "fall back when every lake folder is invalid" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(
         ExportStorageTargets(
           containers = Seq.empty,
@@ -125,7 +125,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "use blob containers when the API returns no lake folders" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(ExportStorageTargets(containers = Seq(apiContainer), lakeFolders = Seq.empty)))
 
     val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers
@@ -140,7 +140,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "discard invalid API blob targets when at least one valid target remains" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(
         ExportStorageTargets(
           containers = Seq(
@@ -160,7 +160,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "fall back when every API blob target is invalid or SAS-less" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(
         ExportStorageTargets(
           containers = Seq(
@@ -188,7 +188,7 @@ class ContainerProviderExportStorageTest extends AnyFlatSpec with Matchers {
 
   it should "use lake folders when the API returns no blob containers" in {
     val kustoClient = new StubKustoClient
-    val exportStorageClient = new StubExportStorageClient(
+    val exportStorageClient: StubExportStorageClient = new StubExportStorageClient(
       Some(ExportStorageTargets(containers = Seq.empty, lakeFolders = Seq(lakeFolder))))
 
     val containers = provider(kustoClient, Some(exportStorageClient)).getExportContainers

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/ContainerProviderTest.scala
@@ -99,11 +99,11 @@ class ContainerProviderTest extends AnyFlatSpec with Matchers with MockFactory {
     val extendedMockClient = createExtendedKustoMockClient(mockDmClient = mockDmClient)
     val containerProvider =
       new ContainerProvider(extendedMockClient, clusterAlias, command, CACHE_EXPIRY_SEC)
-    containerProvider.getContainer().containerUrl should (not be "")
     val ingestionContainer1 =
       "https://sacc1.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0"
     val ingestionContainer2 =
       "https://sacc2.blob.core.windows.net/20230430-ingestdata-e5c334ee145d4b4-0"
+    containerProvider.getContainer().containerUrl shouldBe ingestionContainer1
     Some(containerProvider.getContainer().containerUrl) should contain oneOf
       (ingestionContainer1,
       ingestionContainer2)

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientGateTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientGateTest.scala
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+/** Concurrency and caching tests for export-storage mode discovery. */
+class DmExportStorageClientGateTest extends AnyFlatSpec with Matchers {
+  private val dmUrl = "https://ingest-somecluster.kusto.fabric.microsoft.com"
+  private val clusterAlias = "somecluster"
+  private val threads = 32
+
+  /** Counts and optionally delays mode detection. */
+  private class GateClient(
+      answer: () => Option[ExportStorageMode],
+      delayMs: Long = 0,
+      refreshInterval: Duration = DmExportStorageClient.DefaultRefreshInterval,
+      targets: ExportStorageTargets = ExportStorageTargets(
+        containers = Seq("https://account.blob.core.windows.net/export?sv=x"),
+        lakeFolders = Seq("https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/export/f")))
+      extends DmExportStorageClient(
+        // Calls are intercepted, so a static token avoids network authentication.
+        ConnectionStringBuilder.createWithAadAccessTokenAuthentication(dmUrl, "not-a-real-token"),
+        clusterAlias) {
+    val detections = new AtomicInteger(0)
+    val fetches = new AtomicInteger(0)
+
+    override protected def detectExportStorageDecision(): Option[ExportStorageDecision] = {
+      detections.incrementAndGet()
+      if (delayMs > 0) Thread.sleep(delayMs)
+      answer().map(ExportStorageDecision(_, refreshInterval))
+    }
+
+    override protected def fetchExportStorage(attempt: Int): ExportStorageTargets = {
+      fetches.incrementAndGet()
+      targets
+    }
+  }
+
+  private def gate(answer: Option[ExportStorageMode], delayMs: Long = 0) =
+    new GateClient(() => answer, delayMs)
+
+  private def hammer(client: GateClient)(call: GateClient => Any): Seq[Any] = {
+    val pool = Executors.newFixedThreadPool(threads)
+    val startLine = new CountDownLatch(1)
+    try {
+      val futures = (1 to threads).map { _ =>
+        pool.submit[Any](() => {
+          startLine.await()
+          call(client)
+        })
+      }
+      startLine.countDown()
+      futures.map(_.get(30, TimeUnit.SECONDS))
+    } finally {
+      pool.shutdownNow()
+    }
+  }
+
+  "the configuration gate" should "ask the service once for a burst of concurrent callers" in {
+    val client = gate(Some(ExportStorageMode.LakeFolders), delayMs = 200)
+    val answers = hammer(client)(_.exportStorageMode)
+    answers.distinct shouldBe Seq(ExportStorageMode.LakeFolders)
+    client.detections.get() shouldBe 1
+  }
+
+  it should "remember a definitive negative instead of re-asking on every refresh" in {
+    val client = gate(Some(ExportStorageMode.LegacyCommand), delayMs = 50)
+    val answers = hammer(client)(_.exportStorageMode)
+    answers.distinct shouldBe Seq(ExportStorageMode.LegacyCommand)
+    client.detections.get() shouldBe 1
+    client.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+    client.detections.get() shouldBe 1
+  }
+
+  it should "refresh the selected mode after the service interval" in {
+    val answers = new AtomicInteger(0)
+    val client = new GateClient(
+      () =>
+        if (answers.getAndIncrement() == 0) Some(ExportStorageMode.LakeFolders)
+        else Some(ExportStorageMode.BlobContainers),
+      refreshInterval = Duration.ofMillis(500))
+
+    client.exportStorageMode shouldBe ExportStorageMode.LakeFolders
+    client.exportStorageMode shouldBe ExportStorageMode.LakeFolders
+    client.detections.get() shouldBe 1
+
+    Thread.sleep(650)
+
+    client.exportStorageMode shouldBe ExportStorageMode.BlobContainers
+    client.detections.get() shouldBe 2
+  }
+
+  it should "not remember an inconclusive answer" in {
+    val client = gate(None)
+    client.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+    client.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+    client.detections.get() shouldBe 2
+  }
+
+  it should "recover as soon as the service answers again" in {
+    val outage = new AtomicInteger(2)
+    val client = new GateClient(() =>
+      if (outage.getAndDecrement() > 0) None else Some(ExportStorageMode.BlobContainers))
+    client.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+    client.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+    client.exportStorageMode shouldBe ExportStorageMode.BlobContainers
+    client.exportStorageMode shouldBe ExportStorageMode.BlobContainers
+    client.detections.get() shouldBe 3
+  }
+
+  "getExportStorage" should "not call the export storage API in legacy mode" in {
+    val client = gate(Some(ExportStorageMode.LegacyCommand))
+    client.getExportStorage shouldBe None
+    client.resolveExportStorage.refreshInterval shouldBe
+      DmExportStorageClient.DefaultRefreshInterval
+    client.fetches.get() shouldBe 0
+  }
+
+  it should "not call the export storage API when the gate is inconclusive" in {
+    val client = gate(None)
+    client.getExportStorage shouldBe None
+    client.fetches.get() shouldBe 0
+  }
+
+  it should "return only lake folders in lake mode" in {
+    val client = gate(Some(ExportStorageMode.LakeFolders))
+    val result = client.getExportStorage.get
+    result.lakeFolders should have size 1
+    result.containers shouldBe empty
+    client.fetches.get() shouldBe 1
+  }
+
+  it should "return only blob containers in blob mode" in {
+    val client = gate(Some(ExportStorageMode.BlobContainers))
+    val result = client.getExportStorage.get
+    result.containers should have size 1
+    result.lakeFolders shouldBe empty
+    client.fetches.get() shouldBe 1
+  }
+
+  it should "fall back when the API has no target for the selected mode" in {
+    val lakeModeWithOnlyBlobs = new GateClient(
+      () => Some(ExportStorageMode.LakeFolders),
+      targets = ExportStorageTargets(
+        containers = Seq("https://account.blob.core.windows.net/export?sv=x"),
+        lakeFolders = Seq.empty))
+    lakeModeWithOnlyBlobs.getExportStorage shouldBe None
+
+    val blobModeWithOnlyLake = new GateClient(
+      () => Some(ExportStorageMode.BlobContainers),
+      targets = ExportStorageTargets(
+        containers = Seq.empty,
+        lakeFolders = Seq("https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/export/f")))
+    blobModeWithOnlyLake.getExportStorage shouldBe None
+  }
+
+  it should "stay consistent when concurrent callers race the gate and the fetch" in {
+    val client = gate(Some(ExportStorageMode.LakeFolders), delayMs = 100)
+    val results = hammer(client)(_.getExportStorage)
+    results.distinct should have size 1
+    results.head.asInstanceOf[Option[ExportStorageTargets]].map(_.lakeFolders.size) shouldBe Some(
+      1)
+    client.detections.get() shouldBe 1
+    // ContainerProvider, not this client, serializes target fetches.
+    client.fetches.get() shouldBe threads
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTest.scala
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class DmExportStorageClientTest extends AnyFlatSpec with Matchers {
+  private val objectMapper = new ObjectMapper()
+
+  private def parse(json: String): ExportStorageTargets =
+    DmExportStorageClient.parseExportStorageResponse(objectMapper.readTree(json))
+
+  "parseExportStorageResponse" should "read blob containers with their SAS" in {
+    val targets = parse("""
+        |{
+        |  "exportStorage": {
+        |    "containers": [
+        |      {"path": "https://acc1.blob.core.windows.net/exportcontainer?sv=2018-03-28&sr=c&sp=rwl"},
+        |      {"path": "https://acc2.blob.core.windows.net/exportcontainer?sv=2018-03-28&sr=c&sp=rwl"}
+        |    ],
+        |    "lakeFolders": []
+        |  }
+        |}""".stripMargin)
+
+    targets.containers should have size 2
+    targets.containers.head should startWith(
+      "https://acc1.blob.core.windows.net/exportcontainer?")
+    targets.lakeFolders shouldBe empty
+    targets.isEmpty shouldBe false
+  }
+
+  it should "read OneLake lake folders" in {
+    val targets = parse("""
+        |{
+        |  "exportStorage": {
+        |    "containers": [],
+        |    "lakeFolders": [
+        |      {"path": "https://daily-onelake.dfs.fabric.microsoft.com/ws-guid/artifact-guid/Ingestions/export/20260806/principalhash"}
+        |    ]
+        |  }
+        |}""".stripMargin)
+
+    targets.containers shouldBe empty
+    targets.lakeFolders should have size 1
+    targets.lakeFolders.head should endWith("/Ingestions/export/20260806/principalhash")
+  }
+
+  it should "parse a real DM response that returns both blob containers and a lake folder" in {
+    // Matches the live response shape, with synthetic storage credentials.
+    val targets = parse("""
+        |{
+        |  "exportStorage": {
+        |    "containers": [
+        |      {"path": "https://syntheticaccount1.blob.core.windows.net/exportcontainer-1?sv=test&sr=c&sp=rwdl&sig=synthetic-signature-1"},
+        |      {"path": "https://syntheticaccount2.blob.core.windows.net/exportcontainer-2?sv=test&sr=c&sp=rwdl&sig=synthetic-signature-2"}
+        |    ],
+        |    "lakeFolders": [
+        |      {"path": "https://453f06078e38475d808c5451f2c0e516.z45.daily-onelake.fabric.microsoft.com/453f0607-8e38-475d-808c-5451f2c0e516/893bf5ee-77c1-437a-9b3a-2731c0576aef/Ingestions/export/20260817-lakedata/b879c86e7c71b6dfc48ffea1bb09c4a2"}
+        |    ]
+        |  }
+        |}""".stripMargin)
+
+    targets.containers should have size 2
+    targets.lakeFolders should have size 1
+    targets.lakeFolders.head shouldBe
+      "https://453f06078e38475d808c5451f2c0e516.z45.daily-onelake.fabric.microsoft.com/" +
+      "453f0607-8e38-475d-808c-5451f2c0e516/893bf5ee-77c1-437a-9b3a-2731c0576aef/" +
+      "Ingestions/export/20260817-lakedata/b879c86e7c71b6dfc48ffea1bb09c4a2"
+    // The lake folder must carry no SAS - access is by caller impersonation.
+    targets.lakeFolders.head should not include "?"
+  }
+
+  it should "tolerate different property casing" in {
+    val targets = parse("""
+        |{
+        |  "ExportStorage": {
+        |    "Containers": [{"Path": "https://acc.blob.core.windows.net/c?sv=x"}],
+        |    "LakeFolders": null
+        |  }
+        |}""".stripMargin)
+
+    targets.containers shouldBe Seq("https://acc.blob.core.windows.net/c?sv=x")
+    targets.lakeFolders shouldBe empty
+  }
+
+  it should "return empty targets when both arrays are missing" in {
+    val targets = parse("""{"exportStorage": {}}""")
+    targets.isEmpty shouldBe true
+  }
+
+  it should "skip entries without a usable path" in {
+    val targets = parse("""
+        |{"exportStorage": {"containers": [{"path": ""}, {"other": "x"}, {"path": "https://a.blob.core.windows.net/c?sv=x"}]}}
+        |""".stripMargin)
+
+    targets.containers shouldBe Seq("https://a.blob.core.windows.net/c?sv=x")
+  }
+
+  it should "fail when the response has no exportStorage object" in {
+    a[RuntimeException] should be thrownBy parse("""{"somethingElse": {}}""")
+  }
+
+  it should "fail when exportStorage is not an object" in {
+    a[RuntimeException] should be thrownBy parse("""{"exportStorage": []}""")
+    a[RuntimeException] should be thrownBy parse("""{"exportStorage": "invalid"}""")
+  }
+
+  "redactSecrets" should "strip query strings so SAS tokens never reach the log" in {
+    val body = """{"error":"denied for https://acc.blob.core.windows.net/c?sv=2021&sig=SECRET"}"""
+    val redacted = DmExportStorageClient.redactSecrets(body)
+    redacted should not include "SECRET"
+    redacted should not include "sv=2021"
+    redacted should include("https://acc.blob.core.windows.net/c?<redacted>")
+  }
+
+  it should "leave text without a query string untouched" in {
+    DmExportStorageClient.redactSecrets("Bad gateway") shouldBe "Bad gateway"
+  }
+
+  "isPermanentFailure" should "not retry client errors other than throttling and timeouts" in {
+    DmExportStorageClient.isPermanentFailure(401) shouldBe true
+    DmExportStorageClient.isPermanentFailure(403) shouldBe true
+    DmExportStorageClient.isPermanentFailure(404) shouldBe true
+    DmExportStorageClient.isPermanentFailure(301) shouldBe true
+    DmExportStorageClient.isPermanentFailure(302) shouldBe true
+    DmExportStorageClient.isPermanentFailure(307) shouldBe true
+    DmExportStorageClient.isPermanentFailure(408) shouldBe false
+    DmExportStorageClient.isPermanentFailure(429) shouldBe false
+    DmExportStorageClient.isPermanentFailure(500) shouldBe false
+    DmExportStorageClient.isPermanentFailure(503) shouldBe false
+  }
+
+  "isAuthorizationFailure" should "single out credential rejections from other client errors" in {
+    DmExportStorageClient.isAuthorizationFailure(401) shouldBe true
+    DmExportStorageClient.isAuthorizationFailure(403) shouldBe true
+    DmExportStorageClient.isAuthorizationFailure(404) shouldBe false
+    DmExportStorageClient.isAuthorizationFailure(429) shouldBe false
+    DmExportStorageClient.isAuthorizationFailure(500) shouldBe false
+  }
+
+  "retryAfterMillis" should "honour delta-seconds and ignore anything it cannot trust" in {
+    DmExportStorageClient.retryAfterMillis(Some("5")) shouldBe Some(5000L)
+    DmExportStorageClient.retryAfterMillis(Some("  3 ")) shouldBe Some(3000L)
+    DmExportStorageClient.retryAfterMillis(Some("7")) shouldBe Some(5000L)
+    DmExportStorageClient.retryAfterMillis(Some("100000")) shouldBe Some(5000L)
+    DmExportStorageClient.retryAfterMillis(Some("Wed, 21 Oct 2015 07:28:00 GMT")) shouldBe None
+    DmExportStorageClient.retryAfterMillis(
+      Some("Wed, 02 Sep 2026 07:30:04 GMT"),
+      Instant.parse("2026-09-02T07:30:00Z")) shouldBe Some(4000L)
+    DmExportStorageClient.retryAfterMillis(Some("0")) shouldBe None
+    DmExportStorageClient.retryAfterMillis(Some("-3")) shouldBe None
+    DmExportStorageClient.retryAfterMillis(Some("")) shouldBe None
+    DmExportStorageClient.retryAfterMillis(None) shouldBe None
+  }
+
+  private def config(json: String): IngestionConfiguration =
+    DmExportStorageClient.parseIngestionConfiguration(objectMapper.readTree(json))
+
+  /** Live Fabric ingestion-configuration response shape with SAS values replaced. */
+  private val privateLinkConfiguration =
+    """
+      |{
+      |  "containerSettings": {
+      |    "containers": [
+      |      {"path": "https://acc1.blob.core.windows.net/ingestdata-0?sv=2018-03-28&sr=c&sp=rw"},
+      |      {"path": "https://acc2.blob.core.windows.net/ingestdata-0?sv=2018-03-28&sr=c&sp=rw"}
+      |    ],
+      |    "lakeFolders": [
+      |      {"path": "https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/Ingestions/20260825-lakedata"}
+      |    ],
+      |    "refreshInterval": 3600,
+      |    "preferredUploadMethod": "Lake"
+      |  },
+      |  "ingestionSettings": {
+      |    "maxBlobsPerBatch": 20,
+      |    "maxDataSize": 6442450944,
+      |    "preferredIngestionMethod": "Rest"
+      |  }
+      |}
+      |""".stripMargin
+
+  "parseIngestionConfiguration" should "read a live Fabric private link payload" in {
+    val parsed = config(privateLinkConfiguration)
+    parsed.lakeFolders shouldBe Seq(
+      "https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/Ingestions/20260825-lakedata")
+    parsed.preferredUploadMethod shouldBe Some("Lake")
+    parsed.preferredIngestionMethod shouldBe Some("Rest")
+    parsed.refreshInterval shouldBe Some(java.time.Duration.ofHours(1))
+    parsed.invalidRefreshInterval shouldBe false
+  }
+
+  it should "parse documented TimeSpan refresh intervals" in {
+    config(
+      """{"containerSettings":{"refreshInterval":"01:00:00"}}""").refreshInterval shouldBe Some(
+      java.time.Duration.ofHours(1))
+    config(
+      """{"containerSettings":{"refreshInterval":"1.01:00:00"}}""").refreshInterval shouldBe Some(
+      java.time.Duration.ofHours(25))
+  }
+
+  it should "parse integral numeric refresh intervals as seconds" in {
+    config("""{"containerSettings":{"refreshInterval":3600}}""").refreshInterval shouldBe Some(
+      java.time.Duration.ofHours(1))
+  }
+
+  it should "fall back when the refresh interval is invalid" in {
+    val malformed =
+      config("""{"containerSettings":{"refreshInterval":"not-a-duration"}}""")
+    malformed.refreshInterval shouldBe None
+    malformed.invalidRefreshInterval shouldBe true
+
+    val zero = config("""{"containerSettings":{"refreshInterval":"00:00:00"}}""")
+    zero.refreshInterval shouldBe None
+    zero.invalidRefreshInterval shouldBe true
+
+    val negative = config("""{"containerSettings":{"refreshInterval":-60}}""")
+    negative.refreshInterval shouldBe None
+    negative.invalidRefreshInterval shouldBe true
+
+    val fractional = config("""{"containerSettings":{"refreshInterval":60.5}}""")
+    fractional.refreshInterval shouldBe None
+    fractional.invalidRefreshInterval shouldBe true
+  }
+
+  "effectiveRefreshInterval" should "bound service values and preserve the default" in {
+    DmExportStorageClient.effectiveRefreshInterval(None) shouldBe
+      DmExportStorageClient.DefaultRefreshInterval
+    DmExportStorageClient.effectiveRefreshInterval(
+      Some(java.time.Duration.ofSeconds(10))) shouldBe java.time.Duration.ofMinutes(10)
+    DmExportStorageClient.effectiveRefreshInterval(
+      Some(java.time.Duration.ofMinutes(10))) shouldBe java.time.Duration.ofMinutes(10)
+    DmExportStorageClient.effectiveRefreshInterval(
+      Some(java.time.Duration.ofHours(1))) shouldBe java.time.Duration.ofHours(1)
+    DmExportStorageClient.effectiveRefreshInterval(
+      Some(java.time.Duration.ofHours(2))) shouldBe java.time.Duration.ofHours(2)
+    DmExportStorageClient.effectiveRefreshInterval(Some(java.time.Duration.ofHours(25))) shouldBe
+      DmExportStorageClient.DefaultRefreshInterval
+  }
+
+  it should "report no lake folders for a cluster that is not behind private link" in {
+    val parsed = config("""
+        |{
+        |  "containerSettings": {
+        |    "containers": [{"path": "https://acc1.blob.core.windows.net/ingestdata-0?sv=x"}],
+        |    "lakeFolders": [],
+        |    "preferredUploadMethod": "Storage"
+        |  },
+        |  "ingestionSettings": {"preferredIngestionMethod": "Queue"}
+        |}
+        |""".stripMargin)
+    parsed.lakeFolders shouldBe empty
+    parsed.preferredUploadMethod shouldBe Some("Storage")
+  }
+
+  it should "treat an absent lakeFolders array as no lake folders" in {
+    config("""{"containerSettings": {"containers": []}}""").lakeFolders shouldBe empty
+  }
+
+  it should "tolerate an absent or null preferredIngestionMethod" in {
+    // The service contract marks this field nullable, so the gate must never require it.
+    config(
+      """{"containerSettings": {"lakeFolders": []}}""").preferredIngestionMethod shouldBe None
+    config("""
+        |{"containerSettings": {"lakeFolders": []},
+        | "ingestionSettings": {"preferredIngestionMethod": null}}
+        |""".stripMargin).preferredIngestionMethod shouldBe None
+  }
+
+  it should "not be tied to the casing of the service serializer" in {
+    val parsed = config("""
+        |{
+        |  "ContainerSettings": {
+        |    "LakeFolders": [{"Path": "https://ws.z45.onelake.fabric.microsoft.com/ws/a/f"}],
+        |    "PreferredUploadMethod": "Lake"
+        |  },
+        |  "IngestionSettings": {"PreferredIngestionMethod": "Rest"}
+        |}
+        |""".stripMargin)
+    parsed.lakeFolders should have size 1
+    parsed.preferredUploadMethod shouldBe Some("Lake")
+    parsed.preferredIngestionMethod shouldBe Some("Rest")
+  }
+
+  it should "drop blank folder paths rather than emit an unusable target" in {
+    config("""
+        |{"containerSettings": {"lakeFolders": [
+        |  {"path": ""}, {"path": "   "}, {"path": null}, {"nopath": "x"},
+        |  {"path": "https://ws.z45.onelake.fabric.microsoft.com/ws/a/f"}
+        |]}}
+        |""".stripMargin).lakeFolders shouldBe
+      Seq("https://ws.z45.onelake.fabric.microsoft.com/ws/a/f")
+  }
+
+  it should "reject a payload with no containerSettings" in {
+    // An empty or foreign body must fail loudly here so the caller falls back, rather than
+    // silently reporting "not private link" for a cluster that is.
+    a[RuntimeException] should be thrownBy config("""{"ingestionSettings": {}}""")
+    a[RuntimeException] should be thrownBy config("""{}""")
+  }
+
+  it should "reject a payload whose containerSettings is not an object" in {
+    a[RuntimeException] should be thrownBy config("""{"containerSettings": []}""")
+    a[RuntimeException] should be thrownBy config("""{"containerSettings": "invalid"}""")
+  }
+
+  "exportStorageMode" should "select lake folders only for Rest and Lake" in {
+    config(privateLinkConfiguration).exportStorageMode shouldBe ExportStorageMode.LakeFolders
+    configuration(uploadMethod = "Lake", ingestionMethod = "Rest").exportStorageMode shouldBe
+      ExportStorageMode.LakeFolders
+  }
+
+  it should "select blob containers only for Rest and Storage" in {
+    configuration(uploadMethod = "Storage", ingestionMethod = "Rest").exportStorageMode shouldBe
+      ExportStorageMode.BlobContainers
+  }
+
+  it should "use the legacy command for every other combination" in {
+    configuration(uploadMethod = "Lake", ingestionMethod = "Queue").exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+    configuration(uploadMethod = "Storage", ingestionMethod = "Queue").exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+    configuration(uploadMethod = "Something", ingestionMethod = "Rest").exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+    configuration(uploadMethod = "Lake", ingestionMethod = "Something").exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+  }
+
+  it should "ignore lake folders when the preference pair selects the legacy command" in {
+    val ordinaryFabric = config("""
+        |{
+        |  "containerSettings": {
+        |    "containers": [{"path": "https://acc1.blob.core.windows.net/ingestdata-0?sv=x"}],
+        |    "lakeFolders": [
+        |      {"path": "https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/Ingestions/d"}
+        |    ],
+        |    "preferredUploadMethod": "Storage"
+        |  },
+        |  "ingestionSettings": {"preferredIngestionMethod": "Queue"}
+        |}
+        |""".stripMargin)
+    ordinaryFabric.lakeFolders should have size 1
+    ordinaryFabric.exportStorageMode shouldBe ExportStorageMode.LegacyCommand
+  }
+
+  it should "use the legacy command when either preference is absent" in {
+    IngestionConfiguration(Seq.empty, None, None).exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+    IngestionConfiguration(Seq.empty, Some("Lake"), None).exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+    IngestionConfiguration(Seq.empty, None, Some("Rest")).exportStorageMode shouldBe
+      ExportStorageMode.LegacyCommand
+  }
+
+  it should "not depend on the casing the service happens to use" in {
+    configuration(
+      uploadMethod = "lake",
+      ingestionMethod = "REST").exportStorageMode shouldBe ExportStorageMode.LakeFolders
+    configuration(
+      uploadMethod = "storage",
+      ingestionMethod = "REST").exportStorageMode shouldBe ExportStorageMode.BlobContainers
+  }
+
+  private def configuration(uploadMethod: String, ingestionMethod: String) =
+    IngestionConfiguration(Seq.empty, Some(uploadMethod), Some(ingestionMethod))
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTransportTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTransportTest.scala
@@ -19,7 +19,7 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.zip.GZIPOutputStream
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /** Request-layer tests with an in-memory HTTP transport. */
 class DmExportStorageClientTransportTest extends AnyFlatSpec with Matchers {
@@ -60,7 +60,7 @@ class DmExportStorageClientTransportTest extends AnyFlatSpec with Matchers {
     override def getStatusCode: Int = status
     override def getHeaderValue(name: String): String = headers.getOrElse(name, null)
     override def getHeaders: HttpHeaders = new HttpHeaders(headers.asJava)
-    override def getBody: Flux[ByteBuffer] = Flux.just(ByteBuffer.wrap(bytes))
+    override def getBody: Flux[ByteBuffer] = Mono.just(ByteBuffer.wrap(bytes)).flux()
     override def getBodyAsByteArray: Mono[Array[Byte]] = Mono.just(bytes)
     override def getBodyAsString: Mono[String] = Mono.just(body)
     override def getBodyAsString(charset: java.nio.charset.Charset): Mono[String] =

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTransportTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/DmExportStorageClientTransportTest.scala
@@ -1,0 +1,467 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.azure.core.http.{HttpClient, HttpHeaders, HttpRequest, HttpResponse}
+import com.microsoft.azure.kusto.data.auth.{CloudInfo, ConnectionStringBuilder}
+import com.microsoft.azure.kusto.data.{ClientRequestProperties, KustoOperationResult}
+import io.github.resilience4j.retry.RetryConfig
+import org.awaitility.Awaitility.await
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import reactor.core.publisher.{Flux, Mono}
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.zip.GZIPOutputStream
+import scala.jdk.CollectionConverters._
+
+/** Request-layer tests with an in-memory HTTP transport. */
+class DmExportStorageClientTransportTest extends AnyFlatSpec with Matchers {
+  private val dmUrl = "https://ingest-somecluster.kusto.fabric.microsoft.com"
+  private val notKustoUrl = "https://ingest-somecluster.example.com"
+  private val clusterAlias = "somecluster"
+  private val accessToken = "not-a-real-token"
+
+  // Avoid network metadata lookup without bypassing trusted-host validation.
+  CloudInfo.manuallyAddToCache(dmUrl, Mono.just(CloudInfo.DEFAULT_CLOUD))
+  CloudInfo.manuallyAddToCache(notKustoUrl, Mono.just(CloudInfo.DEFAULT_CLOUD))
+
+  private val lakeFolder =
+    "https://ws.z45.onelake.fabric.microsoft.com/ws/artifact/Ingestions/export/f"
+
+  private val restLake =
+    """{"containerSettings":{"containers":[{"path":"https://blob/c?sas"}],
+      |"lakeFolders":[{"path":"https://ws/lake"}],"preferredUploadMethod":"Lake",
+      |"refreshInterval":"01:00:00"},
+      |"ingestionSettings":{"preferredIngestionMethod":"Rest"}}""".stripMargin
+
+  private val queueStorage =
+    """{"containerSettings":{"containers":[{"path":"https://blob/c?sas"}],
+      |"lakeFolders":[{"path":"https://ws/lake"}],"preferredUploadMethod":"Storage"},
+      |"ingestionSettings":{"preferredIngestionMethod":"Queue"}}""".stripMargin
+
+  private val exportTargets =
+    s"""{"exportStorage":{"containers":[{"path":"https://blob/export?sas"}],
+       |"lakeFolders":[{"path":"$lakeFolder"}]}}""".stripMargin
+
+  private class StubResponse(
+      request: HttpRequest,
+      status: Int,
+      bytes: Array[Byte],
+      headers: Map[String, String])
+      extends HttpResponse(request) {
+    private def body = new String(bytes, StandardCharsets.UTF_8)
+    override def getStatusCode: Int = status
+    override def getHeaderValue(name: String): String = headers.getOrElse(name, null)
+    override def getHeaders: HttpHeaders = new HttpHeaders(headers.asJava)
+    override def getBody: Flux[ByteBuffer] = Flux.just(ByteBuffer.wrap(bytes))
+    override def getBodyAsByteArray: Mono[Array[Byte]] = Mono.just(bytes)
+    override def getBodyAsString: Mono[String] = Mono.just(body)
+    override def getBodyAsString(charset: java.nio.charset.Charset): Mono[String] =
+      Mono.just(body)
+  }
+
+  private class StubHttpClient(respond: HttpRequest => (Int, String, Map[String, String]))
+      extends HttpClient {
+    val requests = new ConcurrentLinkedQueue[HttpRequest]()
+
+    override def send(request: HttpRequest): Mono[HttpResponse] = {
+      requests.add(request)
+      val (status, body, headers) = respond(request)
+      Mono.just(new StubResponse(request, status, body.getBytes(StandardCharsets.UTF_8), headers))
+    }
+
+    def urls: Seq[String] = requests.asScala.map(_.getUrl.toString).toSeq
+    def configCalls: Int = urls.count(_.contains("/ingestion/configuration"))
+    def exportCalls: Int = urls.count(_.contains("/ingestion/exportstorage"))
+  }
+
+  private class TransportClient(val stub: StubHttpClient, url: String = dmUrl)
+      extends DmExportStorageClient(
+        ConnectionStringBuilder.createWithAadAccessTokenAuthentication(url, accessToken),
+        clusterAlias) {
+    override protected lazy val httpClient: HttpClient = stub
+  }
+
+  private class CommandClient
+      extends ExtendedKustoClient(
+        new ConnectionStringBuilder("https://somecluster.kusto.fabric.microsoft.com"),
+        new ConnectionStringBuilder(dmUrl),
+        clusterAlias) {
+    var calls = 0
+
+    override def executeDM(
+        command: String,
+        maybeCrp: Option[ClientRequestProperties],
+        activityName: String,
+        retryConfig: Option[RetryConfig]): KustoOperationResult = {
+      command shouldBe ".show export containers"
+      calls += 1
+      new KustoOperationResult(
+        """{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"StorageRoot","DataType":"String","ColumnType":"string"}],
+          |"Rows":[["https://legacy.blob.core.windows.net/export?sv=x"]]}]}""".stripMargin,
+        "v1")
+    }
+  }
+
+  private def routed(
+      config: => (Int, String, Map[String, String]),
+      export: => (Int, String, Map[String, String]) = (200, exportTargets, Map.empty)) =
+    new StubHttpClient(request =>
+      if (request.getUrl.toString.contains("/ingestion/configuration")) config else export)
+
+  private def ok(body: String) = (200, body, Map.empty[String, String])
+
+  private def gzip(body: String): Array[Byte] = {
+    val output = new ByteArrayOutputStream()
+    val gzip = new GZIPOutputStream(output)
+    try {
+      gzip.write(body.getBytes(StandardCharsets.UTF_8))
+    } finally {
+      gzip.close()
+    }
+    output.toByteArray
+  }
+
+  behavior of "DmExportStorageClient over a real HTTP layer"
+
+  it should "call the configuration route first, and only then the export route" in {
+    val stub = routed(ok(restLake))
+    val client = new TransportClient(stub)
+
+    val resolution = client.resolveExportStorage
+    val targets = resolution.targets
+
+    targets.map(_.lakeFolders) shouldBe Some(Seq(lakeFolder))
+    resolution.refreshInterval shouldBe java.time.Duration.ofHours(1)
+    stub.urls should have size 2
+    stub.urls.head shouldBe s"$dmUrl/v1/rest/ingestion/configuration"
+    stub.urls(1) shouldBe s"$dmUrl/v1/rest/ingestion/exportstorage"
+  }
+
+  it should "send the bearer token and the request id on every call" in {
+    val stub = routed(ok(restLake))
+    new TransportClient(stub).getExportStorage
+
+    stub.requests.asScala.foreach { request =>
+      request.getHeaders.getValue("Authorization") shouldBe s"Bearer $accessToken"
+      request.getHeaders.getValue("Accept") shouldBe "application/json"
+      request.getHeaders.getValue("x-ms-client-request-id") should not be empty
+    }
+  }
+
+  it should "not touch the export route when the cluster advertises Storage and Queue" in {
+    val stub = routed(ok(queueStorage))
+
+    new TransportClient(stub).getExportStorage shouldBe None
+
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 0
+  }
+
+  it should "not engage for Queue and Lake" in {
+    val queueLake =
+      """{"containerSettings":{"preferredUploadMethod":"Lake"},
+        |"ingestionSettings":{"preferredIngestionMethod":"Queue"}}""".stripMargin
+    val stub = routed(ok(queueLake))
+
+    new TransportClient(stub).getExportStorage shouldBe None
+    stub.exportCalls shouldBe 0
+  }
+
+  it should "select blob containers for Rest and Storage" in {
+    val restStorage =
+      """{"containerSettings":{"preferredUploadMethod":"Storage"},
+        |"ingestionSettings":{"preferredIngestionMethod":"Rest"}}""".stripMargin
+    val stub = routed(ok(restStorage))
+
+    val targets = new TransportClient(stub).getExportStorage.get
+    targets.containers shouldBe Seq("https://blob/export?sas")
+    targets.lakeFolders shouldBe empty
+    stub.exportCalls shouldBe 1
+  }
+
+  it should "refuse to send a token over a non-https endpoint" in {
+    val stub = routed(ok(restLake))
+    val client = new TransportClient(stub, url = "http://ingest-somecluster.kusto.windows.net")
+
+    val thrown = intercept[UntrustedEndpointException](client.getExportStorage)
+
+    thrown.getMessage should include("non-https")
+    withClue("the token must not have left the process") {
+      stub.requests shouldBe empty
+    }
+  }
+
+  it should "refuse to send a token to a host the SDK rejects as untrusted" in {
+    val stub = routed(ok(restLake))
+    val client = new TransportClient(stub, url = notKustoUrl)
+
+    val thrown = intercept[UntrustedEndpointException](client.getExportStorage)
+
+    thrown.getMessage should include("not recognise it as a trusted endpoint")
+    withClue("the token must not have left the process") {
+      stub.requests shouldBe empty
+    }
+  }
+
+  it should "not report an unreachable validation as an untrusted endpoint" in {
+    val unresolvable = "https://ingest-nosuchcluster-9f3a2b.kusto.fabric.microsoft.com"
+    val stub = routed(ok(restLake))
+    val client = new TransportClient(stub, url = unresolvable)
+
+    withClue("an unreachable check falls back rather than failing the read") {
+      client.getExportStorage shouldBe None
+    }
+    stub.requests shouldBe empty
+  }
+
+  it should "fall back when the configuration route rejects the REST request" in {
+    val stub = routed((401, """{"error":"unauthorized"}""", Map.empty[String, String]))
+    val client = new TransportClient(stub)
+
+    client.resolveExportStorage shouldBe
+      ExportStorageResolution(None, DmExportStorageClient.DefaultRefreshInterval)
+    client.getExportStorage shouldBe None
+
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 0
+  }
+
+  it should "fall back when the export route rejects the REST request" in {
+    val stub =
+      routed(ok(restLake), export = (403, """{"error":"forbidden"}""", Map.empty[String, String]))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofHours(1))
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 1
+  }
+
+  it should "treat a 404 on the configuration route as an answer and remember it" in {
+    val stub = routed((404, "", Map.empty[String, String]))
+    val client = new TransportClient(stub)
+
+    client.resolveExportStorage shouldBe
+      ExportStorageResolution(None, DmExportStorageClient.DefaultRefreshInterval)
+    client.getExportStorage shouldBe None
+
+    withClue("a 404 is an answer, so the second call must not re-ask within the window") {
+      stub.configCalls shouldBe 1
+    }
+    stub.exportCalls shouldBe 0
+  }
+
+  it should "not remember an unparseable 200, so the next refresh asks again" in {
+    val stub = routed(ok("this is not json"))
+    val client = new TransportClient(stub)
+
+    client.getExportStorage shouldBe None
+    client.getExportStorage shouldBe None
+
+    withClue("an inconclusive answer must not be cached") {
+      // Two calls, each of which retries once: the gate is bounded to two attempts.
+      stub.configCalls shouldBe 4
+    }
+  }
+
+  it should "retry a non-object configuration section before falling back" in {
+    val stub = routed(ok("""{"containerSettings":[]}"""))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofSeconds(5))
+
+    stub.configCalls shouldBe 2
+    stub.exportCalls shouldBe 0
+  }
+
+  it should "retry a non-object export storage section before falling back" in {
+    val stub = routed(ok(restLake), export = ok("""{"exportStorage":[]}"""))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofSeconds(5))
+
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 3
+  }
+
+  it should "recover once the configuration route starts answering" in {
+    val failing = new AtomicBoolean(true)
+    val stub = new StubHttpClient(request =>
+      if (request.getUrl.toString.contains("/ingestion/configuration")) {
+        if (failing.get()) (503, "unavailable", Map.empty[String, String]) else ok(restLake)
+      } else (200, exportTargets, Map.empty[String, String]))
+    val client = new TransportClient(stub)
+
+    client.getExportStorage shouldBe None
+    stub.configCalls shouldBe 2
+    failing.set(false)
+
+    client.getExportStorage.map(_.lakeFolders) shouldBe Some(Seq(lakeFolder))
+    stub.configCalls shouldBe 3
+  }
+
+  Seq("configuration", "exportstorage").foreach { failingRoute =>
+    it should s"rediscover API targets after a transient $failingRoute failure and successful legacy fallback" in {
+      val failing = new AtomicBoolean(true)
+      val stub = new StubHttpClient(request =>
+        if (failing.get() && request.getUrl.getPath.endsWith(failingRoute)) {
+          (503, "unavailable", Map.empty[String, String])
+        } else if (request.getUrl.getPath.endsWith("configuration")) {
+          ok(restLake)
+        } else {
+          ok(exportTargets)
+        })
+      val commandClient = new CommandClient
+      val provider = new ContainerProvider(
+        commandClient,
+        clusterAlias,
+        ".show export containers",
+        maybeExportStorageClient = Some(new TransportClient(stub)))
+
+      val fallback = provider.getExportContainers
+      fallback.map(_.containerUrl) shouldBe Seq("https://legacy.blob.core.windows.net/export")
+      commandClient.calls shouldBe 1
+      val callsBeforeRecovery = stub.requests.size()
+
+      failing.set(false)
+      provider.getExportContainers shouldBe fallback
+      stub.requests.size() shouldBe callsBeforeRecovery
+
+      await()
+        .atMost(Duration.ofSeconds(8))
+        .until(() => provider.getExportContainers.map(_.containerUrl) == Seq(lakeFolder))
+      commandClient.calls shouldBe 1
+      stub.configCalls shouldBe (if (failingRoute == "configuration") 3 else 1)
+      stub.exportCalls shouldBe (if (failingRoute == "configuration") 1 else 4)
+
+      val callsAfterRecovery = stub.requests.size()
+      provider.getExportContainers.map(_.containerUrl) shouldBe Seq(lakeFolder)
+      stub.requests.size() shouldBe callsAfterRecovery
+    }
+  }
+
+  it should "stop asking the export route for the window after it 404s" in {
+    val stub = routed(ok(restLake), export = (404, "", Map.empty[String, String]))
+    val client = new TransportClient(stub)
+
+    client.resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofHours(1))
+    client.getExportStorage shouldBe None
+
+    withClue("the 404 is remembered, so the route is asked once") {
+      stub.exportCalls shouldBe 1
+    }
+  }
+
+  it should "refuse a body that declares itself larger than the limit" in {
+    val oversized =
+      Map("Content-Length" -> (DmExportStorageClient.MaxResponseBodyBytes + 1).toString)
+    val stub = routed((200, restLake, oversized))
+
+    new TransportClient(stub).getExportStorage shouldBe None
+  }
+
+  it should "stop buffering a chunked body when it crosses the limit" in {
+    val oversizedBody = "x" * (DmExportStorageClient.MaxResponseBodyBytes.toInt + 1)
+    val stub = routed(ok(oversizedBody))
+
+    new TransportClient(stub).getExportStorage shouldBe None
+    stub.configCalls shouldBe 1
+  }
+
+  it should "stop decoding a compressed body when it crosses the limit" in {
+    val bytes = gzip("x" * (DmExportStorageClient.MaxResponseBodyBytes.toInt + 1))
+    val stub = new StubHttpClient(_ => throw new IllegalStateException("unused")) {
+      override def send(request: HttpRequest): Mono[HttpResponse] = {
+        requests.add(request)
+        Mono.just(new StubResponse(request, 200, bytes, Map("Content-Encoding" -> "gzip")))
+      }
+    }
+
+    new TransportClient(stub).getExportStorage shouldBe None
+    stub.configCalls shouldBe 1
+  }
+
+  it should "avoid retrying permanent client failures" in {
+    val stub = routed((400, """{"error":"bad request"}""", Map.empty[String, String]))
+    val client = new TransportClient(stub)
+
+    client.resolveExportStorage shouldBe
+      ExportStorageResolution(None, DmExportStorageClient.DefaultRefreshInterval)
+    client.getExportStorage shouldBe None
+    stub.configCalls shouldBe 1
+  }
+
+  it should "retain the service interval after a permanent export-storage failure" in {
+    val stub =
+      routed(ok(restLake), export = (400, "bad request", Map.empty[String, String]))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofHours(1))
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 1
+  }
+
+  it should "bound retries for transient export-storage failures" in {
+    val stub =
+      routed(ok(restLake), export = (503, "unavailable", Map.empty[String, String]))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofSeconds(5))
+    stub.configCalls shouldBe 1
+    stub.exportCalls shouldBe 3
+  }
+
+  it should "stop retrying when a throttled request is interrupted" in {
+    val stub = routed((429, "throttled", Map("Retry-After" -> "5")))
+    val failure = new AtomicReference[Throwable]()
+    val interruptPreserved = new AtomicBoolean(false)
+    val thread = new Thread(new Runnable {
+      override def run(): Unit =
+        try {
+          new TransportClient(stub).getExportStorage
+        } catch {
+          case throwable: Throwable =>
+            failure.set(throwable)
+            interruptPreserved.set(Thread.currentThread().isInterrupted)
+        }
+    })
+
+    thread.start()
+    val requestDeadline = System.currentTimeMillis() + 2000
+    while (stub.configCalls == 0 && System.currentTimeMillis() < requestDeadline) {
+      Thread.sleep(10)
+    }
+    stub.configCalls shouldBe 1
+
+    thread.interrupt()
+    thread.join(2000)
+
+    thread.isAlive shouldBe false
+    failure.get() shouldBe a[InterruptedException]
+    interruptPreserved.get() shouldBe true
+    stub.configCalls shouldBe 1
+  }
+
+  it should "fall back rather than fail when the route is unreachable" in {
+    val stub = new StubHttpClient(_ => throw new RuntimeException("connection reset"))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofSeconds(5))
+  }
+
+  it should "fall back when the export route answers with no targets at all" in {
+    val empty = """{"exportStorage":{"containers":[],"lakeFolders":[]}}"""
+    val stub = routed(ok(restLake), export = (200, empty, Map.empty[String, String]))
+
+    new TransportClient(stub).resolveExportStorage shouldBe
+      ExportStorageResolution(None, Duration.ofHours(1))
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoClientCacheFeatureFlagTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoClientCacheFeatureFlagTest.scala
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.kusto.spark.utils
+
+import com.microsoft.kusto.spark.authentication.KustoAccessTokenAuthentication
+import com.microsoft.kusto.spark.common.KustoCoordinates
+import com.microsoft.kusto.spark.datasource.DistributedReadModeTransientCacheKey
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class KustoClientCacheFeatureFlagTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
+  private val clusterUrl = "https://somecluster.kusto.windows.net"
+  private val ingestionUrl = Some("https://ingest-somecluster.kusto.windows.net")
+  private val authentication = KustoAccessTokenAuthentication("not-a-real-token")
+  private val clusterAlias = "somecluster"
+
+  override protected def beforeEach(): Unit = {
+    KustoClientCache.clientCache.clear()
+    super.beforeEach()
+  }
+
+  override protected def afterEach(): Unit = {
+    KustoClientCache.clientCache.clear()
+    super.afterEach()
+  }
+
+  "getClient" should "keep the export storage API disabled for the existing call" in {
+    val client =
+      KustoClientCache.getClient(clusterUrl, authentication, ingestionUrl, clusterAlias)
+
+    client.exportStorageApiEnabled shouldBe false
+    KustoClientCache
+      .getClient(
+        clusterUrl,
+        authentication,
+        ingestionUrl,
+        clusterAlias,
+        enableExportStorageApi = false) should be theSameInstanceAs client
+  }
+
+  it should "isolate enabled and disabled clients in the cache" in {
+    val disabled =
+      KustoClientCache.getClient(clusterUrl, authentication, ingestionUrl, clusterAlias)
+    val enabled = KustoClientCache.getClient(
+      clusterUrl,
+      authentication,
+      ingestionUrl,
+      clusterAlias,
+      enableExportStorageApi = true)
+
+    disabled.exportStorageApiEnabled shouldBe false
+    enabled.exportStorageApiEnabled shouldBe true
+    enabled should not be theSameInstanceAs(disabled)
+    KustoClientCache
+      .getClient(
+        clusterUrl,
+        authentication,
+        ingestionUrl,
+        clusterAlias,
+        enableExportStorageApi = true) should be theSameInstanceAs enabled
+  }
+
+  "DistributedReadModeTransientCacheKey" should "isolate enabled and disabled export paths" in {
+    val coordinates =
+      KustoCoordinates(clusterUrl, clusterAlias, "database", ingestionUrl = ingestionUrl)
+
+    DistributedReadModeTransientCacheKey(
+      "query",
+      coordinates,
+      authentication,
+      enableExportStorageApi = false) should not equal DistributedReadModeTransientCacheKey(
+      "query",
+      coordinates,
+      authentication,
+      enableExportStorageApi = true)
+  }
+}

--- a/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtilsTest.scala
+++ b/connector/src/test/scala/com/microsoft/kusto/spark/utils/KustoDataSourceUtilsTest.scala
@@ -15,6 +15,7 @@ import com.microsoft.kusto.spark.datasink.{
   SchemaAdjustmentMode,
   SparkIngestionProperties
 }
+import com.microsoft.kusto.spark.common.KustoDebugOptions
 import com.microsoft.kusto.spark.datasource.ReadMode.ForceDistributedMode
 import com.microsoft.kusto.spark.datasource.{
   KustoReadOptions,
@@ -39,7 +40,8 @@ class KustoDataSourceUtilsTest extends AnyFlatSpec with MockFactory {
       KustoSourceOptions.KUSTO_AAD_APP_SECRET -> "AppKey",
       KustoSourceOptions.KUSTO_AAD_AUTHORITY_ID -> "Tenant",
       KustoSourceOptions.KUSTO_EXPORT_OPTIONS_JSON -> "{\"sizeLimit\":250,\"compressionType\":\"gzip\",\"async\":\"none\"}",
-      KustoSourceOptions.STORAGE_PROTOCOL -> "abfss")
+      KustoSourceOptions.STORAGE_PROTOCOL -> "abfss",
+      KustoDebugOptions.KUSTO_ENABLE_EXPORT_STORAGE_API -> true.toString)
     // a no interaction mock only for test
     val actualReadOptions = KustoDataSourceUtils.getReadParameters(conf, null)
     val expectedResult = KustoReadOptions(
@@ -48,9 +50,24 @@ class KustoDataSourceUtilsTest extends AnyFlatSpec with MockFactory {
       distributedReadModeTransientCacheEnabled = true,
       None,
       Map("sizeLimit" -> "250", "compressionType" -> "gzip", "async" -> "none"),
-      Some("abfss"))
+      Some("abfss"),
+      enableExportStorageApi = true)
     assert(actualReadOptions != null)
     assert(actualReadOptions == expectedResult)
+  }
+
+  it should "leave the export storage API disabled by default" in {
+    val actualReadOptions = KustoDataSourceUtils.getReadParameters(Map.empty, null)
+
+    assert(!actualReadOptions.enableExportStorageApi)
+  }
+
+  it should "keep the export storage API disabled when explicitly false" in {
+    val actualReadOptions = KustoDataSourceUtils.getReadParameters(
+      Map(KustoDebugOptions.KUSTO_ENABLE_EXPORT_STORAGE_API -> "false"),
+      null)
+
+    assert(!actualReadOptions.enableExportStorageApi)
   }
 
   "ReadParameters" should "throw an exception when an invalid export options is passed" in {

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}</version>
     <properties>
         <!-- Compile-scoped dependency versions -->
-        <revision>7.1.2</revision>
+        <revision>7.1.3</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <kusto.shade.prefix>kusto_connector_shaded</kusto.shade.prefix>
         <azure.bom.version>1.2.28</azure.bom.version>


### PR DESCRIPTION
#### Pull Request Description

Backport #509 (48cce1866fcf7e9d099bd4eaf28b6a1ef01f4758) to release/spark3 and prepare 7.1.3 following SKILL.md.

- Preserve strict default-off behavior and the original legacy export-container and ingestion paths.
- Include the transient API recovery fix and its regression tests.
- Adapt only Scala 2.12 collection converters and test type inference / Reactor overload resolution.
- Backport existing workflow token masking from #504 before Spark 3 build/release execution.
- Bump revision to 7.1.3 and synchronize the new changelog section with #511. Spark/Scala/Java/SDK versions remain unchanged.
- Keep docs/Troubleshooting.md absent on this branch; the upstream change to it only removed a trailing blank line. No read-option documentation is added.

Validation: 120 tests passed across eight targeted suites using the Spark 3 / Scala 2.12 dependency set; all test sources compiled. Full PR CI and reviewer approval are required before squash merge.

Release tag after approval, successful CI, and squash merge: `v3.0_7.1.3`. No tags are created by this PR.

#### Future Release Comment

**Breaking Changes:**
- None

**Features:**
- Opt-in Data Management export storage discovery for distributed reads.

**Fixes:**
- Prompt rediscovery after transient API failures while preserving default-off legacy behavior.
- Mask Azure access tokens in build and release workflow logs.